### PR TITLE
Flaky test and bug fixes

### DIFF
--- a/changes/202111012244.bugfix
+++ b/changes/202111012244.bugfix
@@ -1,0 +1,1 @@
+Fixed bug in `parallisation` which entailed a bug in file locking where the heartbeat was forced to stop after a timeout

--- a/utils/filesystem/lockfile.go
+++ b/utils/filesystem/lockfile.go
@@ -84,7 +84,7 @@ func (l *RemoteLockFile) IsStale() bool {
 		return false
 	}
 	if len(heartBeatFiles) == 0 {
-		// if directory exists but no folder then it could be that the directory has been created
+		// if directory exists but no files are present, then it could be that the directory has been created
 		// but that the heart beat file hasn't yet. Therefore we check the age of the directory and deduce whether
 		// it is stale or not.
 		dirInfo, err := l.fs.StatTimes(lockPath)


### PR DESCRIPTION
<!--
Copyright (C) 2020-2021 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description
Fixed a bug in the file locking mechanism:
the heartbeat was stopped after a timeout although this is not intended.
Bug was in `parallelisation` and unit tests were added so that the problem does not occur again


### Test Coverage


- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
