### PR TITLE
:sparkles: [collection] `ParseListWithCleanupKeepBlankLines` as alternative to `ParseListWithCleanup` to keep blank lines

### DIFF
--- a/changes/202205121612.feature
+++ b/changes/202205121612.feature
@@ -1,0 +1,1 @@
+Add option to run parseListWithCleanup to keep empty lines

--- a/utils/collection/parseLists.go
+++ b/utils/collection/parseLists.go
@@ -4,12 +4,24 @@
  */
 package collection
 
-import "strings"
+import (
+	"strings"
+	"unicode"
+)
+
+func lineIsOnlyWhitespace(line string) bool {
+	for _, c := range line {
+		if !unicode.IsSpace(c) {
+			return false
+		}
+	}
+	return true
+}
 
 // ParseListWithCleanup splits a string into a list like strings.Split but also removes any whitespace surrounding  the different items
 // for example,
 // ParseListWithCleanup("a, b ,  c", ",") returns []{"a","b","c"}
-func ParseListWithCleanup(input string, sep string) (newS []string) {
+func parseListWithCleanup(input string, sep string, keepBlankLines bool) (newS []string) {
 	if len(input) == 0 {
 		newS = []string{} // initialisation of empty arrays in function returns []string(nil) instead of []string{}
 		return
@@ -17,11 +29,26 @@ func ParseListWithCleanup(input string, sep string) (newS []string) {
 	split := strings.Split(input, sep)
 	for _, s := range split {
 		tempString := strings.TrimSpace(s)
-		if tempString != "" {
+		if tempString != "" || (keepBlankLines && lineIsOnlyWhitespace(s)) {
 			newS = append(newS, tempString)
 		}
 	}
 	return
+}
+
+// ParseListWithCleanup splits a string into a list like strings.Split but also removes any whitespace surrounding  the different items
+// for example,
+// ParseListWithCleanup("a, b ,  c", ",") returns []{"a","b","c"}
+func ParseListWithCleanup(input string, sep string) (newS []string) {
+	return parseListWithCleanup(input, sep, false)
+}
+
+// ParseListWithCleanup splits a string into a list like strings.Split but also removes any whitespace surrounding  the different items
+// unless the entire item is whitespace in which case it is converted to an empty string. For example,
+// ParseListWithCleanup("a, b ,  c", ",") returns []{"a","b","c"}
+// ParseListWithCleanup("a, b ,    , c", ",") returns []{"a","b", "", "c"}
+func ParseListWithCleanupKeepBlankLines(input string, sep string) (newS []string) {
+	return parseListWithCleanup(input, sep, true)
 }
 
 // ParseCommaSeparatedList returns the list of string separated by a comma

--- a/utils/collection/parseLists.go
+++ b/utils/collection/parseLists.go
@@ -18,9 +18,6 @@ func lineIsOnlyWhitespace(line string) bool {
 	return true
 }
 
-// ParseListWithCleanup splits a string into a list like strings.Split but also removes any whitespace surrounding  the different items
-// for example,
-// ParseListWithCleanup("a, b ,  c", ",") returns []{"a","b","c"}
 func parseListWithCleanup(input string, sep string, keepBlankLines bool) (newS []string) {
 	if len(input) == 0 {
 		newS = []string{} // initialisation of empty arrays in function returns []string(nil) instead of []string{}
@@ -43,10 +40,10 @@ func ParseListWithCleanup(input string, sep string) (newS []string) {
 	return parseListWithCleanup(input, sep, false)
 }
 
-// ParseListWithCleanup splits a string into a list like strings.Split but also removes any whitespace surrounding  the different items
+// ParseListWithCleanupKeepBlankLines splits a string into a list like strings.Split but also removes any whitespace surrounding  the different items
 // unless the entire item is whitespace in which case it is converted to an empty string. For example,
-// ParseListWithCleanup("a, b ,  c", ",") returns []{"a","b","c"}
-// ParseListWithCleanup("a, b ,    , c", ",") returns []{"a","b", "", "c"}
+// ParseListWithCleanupKeepBlankLines("a, b ,  c", ",") returns []{"a","b","c"}
+// ParseListWithCleanupKeepBlankLines("a, b ,    , c", ",") returns []{"a","b", "", "c"}
 func ParseListWithCleanupKeepBlankLines(input string, sep string) (newS []string) {
 	return parseListWithCleanup(input, sep, true)
 }

--- a/utils/collection/parseLists_test.go
+++ b/utils/collection/parseLists_test.go
@@ -50,3 +50,35 @@ func TestParseCommaSeparatedListWithSpacesBetweenWords(t *testing.T) {
 	finalList := ParseCommaSeparatedList(stringList)
 	require.Equal(t, stringArray, finalList)
 }
+
+func TestParseCommaSeparatedListWithSpacesBetweenWordsKeepBlanks(t *testing.T) {
+	stringList := ""
+	stringArray := []string{}
+	// we don't need cryptographically secure random numbers for generating a number of elements in a list
+	lengthOfList := rand.Intn(10) + 8 //nolint:gosec
+	for i := 0; i < lengthOfList; i++ {
+		word := faker.Sentence()
+		stringList += word
+		stringArray = append(stringArray, word)
+		numSpacesToAdd := rand.Intn(5) //nolint:gosec
+		for j := 0; j < numSpacesToAdd; j++ {
+			stringList += " "
+		}
+		stringList += ","
+		if i%3 == 2 {
+			numSpacesToAdd := rand.Intn(5) //nolint:gosec
+			for j := 0; j < numSpacesToAdd; j++ {
+				stringList += " "
+			}
+			stringArray = append(stringArray, "")
+			stringList += ","
+		}
+	}
+	stringArray = append(stringArray, "") // account for final ,
+
+	finalList1 := ParseCommaSeparatedList(stringList)
+	require.NotEqual(t, stringArray, finalList1)
+
+	finalList2 := ParseListWithCleanupKeepBlankLines(stringList, ",")
+	require.Equal(t, stringArray, finalList2)
+}


### PR DESCRIPTION
 Add option to run parseListWithCleanup to keep empty lines

<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Add option to run `ParseListWithCleanupKeepBlankLines` to run `ParseListWithCleanup` but keep empty lines. This is necessary for the VHT Service. Backwards compatible with old versions.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [X]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).