### PR TITLE
Remove TryLock as it isn't available in go1.16

### DIFF
--- a/changes/202208111140.bugfix
+++ b/changes/202208111140.bugfix
@@ -1,0 +1,1 @@
+Remove TryLock as it isn't available in go1.16


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Remove TryLock as it isn't available in go1.16

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [x]  Additional tests are not required for this change (e.g. documentation update).
