### PR TITLE
Add `FilepathStem` function to filesystem package, emulating Python's Pathlib.Stem behaviour

### DIFF
--- a/changes/20220525.feature
+++ b/changes/20220525.feature
@@ -1,1 +1,1 @@
-Add `FilepathStem` function to filesystem package, emulating Python's Pathlib.Stem behaviour
+[filesystem] Add `FilepathStem` function to package, emulating Python's [Pathlib.Stem behaviour](https://docs.python.org/3.10/library/pathlib.html#pathlib.PurePath.stem)

--- a/changes/20220525.feature
+++ b/changes/20220525.feature
@@ -1,0 +1,1 @@
+Add `FilepathStem` function to filesystem package, emulating Python's Pathlib.Stem behaviour

--- a/utils/filesystem/files.go
+++ b/utils/filesystem/files.go
@@ -1344,6 +1344,7 @@ func convertToExtendedFile(file afero.File, onCloseCallBack func() error) (File,
 	}, nil
 }
 
+// FilepathStem returns  the final path component, without its suffix.
 func FilepathStem(fp string) string {
 	return strings.TrimSuffix(filepath.Base(fp), filepath.Ext(fp))
 }

--- a/utils/filesystem/files.go
+++ b/utils/filesystem/files.go
@@ -1343,3 +1343,7 @@ func convertToExtendedFile(file afero.File, onCloseCallBack func() error) (File,
 		onCloseCallBack: onCloseCallBack,
 	}, nil
 }
+
+func FilepathStem(fp string) string {
+	return strings.TrimSuffix(filepath.Base(fp), filepath.Ext(fp))
+}

--- a/utils/filesystem/files_test.go
+++ b/utils/filesystem/files_test.go
@@ -1176,6 +1176,21 @@ func TestListDirTree(t *testing.T) {
 	}
 }
 
+func TestFilepathStem(t *testing.T) {
+	t.Run("given a filename with extension, it strips extension", func(t *testing.T) {
+		assert.Equal(t, "foo", FilepathStem("foo.bar"))
+		assert.Equal(t, "library.tar", FilepathStem("library.tar.gz"))
+		assert.Equal(t, "cool", FilepathStem("cool"))
+	})
+
+	t.Run("given a filepath, it returns only file name", func(t *testing.T) {
+		fp := filepath.Join("super", "foo", "bar.baz")
+		assert.Equal(t, "bar", FilepathStem(fp))
+		fp = filepath.Join("nice", "file", "path")
+		assert.Equal(t, "path", FilepathStem(fp))
+	})
+}
+
 func checkCopyDir(t *testing.T, fs FS, src string, dest string) {
 	assert.True(t, fs.Exists(src))
 	assert.False(t, fs.Exists(dest))


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description
New `filesystem.FilepathStem` function, emulating the behaviour of https://docs.python.org/3.10/library/pathlib.html#pathlib.PurePath.stem


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
