### PR TITLE
Clarified flag binding and configuration load and unmarshalling.

### DIFF
--- a/changes/202112191650.bugfix
+++ b/changes/202112191650.bugfix
@@ -1,0 +1,1 @@
+Fix how configuration is loaded from flags and environment and clarifies how default values are chosen.

--- a/utils/config/service_configuration.go
+++ b/utils/config/service_configuration.go
@@ -18,8 +18,9 @@ import (
 
 const (
 	EnvVarSeparator    = "_"
-	configKeySeparator = "."
 	DotEnvFile         = ".env"
+	configKeySeparator = "."
+	flagKeyPrefix      = "uniqueprefixforprivateflagbindingkeys123" // Has to be lower case and hopefully unique
 )
 
 // Load loads the configuration from the environment (i.e. .env file, environment variables) and puts the entries into the configuration object configurationToSet.
@@ -31,6 +32,15 @@ func Load(envVarPrefix string, configurationToSet IServiceConfiguration, default
 }
 
 // LoadFromViper is the same as `Load` but instead of creating a new viper session, reuse the one provided.
+// Important note:
+// Viper's precedence order is maintained:
+//    1) values set using explicit calls to `Set`
+//    2) flags
+//    3) environment (variables or `.env`)
+//    4) configuration file
+//    5) key/value store
+//    6) default values (set via flag default values, or calls to `SetDefault` or via `defaultConfiguration` argument provided)
+// Nonetheless, when it comes to default values. It differs slightly from Viper as default values from the default Configuration (i.e. `defaultConfiguration` argument provided) will take precedence over defaults set via `SetDefault` or flags unless they are considered empty values according to `reflection.IsEmpty`.
 func LoadFromViper(viperSession *viper.Viper, envVarPrefix string, configurationToSet IServiceConfiguration, defaultConfiguration IServiceConfiguration) (err error) {
 	// Load Defaults
 	var defaults map[string]interface{}
@@ -49,27 +59,7 @@ func LoadFromViper(viperSession *viper.Viper, envVarPrefix string, configuration
 	// Load Environment variables
 	setEnvOptions(viperSession, envVarPrefix)
 
-	// Creating aliases for flags/environment variable keys to real structure keys.
-	keys := viperSession.AllKeys()
-	for i := range keys {
-		key := keys[i]
-		longFlagKey, shortFlagKey := generateEnvVarConfigKeys(key, envVarPrefix)
-
-		// The following is a workaround of the aliases implementation in viper which does not really work well with multiple level keys
-		value := viperSession.Get(shortFlagKey)
-		//Note: Have to use a `IsEmpty` function because the `IsSet` in viper does not consider the default values of a flag.
-		if reflection.IsEmpty(value) {
-			value = viperSession.Get(longFlagKey)
-			if !reflection.IsEmpty(value) {
-				viperSession.Set(key, value)
-			}
-		} else {
-			viperSession.Set(key, value)
-		}
-
-		viperSession.RegisterAlias(shortFlagKey, key)
-		viperSession.RegisterAlias(longFlagKey, key)
-	}
+	linkFlagKeysToStructureKeys(viperSession, envVarPrefix)
 
 	// Merge together all the sources and unmarshal into struct
 	err = viperSession.Unmarshal(configurationToSet)
@@ -86,42 +76,43 @@ func LoadFromViper(viperSession *viper.Viper, envVarPrefix string, configuration
 // Envvar is the environment variable string with or without the prefix envVarPrefix
 func BindFlagToEnv(viperSession *viper.Viper, envVarPrefix string, envVar string, flag *pflag.Flag) (err error) {
 	setEnvOptions(viperSession, envVarPrefix)
-	longKey, shortKey := generateEnvVarConfigKeys(envVar, envVarPrefix)
-	err = viperSession.BindPFlag(longKey, flag)
-	if err != nil {
-		return
-	}
+	shortKey, cleansedEnvVar := generateEnvVarConfigKeys(envVar, envVarPrefix)
 
 	err = viperSession.BindPFlag(shortKey, flag)
 	if err != nil {
 		return
 	}
-
-	err = viperSession.BindEnv(shortKey)
+	err = viperSession.BindEnv(shortKey, cleansedEnvVar)
 	return
 }
 
-func generateEnvVarConfigKeys(envVar, envVarPrefix string) (longKey, shortKey string) {
+func generateEnvVarConfigKeys(envVar, envVarPrefix string) (shortKey string, cleansedEnvVar string) {
 	envVarLower := strings.ToLower(envVar)
 	envVarPrefixLower := strings.ToLower(envVarPrefix)
 	hasPrefix := strings.HasPrefix(envVarLower, envVarPrefixLower)
-	var short, extended string
+	var short string
 	if hasPrefix {
-		extended = envVarLower
-		short = strings.TrimPrefix(strings.TrimPrefix(envVarLower, envVarPrefixLower), "_")
+		short = strings.TrimPrefix(strings.TrimPrefix(envVarLower, envVarPrefixLower), EnvVarSeparator)
 	} else {
-		extended = fmt.Sprintf("%v_%v", envVarPrefixLower, envVarLower)
 		short = strings.ToLower(envVar)
 	}
-
-	longKey = generateEnvVarConfigKey(extended)
 	shortKey = generateEnvVarConfigKey(short)
+	cleansedEnvVar = cleanseEnvVar(envVarPrefix, short)
 	return
 }
 
-func generateEnvVarConfigKey(EnvVar string) (key string) {
-	key = strings.NewReplacer(EnvVarSeparator, configKeySeparator).Replace(EnvVar)
+func generateEnvVarConfigKey(shortEnvVar string) (key string) {
+	key = fmt.Sprintf("%v%v%v", flagKeyPrefix, configKeySeparator, strings.NewReplacer(EnvVarSeparator, configKeySeparator).Replace(shortEnvVar))
 	return
+}
+
+func cleanseEnvVar(envVarPrefix string, shortEnvVar string) (cleansedEnvVar string) {
+	cleansedEnvVar = strings.ToUpper(strings.NewReplacer(configKeySeparator, EnvVarSeparator).Replace(fmt.Sprintf("%v%v%v", envVarPrefix, EnvVarSeparator, shortEnvVar)))
+	return
+}
+
+func isFlagKey(key string) bool {
+	return strings.HasPrefix(key, flagKeyPrefix)
 }
 
 func setEnvOptions(viperSession *viper.Viper, envVarPrefix string) {
@@ -130,4 +121,34 @@ func setEnvOptions(viperSession *viper.Viper, envVarPrefix string) {
 
 	viperSession.AutomaticEnv()
 	viperSession.SetEnvKeyReplacer(strings.NewReplacer(configKeySeparator, EnvVarSeparator))
+}
+
+// linkFlagKeysToStructureKeys creates aliases for flags/environment variable keys to real structure keys.
+// It was indeed noticed that viper binding/aliasing did not work well with structured/nested configurations.
+// Therefore, binding between flags and structure configurations is manually handled.
+func linkFlagKeysToStructureKeys(viperSession *viper.Viper, envVarPrefix string) {
+	// The following is a workaround of the aliases implementation in viper which does not really work well with multi-level keys
+	// Similarly BindEnv does not seem to work well with multi-level configuration structures
+	keys := viperSession.AllKeys()
+	for i := range keys {
+		key := keys[i]
+		//This is modifying the value of the structured configuration if flags have been set.
+		if !isFlagKey(key) {
+			flagKey, _ := generateEnvVarConfigKeys(key, envVarPrefix)
+			// if the flag is set, it takes precedence over the structured configuration value.
+			if viperSession.IsSet(flagKey) {
+				viperSession.Set(key, viperSession.Get(flagKey))
+			} else {
+				value := viperSession.Get(flagKey)
+				if !reflection.IsEmpty(value) {
+					viperSession.SetDefault(key, value)
+					// If the value of the structured configuration is empty, default to the default value of the flag.
+					if reflection.IsEmpty(viperSession.Get(key)) {
+						viperSession.Set(key, value)
+					}
+				}
+			}
+			viperSession.RegisterAlias(flagKey, key)
+		}
+	}
 }

--- a/utils/config/service_configuration_test.go
+++ b/utils/config/service_configuration_test.go
@@ -25,6 +25,7 @@ var (
 	expectedDuration = time.Since(time.Date(1999, 2, 3, 4, 30, 45, 46, time.UTC))
 	expectedHost     = fmt.Sprintf("a test host %v", faker.Word())
 	expectedPassword = fmt.Sprintf("a test passwd %v", faker.Password())
+	expectedDb       = fmt.Sprintf("a db %v", faker.Word())
 )
 
 type DummyConfiguration struct {
@@ -33,6 +34,7 @@ type DummyConfiguration struct {
 	DB                string        `mapstructure:"db"`
 	User              string        `mapstructure:"user"`
 	Password          string        `mapstructure:"password"`
+	Flag              bool          `mapstructure:"flag"`
 	HealthCheckPeriod time.Duration `mapstructure:"healthcheck_period"`
 }
 
@@ -49,6 +51,7 @@ func (cfg *DummyConfiguration) Validate() error {
 func DefaultDummyConfiguration() *DummyConfiguration {
 	return &DummyConfiguration{
 		Port:              5432,
+		Flag:              true,
 		HealthCheckPeriod: time.Second,
 	}
 }
@@ -111,7 +114,9 @@ func TestServiceConfigurationLoad(t *testing.T) {
 	require.NoError(t, err)
 	err = os.Setenv("TEST_DUMMYCONFIG_DB", "a test db")
 	require.NoError(t, err)
-	err = os.Setenv("TEST_DUMMY_CONFIG_DB", "a test db")
+	err = os.Setenv("TEST_DUMMY_CONFIG_DB", expectedDb)
+	require.NoError(t, err)
+	err = os.Setenv("TEST_DUMMY_CONFIG_FLAG", "false")
 	require.NoError(t, err)
 	err = os.Setenv("TEST_DUMMY_TIME", expectedDuration.String())
 	require.NoError(t, err)
@@ -125,12 +130,67 @@ func TestServiceConfigurationLoad(t *testing.T) {
 	assert.Equal(t, expectedDuration, configTest.TestTime)
 	assert.Equal(t, defaults.TestConfig.Port, configTest.TestConfig.Port)
 	assert.Equal(t, expectedHost, configTest.TestConfig.Host)
+	assert.Equal(t, expectedPassword, configTest.TestConfig2.Password)
+	assert.Equal(t, expectedDb, configTest.TestConfig2.DB)
 	assert.NotEqual(t, expectedHost, configTest.TestConfig2.Host)
 	assert.NotEqual(t, expectedPassword, configTest.TestConfig.Password)
-	assert.Equal(t, expectedPassword, configTest.TestConfig2.Password)
+	assert.NotEqual(t, expectedDb, configTest.TestConfig.DB)
+	assert.True(t, configTest.TestConfig.Flag)
+	assert.False(t, configTest.TestConfig2.Flag)
 }
 
-func TestBinding(t *testing.T) {
+func TestServiceConfigurationLoad_Errors(t *testing.T) {
+	os.Clearenv()
+	configTest := &ConfigurationTest{}
+	err := Load("test", configTest, DefaultConfiguration())
+	// Some required values are missing.
+	require.Error(t, err)
+	require.NotNil(t, configTest.Validate())
+
+	err = Load("test", nil, DefaultDummyConfiguration())
+	// Incorrect  structure provided.
+	require.Error(t, err)
+}
+
+func TestSimpleFlagBinding(t *testing.T) {
+	os.Clearenv()
+	configTest := &DummyConfiguration{}
+	defaults := DefaultDummyConfiguration()
+	session := viper.New()
+	var err error
+	flagSet := pflag.FlagSet{}
+	prefix := "test"
+	flagSet.String("host", "a host", "dummy host")
+	flagSet.String("password", "a password", "dummy password")
+	flagSet.String("user", "a user", "dummy user")
+	flagSet.String("db", "a db", "dummy db")
+	err = BindFlagToEnv(session, prefix, "TEST_DUMMY_HOST", flagSet.Lookup("host"))
+	require.NoError(t, err)
+	err = BindFlagToEnv(session, prefix, "PASSWORD", flagSet.Lookup("password"))
+	require.NoError(t, err)
+	err = BindFlagToEnv(session, prefix, "TEST_DB", flagSet.Lookup("db"))
+	require.NoError(t, err)
+	err = BindFlagToEnv(session, prefix, "DB", flagSet.Lookup("db"))
+	require.NoError(t, err)
+	err = BindFlagToEnv(session, prefix, "USER", flagSet.Lookup("user"))
+	require.NoError(t, err)
+	err = flagSet.Set("host", expectedHost)
+	require.NoError(t, err)
+	err = flagSet.Set("password", expectedPassword)
+	require.NoError(t, err)
+	err = flagSet.Set("db", expectedDb)
+	require.NoError(t, err)
+	err = LoadFromViper(session, prefix, configTest, defaults)
+	require.NoError(t, err)
+	require.NoError(t, configTest.Validate())
+	assert.Equal(t, defaults.Port, configTest.Port)
+	assert.Equal(t, expectedHost, configTest.Host)
+	assert.Equal(t, expectedPassword, configTest.Password)
+	assert.Equal(t, expectedDb, configTest.DB)
+	assert.True(t, configTest.Flag)
+}
+
+func TestFlagBinding(t *testing.T) {
 	os.Clearenv()
 	configTest := &ConfigurationTest{}
 	defaults := DefaultConfiguration()
@@ -142,8 +202,10 @@ func TestBinding(t *testing.T) {
 	flagSet.String("password", "a password", "dummy password")
 	flagSet.String("user", "a user", "dummy user")
 	flagSet.String("db", "a db", "dummy db")
+	flagSet.String("db2", "a db", "dummy db")
 	flagSet.Int("int", 0, "dummy int")
 	flagSet.Duration("time", time.Second, "dummy time")
+	flagSet.Bool("flag", false, "dummy flag")
 	err = BindFlagToEnv(session, prefix, "TEST_DUMMYCONFIG_DUMMY_HOST", flagSet.Lookup("host"))
 	require.NoError(t, err)
 	err = BindFlagToEnv(session, prefix, "TEST_DUMMY_CONFIG_DUMMY_HOST", flagSet.Lookup("host"))
@@ -158,7 +220,9 @@ func TestBinding(t *testing.T) {
 	require.NoError(t, err)
 	err = BindFlagToEnv(session, prefix, "TEST_DUMMYCONFIG_DB", flagSet.Lookup("db"))
 	require.NoError(t, err)
-	err = BindFlagToEnv(session, prefix, "DUMMY_CONFIG_DB", flagSet.Lookup("db"))
+	err = BindFlagToEnv(session, prefix, "DUMMY_CONFIG_DB", flagSet.Lookup("db2"))
+	require.NoError(t, err)
+	err = BindFlagToEnv(session, prefix, "DUMMY_CONFIG_FLAG", flagSet.Lookup("flag"))
 	require.NoError(t, err)
 	err = BindFlagToEnv(session, prefix, "DUMMY_INT", flagSet.Lookup("int"))
 	require.NoError(t, err)
@@ -170,26 +234,43 @@ func TestBinding(t *testing.T) {
 	require.NoError(t, err)
 	err = flagSet.Set("user", "another test user")
 	require.NoError(t, err)
-	err = flagSet.Set("db", "another test db")
+	err = flagSet.Set("db", expectedDb) //Should take precedence over environment
+	require.NoError(t, err)
+	aDifferentDb := "another test db"
+	assert.NotEqual(t, expectedDb, aDifferentDb)
+	err = os.Setenv("TEST_DUMMY_CONFIG_DB", aDifferentDb)
+	require.NoError(t, err)
+	err = os.Setenv("TEST_DUMMYCONFIG_DB", aDifferentDb)
 	require.NoError(t, err)
 	err = flagSet.Set("int", fmt.Sprintf("%v", expectedInt))
 	require.NoError(t, err)
 	err = flagSet.Set("time", expectedDuration.String())
 	require.NoError(t, err)
+	err = flagSet.Set("flag", fmt.Sprintf("%v", false))
+	require.NoError(t, err)
+	flag, err := flagSet.GetBool("flag")
+	require.NoError(t, err)
+	assert.False(t, flag)
+	assert.False(t, session.GetBool("dummy.config.flag"))
 	err = LoadFromViper(session, prefix, configTest, defaults)
 	require.NoError(t, err)
 	require.NoError(t, configTest.Validate())
-	assert.Equal(t, configTest.TestString, expectedString)
-	assert.Equal(t, configTest.TestInt, expectedInt)
-	assert.Equal(t, configTest.TestTime, expectedDuration)
-	assert.Equal(t, configTest.TestConfig.Port, defaults.TestConfig.Port)
-	assert.Equal(t, configTest.TestConfig.Host, expectedHost)
-	assert.Equal(t, configTest.TestConfig2.Host, expectedHost)
-	assert.Equal(t, configTest.TestConfig.Password, expectedPassword)
-	assert.Equal(t, configTest.TestConfig2.Password, expectedPassword)
+	assert.Equal(t, expectedString, configTest.TestString)
+	assert.Equal(t, expectedInt, configTest.TestInt)
+	assert.Equal(t, expectedDuration, configTest.TestTime)
+	assert.Equal(t, defaults.TestConfig.Port, configTest.TestConfig.Port)
+	assert.Equal(t, expectedHost, configTest.TestConfig.Host)
+	assert.Equal(t, expectedHost, configTest.TestConfig2.Host)
+	assert.Equal(t, expectedPassword, configTest.TestConfig.Password)
+	assert.Equal(t, expectedPassword, configTest.TestConfig2.Password)
+	assert.Equal(t, expectedDb, configTest.TestConfig.DB)
+	assert.Equal(t, aDifferentDb, configTest.TestConfig2.DB)
+	assert.NotEqual(t, expectedDb, configTest.TestConfig2.DB)
+	assert.True(t, configTest.TestConfig.Flag)
+	assert.False(t, configTest.TestConfig2.Flag)
 }
 
-func TestBindingDefaults(t *testing.T) {
+func TestFlagBindingDefaults(t *testing.T) {
 	os.Clearenv()
 	configTest := &ConfigurationTest{}
 	defaults := DefaultConfiguration()
@@ -202,9 +283,12 @@ func TestBindingDefaults(t *testing.T) {
 	flagSet.String("host2", anotherHostName, "dummy host")
 	flagSet.String("password", expectedPassword, "dummy password")
 	flagSet.String("user", "a user", "dummy user")
-	flagSet.String("db", "a db", "dummy db")
+	aDifferentDb := "A different db"
+	assert.NotEqual(t, expectedDb, aDifferentDb)
+	flagSet.String("db", aDifferentDb, "dummy db")
 	flagSet.Int("int", expectedInt, "dummy int")
 	flagSet.Duration("time", expectedDuration, "dummy time")
+	flagSet.Bool("flag", !DefaultDummyConfiguration().Flag, "dummy flag")
 	err = BindFlagToEnv(session, prefix, "TEST_DUMMYCONFIG_DUMMY_HOST", flagSet.Lookup("host"))
 	require.NoError(t, err)
 	err = BindFlagToEnv(session, prefix, "TEST_DUMMY_CONFIG_DUMMY_HOST", flagSet.Lookup("host2"))
@@ -221,21 +305,31 @@ func TestBindingDefaults(t *testing.T) {
 	require.NoError(t, err)
 	err = BindFlagToEnv(session, prefix, "DUMMY_CONFIG_DB", flagSet.Lookup("db"))
 	require.NoError(t, err)
+	err = BindFlagToEnv(session, prefix, "DUMMY_CONFIG_FLAG", flagSet.Lookup("flag"))
+	require.NoError(t, err)
 	err = BindFlagToEnv(session, prefix, "DUMMY_INT", flagSet.Lookup("int"))
 	require.NoError(t, err)
 	err = BindFlagToEnv(session, prefix, "DUMMY_Time", flagSet.Lookup("time"))
 	require.NoError(t, err)
-
+	err = os.Setenv("TEST_DUMMY_CONFIG_DB", expectedDb) //Should take precedence over flag default
+	require.NoError(t, err)
 	err = LoadFromViper(session, prefix, configTest, defaults)
 	require.NoError(t, err)
 	require.NoError(t, configTest.Validate())
-	assert.Equal(t, configTest.TestString, expectedString)
-	assert.Equal(t, configTest.TestInt, expectedInt)
-	assert.Equal(t, configTest.TestTime, expectedDuration)
-	assert.Equal(t, configTest.TestConfig.Port, defaults.TestConfig.Port)
-	assert.NotEqual(t, expectedHost, anotherHostName)
-	assert.Equal(t, configTest.TestConfig.Host, expectedHost)
-	assert.Equal(t, configTest.TestConfig2.Host, anotherHostName)
-	assert.Equal(t, configTest.TestConfig.Password, expectedPassword)
-	assert.Equal(t, configTest.TestConfig2.Password, expectedPassword)
+	assert.Equal(t, expectedString, configTest.TestString)
+	assert.Equal(t, expectedInt, configTest.TestInt)
+	// Defaults from the default structure provided take precedence over defaults from flags when not empty.
+	assert.NotEqual(t, expectedDuration, configTest.TestTime)
+	assert.Equal(t, DefaultConfiguration().TestTime, configTest.TestTime)
+	assert.Equal(t, defaults.TestConfig.Port, configTest.TestConfig.Port)
+	assert.NotEqual(t, anotherHostName, expectedHost)
+	assert.Equal(t, expectedHost, configTest.TestConfig.Host)
+	assert.Equal(t, anotherHostName, configTest.TestConfig2.Host)
+	assert.Equal(t, expectedPassword, configTest.TestConfig.Password)
+	assert.Equal(t, expectedPassword, configTest.TestConfig2.Password)
+	assert.Equal(t, aDifferentDb, configTest.TestConfig.DB)
+	assert.Equal(t, expectedDb, configTest.TestConfig2.DB)
+	// Defaults from the default structure provided take precedence over defaults from flags when empty.
+	assert.Equal(t, DefaultConfiguration().TestConfig.Flag, configTest.TestConfig.Flag)
+	assert.Equal(t, DefaultConfiguration().TestConfig.Flag, configTest.TestConfig2.Flag)
 }

--- a/utils/config/service_configuration_test.go
+++ b/utils/config/service_configuration_test.go
@@ -25,7 +25,7 @@ var (
 	expectedDuration = time.Since(time.Date(1999, 2, 3, 4, 30, 45, 46, time.UTC))
 	expectedHost     = fmt.Sprintf("a test host %v", faker.Word())
 	expectedPassword = fmt.Sprintf("a test passwd %v", faker.Password())
-	expectedDb       = fmt.Sprintf("a db %v", faker.Word())
+	expectedDB       = fmt.Sprintf("a db %v", faker.Word())
 )
 
 type DummyConfiguration struct {
@@ -114,7 +114,7 @@ func TestServiceConfigurationLoad(t *testing.T) {
 	require.NoError(t, err)
 	err = os.Setenv("TEST_DUMMYCONFIG_DB", "a test db")
 	require.NoError(t, err)
-	err = os.Setenv("TEST_DUMMY_CONFIG_DB", expectedDb)
+	err = os.Setenv("TEST_DUMMY_CONFIG_DB", expectedDB)
 	require.NoError(t, err)
 	err = os.Setenv("TEST_DUMMY_CONFIG_FLAG", "false")
 	require.NoError(t, err)
@@ -131,10 +131,10 @@ func TestServiceConfigurationLoad(t *testing.T) {
 	assert.Equal(t, defaults.TestConfig.Port, configTest.TestConfig.Port)
 	assert.Equal(t, expectedHost, configTest.TestConfig.Host)
 	assert.Equal(t, expectedPassword, configTest.TestConfig2.Password)
-	assert.Equal(t, expectedDb, configTest.TestConfig2.DB)
+	assert.Equal(t, expectedDB, configTest.TestConfig2.DB)
 	assert.NotEqual(t, expectedHost, configTest.TestConfig2.Host)
 	assert.NotEqual(t, expectedPassword, configTest.TestConfig.Password)
-	assert.NotEqual(t, expectedDb, configTest.TestConfig.DB)
+	assert.NotEqual(t, expectedDB, configTest.TestConfig.DB)
 	assert.True(t, configTest.TestConfig.Flag)
 	assert.False(t, configTest.TestConfig2.Flag)
 }
@@ -178,7 +178,7 @@ func TestSimpleFlagBinding(t *testing.T) {
 	require.NoError(t, err)
 	err = flagSet.Set("password", expectedPassword)
 	require.NoError(t, err)
-	err = flagSet.Set("db", expectedDb)
+	err = flagSet.Set("db", expectedDB)
 	require.NoError(t, err)
 	err = LoadFromViper(session, prefix, configTest, defaults)
 	require.NoError(t, err)
@@ -186,7 +186,7 @@ func TestSimpleFlagBinding(t *testing.T) {
 	assert.Equal(t, defaults.Port, configTest.Port)
 	assert.Equal(t, expectedHost, configTest.Host)
 	assert.Equal(t, expectedPassword, configTest.Password)
-	assert.Equal(t, expectedDb, configTest.DB)
+	assert.Equal(t, expectedDB, configTest.DB)
 	assert.True(t, configTest.Flag)
 }
 
@@ -234,13 +234,13 @@ func TestFlagBinding(t *testing.T) {
 	require.NoError(t, err)
 	err = flagSet.Set("user", "another test user")
 	require.NoError(t, err)
-	err = flagSet.Set("db", expectedDb) //Should take precedence over environment
+	err = flagSet.Set("db", expectedDB) //Should take precedence over environment
 	require.NoError(t, err)
-	aDifferentDb := "another test db"
-	assert.NotEqual(t, expectedDb, aDifferentDb)
-	err = os.Setenv("TEST_DUMMY_CONFIG_DB", aDifferentDb)
+	aDifferentDB := "another test db"
+	assert.NotEqual(t, expectedDB, aDifferentDB)
+	err = os.Setenv("TEST_DUMMY_CONFIG_DB", aDifferentDB)
 	require.NoError(t, err)
-	err = os.Setenv("TEST_DUMMYCONFIG_DB", aDifferentDb)
+	err = os.Setenv("TEST_DUMMYCONFIG_DB", aDifferentDB)
 	require.NoError(t, err)
 	err = flagSet.Set("int", fmt.Sprintf("%v", expectedInt))
 	require.NoError(t, err)
@@ -263,9 +263,9 @@ func TestFlagBinding(t *testing.T) {
 	assert.Equal(t, expectedHost, configTest.TestConfig2.Host)
 	assert.Equal(t, expectedPassword, configTest.TestConfig.Password)
 	assert.Equal(t, expectedPassword, configTest.TestConfig2.Password)
-	assert.Equal(t, expectedDb, configTest.TestConfig.DB)
-	assert.Equal(t, aDifferentDb, configTest.TestConfig2.DB)
-	assert.NotEqual(t, expectedDb, configTest.TestConfig2.DB)
+	assert.Equal(t, expectedDB, configTest.TestConfig.DB)
+	assert.Equal(t, aDifferentDB, configTest.TestConfig2.DB)
+	assert.NotEqual(t, expectedDB, configTest.TestConfig2.DB)
 	assert.True(t, configTest.TestConfig.Flag)
 	assert.False(t, configTest.TestConfig2.Flag)
 }
@@ -283,9 +283,9 @@ func TestFlagBindingDefaults(t *testing.T) {
 	flagSet.String("host2", anotherHostName, "dummy host")
 	flagSet.String("password", expectedPassword, "dummy password")
 	flagSet.String("user", "a user", "dummy user")
-	aDifferentDb := "A different db"
-	assert.NotEqual(t, expectedDb, aDifferentDb)
-	flagSet.String("db", aDifferentDb, "dummy db")
+	aDifferentDB := "A different db"
+	assert.NotEqual(t, expectedDB, aDifferentDB)
+	flagSet.String("db", aDifferentDB, "dummy db")
 	flagSet.Int("int", expectedInt, "dummy int")
 	flagSet.Duration("time", expectedDuration, "dummy time")
 	flagSet.Bool("flag", !DefaultDummyConfiguration().Flag, "dummy flag")
@@ -311,7 +311,7 @@ func TestFlagBindingDefaults(t *testing.T) {
 	require.NoError(t, err)
 	err = BindFlagToEnv(session, prefix, "DUMMY_Time", flagSet.Lookup("time"))
 	require.NoError(t, err)
-	err = os.Setenv("TEST_DUMMY_CONFIG_DB", expectedDb) //Should take precedence over flag default
+	err = os.Setenv("TEST_DUMMY_CONFIG_DB", expectedDB) //Should take precedence over flag default
 	require.NoError(t, err)
 	err = LoadFromViper(session, prefix, configTest, defaults)
 	require.NoError(t, err)
@@ -327,8 +327,8 @@ func TestFlagBindingDefaults(t *testing.T) {
 	assert.Equal(t, anotherHostName, configTest.TestConfig2.Host)
 	assert.Equal(t, expectedPassword, configTest.TestConfig.Password)
 	assert.Equal(t, expectedPassword, configTest.TestConfig2.Password)
-	assert.Equal(t, aDifferentDb, configTest.TestConfig.DB)
-	assert.Equal(t, expectedDb, configTest.TestConfig2.DB)
+	assert.Equal(t, aDifferentDB, configTest.TestConfig.DB)
+	assert.Equal(t, expectedDB, configTest.TestConfig2.DB)
 	// Defaults from the default structure provided take precedence over defaults from flags when empty.
 	assert.Equal(t, DefaultConfiguration().TestConfig.Flag, configTest.TestConfig.Flag)
 	assert.Equal(t, DefaultConfiguration().TestConfig.Flag, configTest.TestConfig2.Flag)


### PR DESCRIPTION
### Description

Fixed a bug introduced for handling flags and their binding to structured configuration fields

### Test Coverage

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
