### PR TITLE
[lock file] ensuring context termination is taken into account during retries

### DIFF
--- a/changes/202206101540.bugfix
+++ b/changes/202206101540.bugfix
@@ -1,0 +1,1 @@
+[file lock] Ensure retries stop when context is asked to terminate

--- a/utils/filesystem/lockfile.go
+++ b/utils/filesystem/lockfile.go
@@ -197,7 +197,7 @@ func (l *RemoteLockFile) LockWithTimeout(ctx context.Context, timeout time.Durat
 }
 
 // Unlock unlocks the lock
-func (l *RemoteLockFile) Unlock(context.Context) error {
+func (l *RemoteLockFile) Unlock(ctx context.Context) error {
 	l.cancelStore.Cancel()
 	return retry.Do(
 		func() error {
@@ -213,6 +213,7 @@ func (l *RemoteLockFile) Unlock(context.Context) error {
 		retry.MaxJitter(25*time.Millisecond),
 		retry.DelayType(retry.RandomDelay),
 		retry.Attempts(10),
+		retry.Context(ctx),
 	)
 }
 
@@ -241,5 +242,6 @@ func (l *RemoteLockFile) MakeStale(ctx context.Context) error {
 		retry.MaxJitter(l.lockHeartBeatPeriod),
 		retry.DelayType(retry.RandomDelay),
 		retry.Attempts(10),
+		retry.Context(ctx),
 	)
 }


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

[lock file] ensuring context termination is taken into account during retries



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
