### PR TITLE
Add utility for generating a list of the environment variables based on a struct that uses mapstructure

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -107,6 +107,13 @@
         "hashed_secret": "ddcec2f503a5d58f432a0beee3fb9544fa581f54",
         "is_verified": false,
         "line_number": 27
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "utils/config/service_configuration_test.go",
+        "hashed_secret": "7ca1cc114e7e5f955880bb96a5bf391b4dc20ab6",
+        "is_verified": false,
+        "line_number": 348
       }
     ],
     "utils/filesystem/filehash_test.go": [
@@ -163,5 +170,5 @@
       }
     ]
   },
-  "generated_at": "2022-02-03T10:26:30Z"
+  "generated_at": "2022-07-29T08:53:28Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -106,14 +106,28 @@
         "filename": "utils/config/service_configuration_test.go",
         "hashed_secret": "ddcec2f503a5d58f432a0beee3fb9544fa581f54",
         "is_verified": false,
-        "line_number": 27
+        "line_number": 29
       },
       {
         "type": "Secret Keyword",
         "filename": "utils/config/service_configuration_test.go",
         "hashed_secret": "7ca1cc114e7e5f955880bb96a5bf391b4dc20ab6",
         "is_verified": false,
-        "line_number": 348
+        "line_number": 350
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "utils/config/service_configuration_test.go",
+        "hashed_secret": "ddb5c642549caa0cae3eab9eeaf1a26cfaacb2c0",
+        "is_verified": false,
+        "line_number": 440
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "utils/config/service_configuration_test.go",
+        "hashed_secret": "7dbc962be2561262a6d7d0fe675db18e4511bb96",
+        "is_verified": false,
+        "line_number": 447
       }
     ],
     "utils/filesystem/filehash_test.go": [
@@ -170,5 +184,5 @@
       }
     ]
   },
-  "generated_at": "2022-07-29T08:53:28Z"
+  "generated_at": "2022-07-29T10:42:52Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -113,21 +113,21 @@
         "filename": "utils/config/service_configuration_test.go",
         "hashed_secret": "7ca1cc114e7e5f955880bb96a5bf391b4dc20ab6",
         "is_verified": false,
-        "line_number": 350
+        "line_number": 366
       },
       {
         "type": "Secret Keyword",
         "filename": "utils/config/service_configuration_test.go",
-        "hashed_secret": "ddb5c642549caa0cae3eab9eeaf1a26cfaacb2c0",
+        "hashed_secret": "11519c144be4850d95b34220a40030cbd5a36b57",
         "is_verified": false,
-        "line_number": 440
+        "line_number": 461
       },
       {
         "type": "Secret Keyword",
         "filename": "utils/config/service_configuration_test.go",
-        "hashed_secret": "7dbc962be2561262a6d7d0fe675db18e4511bb96",
+        "hashed_secret": "15fae91d8fa7f2c531c1cf3ddc745e1f4473c02d",
         "is_verified": false,
-        "line_number": 447
+        "line_number": 468
       }
     ],
     "utils/filesystem/filehash_test.go": [
@@ -184,5 +184,5 @@
       }
     ]
   },
-  "generated_at": "2022-07-29T10:42:52Z"
+  "generated_at": "2022-07-29T11:15:42Z"
 }

--- a/changes/202207290929.feature
+++ b/changes/202207290929.feature
@@ -1,0 +1,1 @@
+Add utility for generating a list of the environment variables based on a struct that uses mapstructure

--- a/utils/config/service_configuration.go
+++ b/utils/config/service_configuration.go
@@ -154,12 +154,12 @@ func linkFlagKeysToStructureKeys(viperSession *viper.Viper, envVarPrefix string)
 	}
 }
 
-func flattenDefaultsMap(appName string, m map[string]interface{}) map[string]interface{} {
+func flattenDefaultsMap(m map[string]interface{}) map[string]interface{} {
 	output := make(map[string]interface{})
 	for key, value := range m {
 		switch child := value.(type) {
 		case map[string]interface{}:
-			next := flattenDefaultsMap(appName, child)
+			next := flattenDefaultsMap(child)
 			for nextKey, nextValue := range next {
 				output[strings.ToUpper(fmt.Sprintf("%s_%s", key, nextKey))] = nextValue
 			}
@@ -182,7 +182,7 @@ func DetermineConfigurationEnvironmentVariables(appName string, configurationToD
 	if err != nil {
 		return
 	}
-	withoutPrefix = flattenDefaultsMap(appName, withoutPrefix)
+	withoutPrefix = flattenDefaultsMap(withoutPrefix)
 	if err != nil {
 		return
 	}

--- a/utils/config/service_configuration.go
+++ b/utils/config/service_configuration.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/reflection"
 )
 
@@ -169,7 +170,12 @@ func flattenDefaultsMap(appName string, m map[string]interface{}) map[string]int
 	return output
 }
 
-func GenerateEnvVars(appName string, configurationToDecode IServiceConfiguration) (defaults map[string]interface{}, err error) {
+// DetermineConfigurationEnvironmentVariables returns all the environment variables corresponding to a configuration structure as well as all the default values currently set.
+func DetermineConfigurationEnvironmentVariables(appName string, configurationToDecode IServiceConfiguration) (defaults map[string]interface{}, err error) {
+	if reflection.IsEmpty(configurationToDecode) {
+		err = fmt.Errorf("%w: configurationToDecode isn't defined", commonerrors.ErrUndefined)
+		return
+	}
 
 	err = mapstructure.Decode(configurationToDecode, &defaults)
 	if err != nil {

--- a/utils/config/service_configuration.go
+++ b/utils/config/service_configuration.go
@@ -6,7 +6,6 @@ package config
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/joho/godotenv"
@@ -170,8 +169,8 @@ func flattenDefaultsMap(appName string, m map[string]interface{}) map[string]int
 	return output
 }
 
-func GenerateEnvVars(appName string, configurationToDecode IServiceConfiguration) (envVars []string, err error) {
-	defaults := make(map[string]interface{})
+func GenerateEnvVars(appName string, configurationToDecode IServiceConfiguration) (defaults map[string]interface{}, err error) {
+
 	err = mapstructure.Decode(configurationToDecode, &defaults)
 	if err != nil {
 		return
@@ -180,9 +179,5 @@ func GenerateEnvVars(appName string, configurationToDecode IServiceConfiguration
 	if err != nil {
 		return
 	}
-	for key, value := range defaults {
-		envVars = append(envVars, fmt.Sprintf("%s=%v", key, value))
-	}
-	sort.Strings(envVars)
 	return
 }

--- a/utils/config/service_configuration.go
+++ b/utils/config/service_configuration.go
@@ -170,7 +170,7 @@ func flattenDefaultsMap(appName string, m map[string]interface{}) map[string]int
 	return output
 }
 
-func GenerateEnvFile(appName string, configurationToDecode IServiceConfiguration) (envVars []string, err error) {
+func GenerateEnvVars(appName string, configurationToDecode IServiceConfiguration) (envVars []string, err error) {
 	defaults := make(map[string]interface{})
 	err = mapstructure.Decode(configurationToDecode, &defaults)
 	if err != nil {

--- a/utils/config/service_configuration_test.go
+++ b/utils/config/service_configuration_test.go
@@ -341,16 +341,10 @@ func TestGenerateEnvFile_Defaults(t *testing.T) {
 	configTest := DefaultDummyConfiguration()
 
 	// Get the expected test values
-	var flag string // convert bool to string for test
-	if configTest.Flag {
-		flag = "true"
-	} else {
-		flag = "false"
-	}
 	testValues := map[string]string{
 		"TEST_DB":                 configTest.DB,
 		"TEST_DUMMY_HOST":         configTest.Host,
-		"TEST_FLAG":               flag,
+		"TEST_FLAG":               strconv.FormatBool(configTest.Flag),
 		"TEST_HEALTHCHECK_PERIOD": configTest.HealthCheckPeriod.String(),
 		"TEST_PASSWORD":           configTest.Password,
 		"TEST_PORT":               strconv.Itoa(configTest.Port),
@@ -408,16 +402,10 @@ func TestGenerateEnvFile_Populated(t *testing.T) {
 	require.NoError(t, configTest.Validate())
 
 	// Create test data
-	var flag string
-	if configTest.Flag {
-		flag = "true"
-	} else {
-		flag = "false"
-	}
 	testValues := map[string]string{
 		"TEST_DB":                 configTest.DB,
 		"TEST_DUMMY_HOST":         configTest.Host,
-		"TEST_FLAG":               flag,
+		"TEST_FLAG":               strconv.FormatBool(configTest.Flag),
 		"TEST_HEALTHCHECK_PERIOD": configTest.HealthCheckPeriod.String(),
 		"TEST_PASSWORD":           configTest.Password,
 		"TEST_PORT":               strconv.Itoa(configTest.Port),

--- a/utils/config/service_configuration_test.go
+++ b/utils/config/service_configuration_test.go
@@ -11,13 +11,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/bxcodec/faker/v3"
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
 )
 
 var (

--- a/utils/config/service_configuration_test.go
+++ b/utils/config/service_configuration_test.go
@@ -361,7 +361,7 @@ func TestGenerateEnvFile_Defaults(t *testing.T) {
 	prefix := "test"
 
 	// Generate the env vars
-	vars, err := GenerateEnvFile(prefix, configTest)
+	vars, err := GenerateEnvVars(prefix, configTest)
 	require.NoError(t, err)
 
 	// Go through generated vars and check they match the defaults
@@ -425,7 +425,7 @@ func TestGenerateEnvFile_Populated(t *testing.T) {
 	}
 
 	// Generate env file
-	vars, err := GenerateEnvFile(prefix, configTest)
+	vars, err := GenerateEnvVars(prefix, configTest)
 	require.NoError(t, err)
 
 	// Go through generated vars and check they match the defaults

--- a/utils/config/service_configuration_test.go
+++ b/utils/config/service_configuration_test.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -339,30 +337,25 @@ func TestFlagBindingDefaults(t *testing.T) {
 // Test you can use a struct to load the default env vars
 func TestGenerateEnvFile_Defaults(t *testing.T) {
 	configTest := DefaultDummyConfiguration()
+	prefix := "test"
 
-	// Get the expected test values
-	testValues := map[string]string{
+	// Create test data
+	testValues := map[string]interface{}{
 		"TEST_DB":                 configTest.DB,
 		"TEST_DUMMY_HOST":         configTest.Host,
-		"TEST_FLAG":               strconv.FormatBool(configTest.Flag),
-		"TEST_HEALTHCHECK_PERIOD": configTest.HealthCheckPeriod.String(),
+		"TEST_FLAG":               configTest.Flag,
+		"TEST_HEALTHCHECK_PERIOD": configTest.HealthCheckPeriod,
 		"TEST_PASSWORD":           configTest.Password,
-		"TEST_PORT":               strconv.Itoa(configTest.Port),
+		"TEST_PORT":               configTest.Port,
 		"TEST_USER":               configTest.User,
 	}
 
-	// Set prefix
-	prefix := "test"
-
-	// Generate the env vars
+	// Generate env file
 	vars, err := GenerateEnvVars(prefix, configTest)
 	require.NoError(t, err)
 
 	// Go through generated vars and check they match the defaults
-	for i := range vars {
-		envVar := vars[i]
-		split := strings.Split(envVar, "=")
-		key, value := split[0], split[1]
+	for key, value := range vars {
 		require.Equal(t, value, testValues[key])
 	}
 }
@@ -402,13 +395,13 @@ func TestGenerateEnvFile_Populated(t *testing.T) {
 	require.NoError(t, configTest.Validate())
 
 	// Create test data
-	testValues := map[string]string{
+	testValues := map[string]interface{}{
 		"TEST_DB":                 configTest.DB,
 		"TEST_DUMMY_HOST":         configTest.Host,
-		"TEST_FLAG":               strconv.FormatBool(configTest.Flag),
-		"TEST_HEALTHCHECK_PERIOD": configTest.HealthCheckPeriod.String(),
+		"TEST_FLAG":               configTest.Flag,
+		"TEST_HEALTHCHECK_PERIOD": configTest.HealthCheckPeriod,
 		"TEST_PASSWORD":           configTest.Password,
-		"TEST_PORT":               strconv.Itoa(configTest.Port),
+		"TEST_PORT":               configTest.Port,
 		"TEST_USER":               configTest.User,
 	}
 
@@ -417,10 +410,7 @@ func TestGenerateEnvFile_Populated(t *testing.T) {
 	require.NoError(t, err)
 
 	// Go through generated vars and check they match the defaults
-	for i := range vars {
-		envVar := vars[i]
-		split := strings.Split(envVar, "=")
-		key, value := split[0], split[1]
+	for key, value := range vars {
 		require.Equal(t, value, testValues[key])
 	}
 }

--- a/utils/config/service_configuration_test.go
+++ b/utils/config/service_configuration_test.go
@@ -66,6 +66,22 @@ type ConfigurationTest struct {
 	TestConfig2 DummyConfiguration `mapstructure:"dummy_config"`
 }
 
+type DeepConfig struct {
+	TestString     string            `mapstructure:"dummy_string"`
+	TestConfigDeep ConfigurationTest `mapstructure:"deep_config"`
+}
+
+func DefaultDeepConfiguration() *DeepConfig {
+	return &DeepConfig{
+		TestString:     expectedString,
+		TestConfigDeep: *DefaultConfiguration(),
+	}
+}
+
+func (cfg *DeepConfig) Validate() error {
+	return nil
+}
+
 func (cfg *ConfigurationTest) Validate() error {
 	validation.ErrorTag = "mapstructure"
 
@@ -418,10 +434,10 @@ func TestGenerateEnvFile_Populated(t *testing.T) {
 }
 
 func TestGenerateEnvFile_Nested(t *testing.T) {
-	configTest := DefaultConfiguration()
+	configTest := DefaultDeepConfiguration()
 	prefix := "test"
 
-	// Nested test values
+	// Deep nested test values
 	/*
 		type ConfigurationTest struct {
 			TestString  string             `mapstructure:"dummy_string"`
@@ -431,25 +447,31 @@ func TestGenerateEnvFile_Nested(t *testing.T) {
 			TestConfig2 DummyConfiguration `mapstructure:"dummy_config"` <- nested
 		}
 
+		type DeepConfig struct {
+			TestString     string            `mapstructure:"dummy_string"`
+			TestConfigDeep ConfigurationTest `mapstructure:"deep_config"` <- nested
+		}
+
 	*/
 	testValues := map[string]interface{}{
-		"TEST_DUMMYCONFIG_TEST_DB":                  configTest.TestConfig.DB,
-		"TEST_DUMMYCONFIG_TEST_DUMMY_HOST":          configTest.TestConfig.Host,
-		"TEST_DUMMYCONFIG_TEST_FLAG":                configTest.TestConfig.Flag,
-		"TEST_DUMMYCONFIG_TEST_HEALTHCHECK_PERIOD":  configTest.TestConfig.HealthCheckPeriod,
-		"TEST_DUMMYCONFIG_TEST_PASSWORD":            configTest.TestConfig.Password,
-		"TEST_DUMMYCONFIG_TEST_PORT":                configTest.TestConfig.Port,
-		"TEST_DUMMYCONFIG_TEST_USER":                configTest.TestConfig.User,
-		"TEST_DUMMY_CONFIG_TEST_DB":                 configTest.TestConfig2.DB,
-		"TEST_DUMMY_CONFIG_TEST_DUMMY_HOST":         configTest.TestConfig2.Host,
-		"TEST_DUMMY_CONFIG_TEST_FLAG":               configTest.TestConfig2.Flag,
-		"TEST_DUMMY_CONFIG_TEST_HEALTHCHECK_PERIOD": configTest.TestConfig2.HealthCheckPeriod,
-		"TEST_DUMMY_CONFIG_TEST_PASSWORD":           configTest.TestConfig2.Password,
-		"TEST_DUMMY_CONFIG_TEST_PORT":               configTest.TestConfig2.Port,
-		"TEST_DUMMY_CONFIG_TEST_USER":               configTest.TestConfig2.User,
-		"TEST_DUMMY_INT":                            configTest.TestInt,
-		"TEST_DUMMY_STRING":                         configTest.TestString,
-		"TEST_DUMMY_TIME":                           configTest.TestTime,
+		"TEST_DEEP_CONFIG_DUMMYCONFIG_DB":                  configTest.TestConfigDeep.TestConfig.DB,
+		"TEST_DEEP_CONFIG_DUMMYCONFIG_DUMMY_HOST":          configTest.TestConfigDeep.TestConfig.Host,
+		"TEST_DEEP_CONFIG_DUMMYCONFIG_FLAG":                configTest.TestConfigDeep.TestConfig.Flag,
+		"TEST_DEEP_CONFIG_DUMMYCONFIG_HEALTHCHECK_PERIOD":  configTest.TestConfigDeep.TestConfig.HealthCheckPeriod,
+		"TEST_DEEP_CONFIG_DUMMYCONFIG_PASSWORD":            configTest.TestConfigDeep.TestConfig.Password,
+		"TEST_DEEP_CONFIG_DUMMYCONFIG_PORT":                configTest.TestConfigDeep.TestConfig.Port,
+		"TEST_DEEP_CONFIG_DUMMYCONFIG_USER":                configTest.TestConfigDeep.TestConfig.User,
+		"TEST_DEEP_CONFIG_DUMMY_CONFIG_DB":                 configTest.TestConfigDeep.TestConfig2.DB,
+		"TEST_DEEP_CONFIG_DUMMY_CONFIG_DUMMY_HOST":         configTest.TestConfigDeep.TestConfig2.Host,
+		"TEST_DEEP_CONFIG_DUMMY_CONFIG_FLAG":               configTest.TestConfigDeep.TestConfig2.Flag,
+		"TEST_DEEP_CONFIG_DUMMY_CONFIG_HEALTHCHECK_PERIOD": configTest.TestConfigDeep.TestConfig2.HealthCheckPeriod,
+		"TEST_DEEP_CONFIG_DUMMY_CONFIG_PASSWORD":           configTest.TestConfigDeep.TestConfig2.Password,
+		"TEST_DEEP_CONFIG_DUMMY_CONFIG_PORT":               configTest.TestConfigDeep.TestConfig2.Port,
+		"TEST_DEEP_CONFIG_DUMMY_CONFIG_USER":               configTest.TestConfigDeep.TestConfig2.User,
+		"TEST_DEEP_CONFIG_DUMMY_INT":                       configTest.TestConfigDeep.TestInt,
+		"TEST_DUMMY_STRING":                                configTest.TestString,
+		"TEST_DEEP_CONFIG_DUMMY_TIME":                      configTest.TestConfigDeep.TestTime,
+		"TEST_DEEP_CONFIG_DUMMY_STRING":                    configTest.TestConfigDeep.TestString,
 	}
 
 	// Generate env file


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Add utility for generating a list of the environment variables based on a struct that uses mapstructure.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [X]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
