### PR TITLE
[commonerrors] Improved test cases and fixed gosec reported issue

### DIFF
--- a/changes/202109131145.bugfix
+++ b/changes/202109131145.bugfix
@@ -1,0 +1,1 @@
+Improved testing and fixed `gosec` reported error in `commonerrors`

--- a/utils/commonerrors/errors.go
+++ b/utils/commonerrors/errors.go
@@ -35,7 +35,8 @@ var (
 )
 
 func Any(target error, err ...error) bool {
-	for _, e := range err {
+	for i := range err {
+		e := err[i]
 		if errors.Is(e, target) || errors.Is(target, e) {
 			return true
 		}
@@ -44,7 +45,8 @@ func Any(target error, err ...error) bool {
 }
 
 func None(target error, err ...error) bool {
-	for _, e := range err {
+	for i := range err {
+		e := err[i]
 		if errors.Is(e, target) || errors.Is(target, e) {
 			return false
 		}

--- a/utils/commonerrors/errors_test.go
+++ b/utils/commonerrors/errors_test.go
@@ -18,13 +18,21 @@ import (
 func TestAny(t *testing.T) {
 	assert.True(t, Any(ErrNotImplemented, ErrInvalid, ErrNotImplemented, ErrUnknown))
 	assert.False(t, Any(ErrNotImplemented, ErrInvalid, ErrUnknown))
+	assert.True(t, Any(ErrNotImplemented, nil, ErrNotImplemented))
+	assert.True(t, Any(nil, nil, ErrNotImplemented))
+	assert.False(t, Any(ErrNotImplemented, nil, ErrInvalid, ErrUnknown))
+	assert.False(t, Any(nil, ErrInvalid, ErrUnknown))
 	assert.True(t, Any(fmt.Errorf("an error %w", ErrNotImplemented), ErrInvalid, ErrNotImplemented, ErrUnknown))
 	assert.False(t, Any(fmt.Errorf("an error %w", ErrNotImplemented), ErrInvalid, ErrUnknown))
 }
 
 func TestNone(t *testing.T) {
 	assert.False(t, None(ErrNotImplemented, ErrInvalid, ErrNotImplemented, ErrUnknown))
+	assert.False(t, None(ErrNotImplemented, nil, ErrInvalid, ErrNotImplemented, ErrUnknown))
 	assert.True(t, None(ErrNotImplemented, ErrInvalid, ErrUnknown))
+	assert.True(t, None(ErrNotImplemented, nil, ErrInvalid, ErrUnknown))
+	assert.True(t, None(nil, ErrInvalid, ErrUnknown))
+	assert.False(t, None(nil, nil, ErrInvalid, ErrNotImplemented, ErrUnknown))
 	assert.False(t, None(fmt.Errorf("an error %w", ErrNotImplemented), ErrInvalid, ErrNotImplemented, ErrUnknown))
 	assert.True(t, None(fmt.Errorf("an error %w", ErrNotImplemented), ErrInvalid, ErrUnknown))
 }


### PR DESCRIPTION
<!--
Copyright (C) 2020-2021 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

Improved commonerrors `Any` and `None` to comply with `gosec` recommendations.
Also improved the test cases

### Test Coverage

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
