### PR TITLE
⭐ Added `shared cache` using the filesystem

### DIFF
--- a/changes/202208231010.feature
+++ b/changes/202208231010.feature
@@ -1,0 +1,1 @@
+`[shared cache]` Added a new module to create and manage shared cache between processes

--- a/utils/sharedcache/common.go
+++ b/utils/sharedcache/common.go
@@ -1,0 +1,312 @@
+package sharedcache
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ARM-software/golang-utils/utils/collection"
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/filesystem"
+	"github.com/ARM-software/golang-utils/utils/hashing"
+	"github.com/ARM-software/golang-utils/utils/parallelisation"
+	"github.com/ARM-software/golang-utils/utils/reflection"
+)
+
+const defaultCachedPackage = "cache.zip"
+const hashFileDescriptor = ".hash"
+
+// GenerateKey generates a key based on a list of key elements `elems`.
+func GenerateKey(elems ...string) string {
+	hash := "ef46db3751d8e999" // xxhash(""). No point in calculating it for "" everytime
+	for _, elem := range elems {
+		hash = hashing.CalculateHash(hash+elem, hashing.HashXXHash)
+	}
+	return hash
+}
+
+func generateHashFileName(srcFile string) string {
+	return fmt.Sprintf("%v%v", filepath.Base(srcFile), hashFileDescriptor)
+}
+func getHash(ctx context.Context, fs filesystem.FS, src string, forceHashUpdate bool) (hash string, err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+	hashFile := filepath.Join(filepath.Dir(src), generateHashFileName(src))
+	if fs.Exists(hashFile) && !forceHashUpdate {
+		fileContents, readErr := fs.ReadFile(hashFile)
+		if readErr == nil {
+			hash = string(fileContents)
+			if len(hash) == 16 { // if valid hash
+				// xxhash 64 bit will have 16 characters
+				return
+			}
+		}
+	}
+
+	hash, err = fs.FileHash(hashing.HashXXHash, src)
+	if err != nil {
+		return
+	}
+	_ = fs.WriteFile(hashFile, []byte(hash), 0775)
+	return
+}
+
+func isPathForDirectory(fs filesystem.FS, dst string) bool {
+	if ok, _ := fs.IsDir(dst); ok {
+		return true
+	}
+	if filepath.Ext(dst) == "" {
+		return true
+	}
+	return strings.HasSuffix(dst, string(fs.PathSeparator())) || strings.HasSuffix(dst, "/")
+}
+
+// TransferFiles transfers a file from a location `src` to another `dest` and ensures the integrity (i.e. hash validation) of what was copied across.
+// `dest` can be a file or a directory. If not existent, it will be created on the fly. non-existent directory path should be terminated by a path separator i.e. / or \
+func TransferFiles(ctx context.Context, fs filesystem.FS, dst, src string) (destFile string, err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+	if !fs.Exists(src) {
+		err = fmt.Errorf("%w: source path does not exist [%v]", commonerrors.ErrNotFound, src)
+		return
+	}
+	if result, suberr := fs.IsFile(src); !result || suberr != nil {
+		err = fmt.Errorf("%w: source is not a file [%v, (%v)]", commonerrors.ErrInvalid, src, suberr)
+		return
+	}
+
+	destDir := dst
+	destFile = dst
+	renameFile := false
+
+	if isPathForDirectory(fs, destFile) {
+		baseName := filepath.Base(src)
+		destFile = filepath.Join(destDir, baseName)
+	} else {
+		destDir = filepath.Dir(dst)
+		renameFile = true
+	}
+
+	// get hash of original file
+	hash1, err := getHash(ctx, fs, src, false)
+	if err != nil {
+		return
+	}
+
+	// download/upload from/to cache
+	err = fs.Copy(src, destDir)
+	if err != nil {
+		return
+	}
+
+	if renameFile {
+		err = fs.Move(filepath.Join(destDir, filepath.Base(src)), destFile)
+		if err != nil {
+			return
+		}
+	}
+
+	// get hash of downloaded/uploaded file
+	hash2, err := getHash(ctx, fs, destFile, true)
+	if err != nil {
+		return
+	}
+
+	// check that hashes match
+	if !strings.EqualFold(hash1, hash2) {
+		_ = fs.Rm(destFile)
+		err = fmt.Errorf("%w: error occurred during file transfer (hash mismatch) [%v]", commonerrors.ErrInvalid, src)
+		return
+	}
+	return
+}
+
+// AbstractSharedCacheRepository defines an abstract cache repository.
+type AbstractSharedCacheRepository struct {
+	cfg *Configuration
+	fs  *filesystem.VFS
+}
+
+func (c *AbstractSharedCacheRepository) getCacheEntryPath(key string) string {
+	return filepath.Join(c.cfg.RemoteStoragePath, key)
+}
+
+func (c *AbstractSharedCacheRepository) createEntry(ctx context.Context, key string) (entryPath string, err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+	entryPath = c.getCacheEntryPath(key)
+	// create remote directory if this is the first time
+	err = c.fs.MkDir(entryPath) // won't do anything if dir already exists
+	return
+}
+
+func (c *AbstractSharedCacheRepository) GenerateKey(elems ...string) string {
+	return GenerateKey(elems...)
+}
+
+func (c *AbstractSharedCacheRepository) RemoveEntry(ctx context.Context, key string) error {
+	err := parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return err
+	}
+	return c.fs.Rm(c.getCacheEntryPath(key))
+}
+
+func (c *AbstractSharedCacheRepository) GetEntries(ctx context.Context) (entries []string, err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+	entries, err = c.fs.Ls(c.cfg.RemoteStoragePath)
+	if err != nil {
+		return
+	}
+	if reflection.IsEmpty(c.cfg.FilesystemItemsToIgnore) {
+		return
+	}
+	toIgnore := collection.ParseCommaSeparatedList(c.cfg.FilesystemItemsToIgnore)
+	entries, err = c.fs.ExcludeAll(entries, toIgnore...)
+	return
+}
+
+func (c *AbstractSharedCacheRepository) EntriesCount(ctx context.Context) (count int64, err error) {
+	files, err := c.GetEntries(ctx)
+	if err != nil {
+		return
+	}
+	count = int64(len(files))
+	return
+}
+
+func (c *AbstractSharedCacheRepository) setUpLocalDestination(ctx context.Context, dest string) (err error) {
+	// create localDir if necessary and remove old cache file(s)
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+	err = c.fs.MkDir(dest)
+	if err != nil {
+		return
+	}
+	err = c.fs.CleanDir(dest)
+	if err != nil {
+		return
+	}
+	return
+}
+
+func (c *AbstractSharedCacheRepository) unpackPackageToLocalDestination(ctx context.Context, cachedPackagePath, dest string) (err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+	// create temp location for cached package to be unzipped
+	tempDir, err := c.fs.TempDirInTempDir(tempDirPrefix)
+	if err != nil {
+		return
+	}
+	defer func() { _ = c.fs.Rm(tempDir) }()
+	// do the transfer to a temporary folder.
+	destZip, err := TransferFiles(ctx, c.fs, tempDir, cachedPackagePath)
+	defer func() { _ = c.fs.Rm(destZip) }()
+	if err != nil {
+		return
+	}
+
+	// unpack package into destination
+	_, err = c.fs.UnzipWithContext(ctx, destZip, dest)
+	return
+}
+
+func (c *AbstractSharedCacheRepository) getEntryAge(ctx context.Context, key string, getCachedPackageFromEntryPath func(ctx context.Context, key, entryDir string) (string, error)) (age time.Duration, err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+	remoteDir := c.getCacheEntryPath(key)
+	remoteExists, err := c.fs.IsDir(remoteDir)
+	if err != nil {
+		return
+	}
+	if !remoteExists {
+		err = fmt.Errorf("no cache entry for key [%v]: %w", key, commonerrors.ErrNotFound)
+		return
+	}
+	dirTime, suberr := c.fs.StatTimes(remoteDir)
+	cachedPackage, err := getCachedPackageFromEntryPath(ctx, key, remoteDir)
+	if err != nil {
+		err = suberr
+		if err == nil && dirTime != nil {
+			age = time.Since(dirTime.ModTime())
+		}
+		return
+	}
+	packageTime, err := c.fs.StatTimes(cachedPackage)
+	if err != nil {
+		if suberr == nil && dirTime != nil {
+			err = suberr
+			age = time.Since(dirTime.ModTime())
+			return
+		}
+		return
+	}
+	age = time.Since(packageTime.ModTime())
+	return
+}
+
+func (c *AbstractSharedCacheRepository) setEntryAge(ctx context.Context, key string, age time.Duration, getCachedPackageFromEntryPath func(ctx context.Context, key, entryDir string) (string, error)) (err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+	modTime := time.Now().Add(-age)
+	remoteDir := c.getCacheEntryPath(key)
+	remoteExists, err := c.fs.IsDir(remoteDir)
+	if err != nil {
+		return
+	}
+	if !remoteExists {
+		err = fmt.Errorf("no cache entry for key [%v]: %w", key, commonerrors.ErrNotFound)
+		return
+	}
+	err = c.fs.Chtimes(remoteDir, modTime, modTime)
+	if err != nil {
+		return
+	}
+	cachedPackage, err := getCachedPackageFromEntryPath(ctx, key, remoteDir)
+	if err != nil {
+		return
+	}
+	err = c.fs.Chtimes(cachedPackage, modTime, modTime)
+	return
+}
+
+func NewAbstractSharedCacheRepository(cfg *Configuration, fs filesystem.FS) (cache *AbstractSharedCacheRepository, err error) {
+	if cfg == nil {
+		err = fmt.Errorf("%w: missing configuration", commonerrors.ErrUndefined)
+		return
+	}
+	err = cfg.Validate()
+	if err != nil {
+		err = fmt.Errorf("%w: invalid configuration: %v", commonerrors.ErrInvalid, err.Error())
+		return
+	}
+	rawFs, ok := fs.(*filesystem.VFS)
+	if !ok {
+		err = fmt.Errorf("%w: to work properly, cache needs a VFS filesystem implementation", commonerrors.ErrNotImplemented)
+		return
+	}
+	cache = &AbstractSharedCacheRepository{
+		cfg: cfg,
+		fs:  rawFs,
+	}
+	return
+}

--- a/utils/sharedcache/common_test.go
+++ b/utils/sharedcache/common_test.go
@@ -1,0 +1,191 @@
+package sharedcache
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ARM-software/golang-utils/utils/filesystem"
+)
+
+func TestGenerateKey(t *testing.T) {
+	builderID := "test-builder"
+	projectPath := "project-path"
+
+	// https://asecuritysite.com/encryption/xxHash
+	// xxhash("") = ef46db3751d8e999
+	// xxhash("ef46db3751d8e999" + "project-path") = 9eef8a610714c80f
+	// xxhash("9eef8a610714c80f" + "test-builder") = 8dee155db58cff5d
+	expectedHashValue := "8dee155db58cff5d"
+
+	// check hash is as expected
+	testHashValue := GenerateKey(projectPath, builderID)
+
+	require.Equal(t, testHashValue, expectedHashValue)
+}
+
+func TestHashWithHashFileExists(t *testing.T) {
+	for _, fsType := range filesystem.FileSystemTypes {
+		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
+			t.Parallel()
+			fs := filesystem.NewFs(fsType)
+
+			// set up temp remote directory
+			tmpRemoteDir, err := fs.TempDirInTempDir("test-hashFile")
+			require.NoError(t, err)
+			defer func() { _ = fs.Rm(tmpRemoteDir) }()
+
+			testFile := filepath.Join(tmpRemoteDir, "test")
+
+			// Add test file containing fake hash
+			hashFilePath := fmt.Sprintf("%v%v", testFile, hashFileDescriptor)
+			err = fs.WriteFile(hashFilePath, []byte("testtesttesttest"), 0755) // 16 chars long
+			require.NoError(t, err)
+
+			// check that it uses the hash in the hash file
+			hash, err := getHash(context.TODO(), fs, testFile, false)
+			require.NoError(t, err)
+			require.Equal(t, "testtesttesttest", hash)
+
+		})
+	}
+}
+
+func TestHashWithHashFileNotExist(t *testing.T) {
+	for _, fsType := range filesystem.FileSystemTypes {
+		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
+			t.Parallel()
+			fs := filesystem.NewFs(fsType)
+
+			// set up temp remote directory
+			tmpRemoteDir, err := fs.TempDirInTempDir("test-hashFile")
+			require.NoError(t, err)
+			defer func() { _ = fs.Rm(tmpRemoteDir) }()
+
+			// paths for test file and eventual hash file
+			testFile := filepath.Join(tmpRemoteDir, "test")
+			hashFilePath := fmt.Sprintf("%v%v", testFile, hashFileDescriptor)
+			err = fs.Rm(hashFilePath)
+			require.NoError(t, err)
+
+			// Add test file
+			err = fs.WriteFile(testFile, []byte("test"), 0755)
+			require.NoError(t, err)
+
+			// check has is as expected
+			hash, err := getHash(context.TODO(), fs, testFile, false)
+			require.NoError(t, err)
+			require.Equal(t, "4fdcca5ddb678139", hash) // hash for file = "test" containing "test"
+
+		})
+	}
+}
+
+func TestHashWithHashFileForceUpdate(t *testing.T) {
+	for _, fsType := range filesystem.FileSystemTypes {
+		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
+			t.Parallel()
+			fs := filesystem.NewFs(fsType)
+
+			// set up temp remote directory
+			tmpRemoteDir, err := fs.TempDirInTempDir("test-hashFile")
+			require.NoError(t, err)
+			defer func() { _ = fs.Rm(tmpRemoteDir) }()
+
+			testFile := filepath.Join(tmpRemoteDir, "test")
+
+			// Add test file containing fake hash
+			err = fs.WriteFile(testFile, []byte("test"), 0755) // 16 chars long
+			require.NoError(t, err)
+
+			// check that it uses correct hash not the fake hash
+			hash, err := getHash(context.TODO(), fs, testFile, true)
+			require.NoError(t, err)
+			require.Equal(t, "4fdcca5ddb678139", hash) // hash for file = "test" containing "test"
+		})
+	}
+}
+
+func testTransfert(t *testing.T, ctx context.Context, fs filesystem.FS, folder1, dest1, dest2 string) {
+	testFile := filepath.Join(folder1, "test-tranfer1")
+
+	testContent := "test"
+	// create file
+	err := fs.WriteFile(testFile, []byte(testContent), 0755) // 16 chars long
+	require.NoError(t, err)
+
+	destFile, err := TransferFiles(ctx, fs, dest2, testFile)
+	require.NoError(t, err)
+	err = fs.Rm(testFile)
+	require.NoError(t, err)
+
+	testFile, err = TransferFiles(ctx, fs, dest1, destFile)
+	require.NoError(t, err)
+	content, err := fs.ReadFile(testFile)
+	require.NoError(t, err)
+
+	assert.Equal(t, testContent, string(content))
+}
+
+func TestTransferWithExistingDestination(t *testing.T) {
+	for _, fsType := range filesystem.FileSystemTypes {
+		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fs := filesystem.NewFs(fsType)
+
+			folder1, err := fs.TempDirInTempDir("test-tranfer1")
+			require.NoError(t, err)
+			defer func() { _ = fs.Rm(folder1) }()
+			folder2, err := fs.TempDirInTempDir("test-tranfer2")
+			require.NoError(t, err)
+			defer func() { _ = fs.Rm(folder2) }()
+
+			testTransfert(t, ctx, fs, folder1, folder1, folder2)
+		})
+	}
+}
+
+func TestTransferWithDestinationFiles(t *testing.T) {
+	for _, fsType := range filesystem.FileSystemTypes {
+		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
+			ctx := context.Background()
+			fs := filesystem.NewFs(fsType)
+
+			folder1, err := fs.TempDirInTempDir("test-tranfer1")
+			require.NoError(t, err)
+			defer func() { _ = fs.Rm(folder1) }()
+			folder2, err := fs.TempDirInTempDir("test-tranfer2")
+			require.NoError(t, err)
+			defer func() { _ = fs.Rm(folder2) }()
+			dest1 := filepath.Join(folder1, "test_dest_tranfer1.txt")
+			dest2 := filepath.Join(folder2, "test_dest_tranfer2.txt")
+
+			testTransfert(t, ctx, fs, folder1, dest1, dest2)
+		})
+	}
+}
+
+func TestTransferWithNonExistentDestinationFolders(t *testing.T) {
+	for _, fsType := range filesystem.FileSystemTypes {
+		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
+			ctx := context.Background()
+			fs := filesystem.NewFs(fsType)
+
+			folder1, err := fs.TempDirInTempDir("test-tranfer1")
+			require.NoError(t, err)
+			defer func() { _ = fs.Rm(folder1) }()
+			folder2, err := fs.TempDirInTempDir("test-tranfer2")
+			require.NoError(t, err)
+			defer func() { _ = fs.Rm(folder2) }()
+			dest1 := filepath.Join(folder1, "test_dest_tranfer1_dir/")
+			dest2 := filepath.Join(folder2, "test_dest_tranfer2_dir/")
+
+			testTransfert(t, ctx, fs, folder1, dest1, dest2)
+		})
+	}
+}

--- a/utils/sharedcache/config.go
+++ b/utils/sharedcache/config.go
@@ -1,0 +1,32 @@
+package sharedcache
+
+import (
+	"time"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+
+	configUtils "github.com/ARM-software/golang-utils/utils/config"
+)
+
+type Configuration struct {
+	RemoteStoragePath       string        `mapstructure:"remote_storage_path"` // Path where the cache will be stored.
+	Timeout                 time.Duration `mapstructure:"Timeout"`             // Cache timeout if need be
+	FilesystemItemsToIgnore string        `mapstructure:"ignore_fs_items"`     // List of files/folders to ignore (pattern list separated by commas)
+}
+
+func (cfg *Configuration) Validate() error {
+	// Validate Embedded Structs
+	err := configUtils.ValidateEmbedded(cfg)
+
+	if err != nil {
+		return err
+	}
+
+	return validation.ValidateStruct(cfg,
+		validation.Field(&cfg.RemoteStoragePath, validation.Required),
+	)
+}
+
+func DefaultSharedCacheConfiguration() *Configuration {
+	return &Configuration{}
+}

--- a/utils/sharedcache/config_test.go
+++ b/utils/sharedcache/config_test.go
@@ -1,0 +1,15 @@
+package sharedcache
+
+import (
+	"testing"
+
+	"github.com/bxcodec/faker/v3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultSharedCacheConfiguration(t *testing.T) {
+	cfg := DefaultSharedCacheConfiguration()
+	require.Error(t, cfg.Validate())
+	cfg.RemoteStoragePath = faker.URL()
+	require.NoError(t, cfg.Validate())
+}

--- a/utils/sharedcache/factory.go
+++ b/utils/sharedcache/factory.go
@@ -1,0 +1,27 @@
+package sharedcache
+
+import (
+	"fmt"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/filesystem"
+)
+
+const (
+	CacheMutable int = iota
+	CacheImmutable
+)
+
+var (
+	CacheTypes = []int{CacheMutable, CacheImmutable}
+)
+
+func NewCache(cacheType int, fs filesystem.FS, cfg *Configuration) (ISharedCacheRepository, error) {
+	switch cacheType {
+	case CacheMutable:
+		return NewSharedMutableCacheRepository(cfg, fs)
+	case CacheImmutable:
+		return NewSharedImmutableCacheRepository(cfg, fs)
+	}
+	return nil, fmt.Errorf("%w: unknown cache type [%v]", commonerrors.ErrNotFound, cacheType)
+}

--- a/utils/sharedcache/interface.go
+++ b/utils/sharedcache/interface.go
@@ -1,0 +1,32 @@
+package sharedcache
+
+import (
+	"context"
+	"time"
+)
+
+// Mocks are generated using `go generate ./...`
+// Add interfaces to the following command for a mock to be generated
+//go:generate mockgen -destination=../mocks/mock_$GOPACKAGE.go -package=mocks github.com/Arm-Debug/build-service-common/common/$GOPACKAGE ISharedCacheRepository
+
+// ISharedCacheRepository defines a cache stored on a remote location and shared by separate processes.
+type ISharedCacheRepository interface {
+	// GenerateKey generates a unique key based on key elements `elems`.
+	GenerateKey(elems ...string) string
+	// Fetch downloads and installs files from the cache[`key`] to `dest`.
+	Fetch(ctx context.Context, key, dest string) error
+	// Store uploads files from `src` to cache[`key`].
+	Store(ctx context.Context, key, src string) error
+	// CleanEntry cleans up cache[`key`]. The key is still present in the cache.
+	CleanEntry(ctx context.Context, key string) error
+	//RemoveEntry removes cache[`key`] entry. The key is then no longer present in the cache.
+	RemoveEntry(ctx context.Context, key string) error
+	// GetEntryAge returns the age of the cache[`key`] entry
+	GetEntryAge(ctx context.Context, key string) (age time.Duration, err error)
+	// SetEntryAge sets the age of the cache[`key`] entry. Mostly for testing.
+	SetEntryAge(ctx context.Context, key string, age time.Duration) error
+	// GetEntries returns all cache entries.
+	GetEntries(ctx context.Context) (entries []string, err error)
+	// EntriesCount returns cache entries count
+	EntriesCount(ctx context.Context) (int64, error)
+}

--- a/utils/sharedcache/sharedcache_immutable.go
+++ b/utils/sharedcache/sharedcache_immutable.go
@@ -1,0 +1,232 @@
+package sharedcache
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/filesystem"
+	"github.com/ARM-software/golang-utils/utils/idgen"
+	"github.com/ARM-software/golang-utils/utils/parallelisation"
+)
+
+const (
+	partFileDescriptor     = ".part"
+	defaultCachedPackageID = "cb93fdbe-6c2e-4f7d-96ac-c422fc52618e "
+)
+
+type SharedImmutableCacheRepository struct {
+	AbstractSharedCacheRepository
+}
+
+type FileWithModTime struct {
+	filename string
+	modTime  time.Time
+}
+
+func NewSharedImmutableCacheRepository(cfg *Configuration, fs filesystem.FS) (repository *SharedImmutableCacheRepository, err error) {
+	abstractCache, err := NewAbstractSharedCacheRepository(cfg, fs)
+	if err != nil {
+		return
+	}
+	repository = &SharedImmutableCacheRepository{
+		AbstractSharedCacheRepository: *abstractCache,
+	}
+	return
+}
+
+func listCompleteFilesByModTime(ctx context.Context, fs filesystem.FS, entryDir string) (sorted []string, err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+
+	// sort the files by mod time
+	var fileModTimes []FileWithModTime
+	files, err := fs.Ls(entryDir)
+	if err != nil {
+		return
+	}
+
+	// Create array of non .part and non .hash files with their modtimes
+	for _, file := range files {
+		err = parallelisation.DetermineContextError(ctx)
+		if err != nil {
+			return sorted, err
+		}
+		isPartFile := strings.EqualFold(filepath.Ext(file), partFileDescriptor)
+		isHashFile := strings.EqualFold(filepath.Ext(file), hashFileDescriptor)
+		if !isPartFile && !isHashFile {
+			fullPath := filepath.Join(entryDir, file)
+			statInfo, err := fs.StatTimes(fullPath)
+			if err != nil {
+				return sorted, err
+			}
+			fileModTime := statInfo.ModTime()
+			fileModTimes = append(fileModTimes, FileWithModTime{
+				filename: file,
+				modTime:  fileModTime,
+			})
+		}
+	}
+	// can't do this directly using strings and stattimes to check on the
+	// file because the sort.Slice requires the function to output bool
+	// so if we wouldn't be abele to return an error if stattimes failed
+	sort.Slice(fileModTimes, func(i, j int) bool { return fileModTimes[i].modTime.After(fileModTimes[j].modTime) })
+
+	// map to just string
+	for _, file := range fileModTimes {
+		err = parallelisation.DetermineContextError(ctx)
+		if err != nil {
+			return sorted, err
+		}
+		sorted = append(sorted, file.filename)
+	}
+
+	return
+}
+
+func (s *SharedImmutableCacheRepository) Fetch(ctx context.Context, key, dest string) (err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+
+	// setup the lock
+	remoteDir := s.getCacheEntryPath(key)
+	remoteExists, err := s.fs.IsDir(remoteDir)
+	if err != nil {
+		return
+	}
+	if !remoteExists {
+		err = fmt.Errorf("no cache entry for key [%v]: %w", key, commonerrors.ErrNotFound)
+		return
+	}
+	err = s.setUpLocalDestination(ctx, dest)
+	if err != nil {
+		return err
+	}
+	// find the most recent cached package
+	cachedPackage, err := s.findCachedPackageFromEntryDir(ctx, key, remoteDir)
+	if err != nil {
+		return err
+	}
+	err = s.unpackPackageToLocalDestination(ctx, cachedPackage, dest)
+	return
+}
+
+func (s *SharedImmutableCacheRepository) Store(ctx context.Context, key, src string) (err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+
+	remoteDir, err := s.createEntry(ctx, key)
+	if err != nil {
+		return
+	}
+
+	// create temp location for files so we don't include zip inside itself
+	tempDir, err := s.fs.TempDirInTempDir(tempDirPrefix)
+	if err != nil {
+		return
+	}
+	defer func() { _ = s.fs.Rm(tempDir) }()
+
+	// zip the local cache
+	// generate zip
+	zipped := filepath.Join(tempDir, s.generateCachedPackageName())
+	err = s.fs.ZipWithContext(ctx, src, zipped)
+	if err != nil {
+		return
+	}
+
+	// do the transfer
+	destZip, err := TransferFiles(ctx, s.fs, remoteDir, zipped)
+	if err != nil {
+		_ = s.fs.Rm(destZip)
+		return
+	}
+
+	// remove .part from uploaded cache file
+	if strings.EqualFold(filepath.Ext(destZip), partFileDescriptor) {
+		finalZip := strings.ReplaceAll(destZip, partFileDescriptor, "")
+		err = s.fs.Move(destZip, finalZip)
+		// Don't forget the hash file
+		hashFile := filepath.Join(filepath.Dir(destZip), generateHashFileName(destZip))
+		if s.fs.Exists(hashFile) {
+			finalHash := strings.ReplaceAll(hashFile, partFileDescriptor, "")
+			_ = s.fs.Move(hashFile, finalHash)
+		}
+	}
+	return
+}
+
+func (s *SharedImmutableCacheRepository) generateCachedPackageName() string {
+	cacheUUID, err := idgen.GenerateUUID4()
+	if err != nil {
+		cacheUUID = defaultCachedPackageID
+	}
+	return fmt.Sprintf("%v-%v%v", cacheUUID, defaultCachedPackage, partFileDescriptor)
+}
+
+func (s *SharedImmutableCacheRepository) CleanEntry(ctx context.Context, key string) (err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+	entryDir := s.getCacheEntryPath(key)
+	// need to remove all files in cache except most recent
+	files, err := listCompleteFilesByModTime(ctx, s.fs, entryDir)
+	if err != nil {
+		return
+	}
+	if len(files) < 2 {
+		return
+	}
+	toClean := files[1:]
+	for _, file := range toClean {
+		err = parallelisation.DetermineContextError(ctx)
+		if err != nil {
+			return err
+		}
+		packageFile := filepath.Join(entryDir, file)
+		err = s.fs.Rm(packageFile)
+		if err != nil {
+			return err
+		}
+		// Don't forget the hash file
+		hashFile := filepath.Join(filepath.Dir(packageFile), generateHashFileName(packageFile))
+		if s.fs.Exists(hashFile) {
+			_ = s.fs.Rm(hashFile)
+		}
+	}
+	// clean cache ignore .part files as it might be run at the same time as an upload
+	return
+}
+
+func (s *SharedImmutableCacheRepository) findCachedPackageFromEntryDir(ctx context.Context, key, entryDir string) (cachedPackage string, err error) {
+	// find the most recent cached package
+	files, err := listCompleteFilesByModTime(ctx, s.fs, entryDir)
+	if err != nil {
+		return
+	}
+	if len(files) == 0 {
+		err = fmt.Errorf("no entry for key [%v] in cache: %w", key, commonerrors.ErrEmpty)
+		return
+	}
+	cachedPackage = filepath.Join(entryDir, files[0])
+	return
+}
+
+func (s *SharedImmutableCacheRepository) GetEntryAge(ctx context.Context, key string) (age time.Duration, err error) {
+	return s.getEntryAge(ctx, key, s.findCachedPackageFromEntryDir)
+}
+
+func (s *SharedImmutableCacheRepository) SetEntryAge(ctx context.Context, key string, age time.Duration) error {
+	return s.setEntryAge(ctx, key, age, s.findCachedPackageFromEntryDir)
+}

--- a/utils/sharedcache/sharedcache_immutable_test.go
+++ b/utils/sharedcache/sharedcache_immutable_test.go
@@ -1,0 +1,187 @@
+package sharedcache
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bxcodec/faker/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ARM-software/golang-utils/utils/filesystem"
+)
+
+// listCompleteFilesByModTime returns a slice of filenames in a directory sorted by modification time
+func TestListCompleteFilesByModTime(t *testing.T) {
+	for _, fsType := range filesystem.FileSystemTypes {
+		testName := fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType)
+		t.Run(testName, func(t *testing.T) {
+			fs := filesystem.NewFs(fsType)
+
+			// Set up temp remote directory
+			tmpRemoteDir, err := fs.TempDirInTempDir(fmt.Sprintf("test-%v-remote", testName))
+			require.NoError(t, err)
+			defer func() { _ = fs.Rm(tmpRemoteDir) }()
+
+			// Create file1
+			file1 := fmt.Sprintf("%v-1.zip", faker.Word())
+			path1 := filepath.Join(tmpRemoteDir, file1)
+			err = fs.WriteFile(path1, []byte("thing"), 0755)
+			require.NoError(t, err)
+			time.Sleep(50 * time.Millisecond)
+
+			// Create file2
+			file2 := fmt.Sprintf("%v-2.zip", faker.Word())
+			path2 := filepath.Join(tmpRemoteDir, file2)
+			err = fs.WriteFile(path2, []byte("stuff"), 0755)
+			require.NoError(t, err)
+			time.Sleep(50 * time.Millisecond)
+
+			// run listCompleteFilesByModTime
+			sorted, err := listCompleteFilesByModTime(context.TODO(), fs, tmpRemoteDir)
+			require.NoError(t, err)
+
+			// Assert that file2 was written after file1
+			assert.Equal(t, file2, sorted[0])
+			assert.Equal(t, file1, sorted[1])
+
+			// Update file1
+			err = fs.WriteFile(path1, []byte("something"), 0755)
+			require.NoError(t, err)
+			time.Sleep(50 * time.Millisecond)
+
+			// run listCompleteFilesByModTime again
+			sorted, err = listCompleteFilesByModTime(context.TODO(), fs, tmpRemoteDir)
+			require.NoError(t, err)
+
+			// Assert that now file1 was written after file2
+			assert.Equal(t, file1, sorted[0])
+			assert.Equal(t, file2, sorted[1])
+
+		})
+	}
+}
+
+func TestStoreImmutableCache(t *testing.T) {
+	for _, fsType := range filesystem.FileSystemTypes {
+		testName := fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType)
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fs := filesystem.NewFs(fsType)
+
+			// set up temp remote directory
+			tmpRemoteDir, err := fs.TempDirInTempDir(fmt.Sprintf("test-%v-remote", testName))
+			require.NoError(t, err)
+			defer func() { _ = fs.Rm(tmpRemoteDir) }()
+
+			tmpSrcDir, err := fs.TempDirInTempDir(fmt.Sprintf("test-%v-local", testName))
+			require.NoError(t, err)
+			defer func() { _ = fs.Rm(tmpSrcDir) }()
+
+			_, err = createTestFileTree(fs, tmpSrcDir, time.Now(), time.Now())
+			require.NoError(t, err)
+
+			remoteCache, err := NewSharedImmutableCacheRepository(&Configuration{
+				RemoteStoragePath: tmpRemoteDir,
+			}, fs)
+			require.NoError(t, err)
+			count, err := remoteCache.EntriesCount(context.TODO())
+			require.NoError(t, err)
+			assert.Zero(t, count)
+
+			key := remoteCache.GenerateKey("test", "cache")
+			for i := 0; i < 5; i++ {
+				// store src
+				err = remoteCache.Store(ctx, key, tmpSrcDir)
+				require.NoError(t, err)
+				// sleep so files have different mod times
+				time.Sleep(50 * time.Millisecond)
+			}
+
+			// check remote directory isn't empty
+			count, err = remoteCache.EntriesCount(context.TODO())
+			require.NoError(t, err)
+			assert.Equal(t, int64(1), count)
+
+			entryPath := remoteCache.getCacheEntryPath(key)
+			files, err := fs.Ls(entryPath)
+			require.NoError(t, err)
+			require.NotEmpty(t, files)
+			assert.Len(t, files, 5+5) // 5 zip files + 5 hash files
+		})
+	}
+}
+
+func TestCleanEntryImmutableCache(t *testing.T) {
+	for _, fsType := range filesystem.FileSystemTypes {
+		testName := fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType)
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fs := filesystem.NewFs(fsType)
+
+			// set up temp remote directory
+			tmpRemoteDir, err := fs.TempDirInTempDir(fmt.Sprintf("test-%v-remote", testName))
+			require.NoError(t, err)
+			defer func() { _ = fs.Rm(tmpRemoteDir) }()
+
+			tmpSrcDir, err := fs.TempDirInTempDir(fmt.Sprintf("test-%v-local", testName))
+			require.NoError(t, err)
+			defer func() { _ = fs.Rm(tmpSrcDir) }()
+
+			_, err = createTestFileTree(fs, tmpSrcDir, time.Now(), time.Now())
+			require.NoError(t, err)
+
+			remoteCache, err := NewSharedImmutableCacheRepository(&Configuration{
+				RemoteStoragePath: tmpRemoteDir,
+			}, fs)
+			require.NoError(t, err)
+			count, err := remoteCache.EntriesCount(context.TODO())
+			require.NoError(t, err)
+			assert.Zero(t, count)
+
+			key := remoteCache.GenerateKey("test", "cache")
+			for i := 0; i < 5; i++ {
+				// store src
+				err = remoteCache.Store(ctx, key, tmpSrcDir)
+				require.NoError(t, err)
+				// sleep so files have different mod times
+				time.Sleep(50 * time.Millisecond)
+			}
+
+			// create a fake part file
+			entryPath := remoteCache.getCacheEntryPath(key)
+			partFileName := remoteCache.generateCachedPackageName()
+			file, err := fs.CreateFile(filepath.Join(entryPath, partFileName))
+			require.NoError(t, err)
+			_ = file.Close()
+
+			// check remote directory isn't empty
+			count, err = remoteCache.EntriesCount(context.TODO())
+			require.NoError(t, err)
+			assert.Equal(t, int64(1), count)
+			files, err := fs.Ls(entryPath)
+			require.NoError(t, err)
+			require.NotEmpty(t, files)
+			assert.Len(t, files, 5+5+1) // 5 zip files + 5 hash files + 1 part file
+
+			err = remoteCache.CleanEntry(ctx, key)
+			require.NoError(t, err)
+
+			// check remote directory isn't empty
+			count, err = remoteCache.EntriesCount(context.TODO())
+			require.NoError(t, err)
+			assert.Equal(t, int64(1), count)
+			entryPath = remoteCache.getCacheEntryPath(key)
+			files, err = fs.Ls(entryPath)
+			require.NoError(t, err)
+			require.NotEmpty(t, files)
+			assert.Len(t, files, 2+1) // 1 zip file + 1 hash file + 1 part file
+			assert.Contains(t, files, partFileName)
+		})
+	}
+}

--- a/utils/sharedcache/sharedcache_mutable.go
+++ b/utils/sharedcache/sharedcache_mutable.go
@@ -1,0 +1,156 @@
+package sharedcache
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/filesystem"
+	"github.com/ARM-software/golang-utils/utils/parallelisation"
+	"github.com/ARM-software/golang-utils/utils/reflection"
+)
+
+const (
+	lockPrefix    = "SharedMutableCache"
+	tempDirPrefix = "sharedmutablecache-packing"
+)
+
+// SharedMutableCacheRepository defines a shared cache using a distributed lock system solely based on lock files.
+type SharedMutableCacheRepository struct {
+	AbstractSharedCacheRepository
+	lockTimeout time.Duration
+}
+
+func NewSharedMutableCacheRepository(cfg *Configuration, fs filesystem.FS) (repository ISharedCacheRepository, err error) {
+	abstractCache, err := NewAbstractSharedCacheRepository(cfg, fs)
+	if err != nil {
+		return
+	}
+	if reflection.IsEmpty(cfg.Timeout) {
+		err = fmt.Errorf("%w: cache timeout cannot be unset", commonerrors.ErrUndefined)
+	}
+	repository = &SharedMutableCacheRepository{
+		AbstractSharedCacheRepository: *abstractCache,
+		lockTimeout:                   cfg.Timeout,
+	}
+	return
+}
+
+func (s *SharedMutableCacheRepository) Fetch(ctx context.Context, key, dest string) (err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+
+	// setup the lock
+	remoteDir := s.getCacheEntryPath(key)
+	remoteExists, err := s.fs.IsDir(remoteDir)
+	if err != nil {
+		return
+	}
+	if !remoteExists {
+		return fmt.Errorf("no cache entry for key [%v]: %w", key, commonerrors.ErrNotFound)
+	}
+
+	cachedPackage, err := s.findCachedPackageFromEntryDir(ctx, key, remoteDir)
+	if err != nil {
+		return
+	}
+	err = s.setUpLocalDestination(ctx, dest)
+	if err != nil {
+		return
+	}
+
+	remoteLock := s.generateEntryLock(key)
+	defer func() { _ = remoteLock.Unlock(ctx) }()
+
+	// do the transfer
+	err = remoteLock.LockWithTimeout(ctx, s.lockTimeout)
+	if err != nil {
+		return
+	}
+	err = s.unpackPackageToLocalDestination(ctx, cachedPackage, dest)
+	if err != nil {
+		return
+	}
+	err = remoteLock.Unlock(ctx)
+	return
+}
+
+func (s *SharedMutableCacheRepository) Store(ctx context.Context, key, src string) (err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+
+	remoteDir, err := s.createEntry(ctx, key)
+	if err != nil {
+		return
+	}
+
+	// create temp location for files so we don't include zip inside itself
+	tempDir, err := s.fs.TempDirInTempDir(tempDirPrefix)
+	if err != nil {
+		return
+	}
+	defer func() { _ = s.fs.Rm(tempDir) }()
+
+	// zip the local cache
+	zipped := filepath.Join(tempDir, defaultCachedPackage)
+	err = s.fs.ZipWithContext(ctx, src, zipped)
+	if err != nil {
+		return
+	}
+
+	remoteLock := s.generateEntryLock(key)
+	defer func() { _ = remoteLock.Unlock(ctx) }()
+
+	// Do the transfer
+	err = remoteLock.LockWithTimeout(ctx, s.lockTimeout)
+	if err != nil {
+		return
+	}
+	destZip, err := TransferFiles(ctx, s.fs, remoteDir, zipped)
+	if err != nil {
+		_ = s.fs.Rm(destZip)
+		return
+	}
+	err = remoteLock.Unlock(ctx)
+	return
+}
+
+func (s *SharedMutableCacheRepository) CleanEntry(ctx context.Context, key string) error {
+	lock := s.generateEntryLock(key)
+	return lock.ReleaseIfStale(ctx)
+}
+
+func (s *SharedMutableCacheRepository) generateEntryLock(key string) filesystem.ILock {
+	lockID := fmt.Sprintf("%v-%v", lockPrefix, key)
+	return filesystem.NewRemoteLockFile(s.fs, lockID, s.getCacheEntryPath(key))
+}
+
+func (s *SharedMutableCacheRepository) findCachedPackageFromEntryDir(ctx context.Context, key, entryDir string) (cachedPackage string, err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+	cachedPackage = getCachedPackagePath(entryDir)
+	if !s.fs.Exists(cachedPackage) {
+		err = fmt.Errorf("no entry for key [%v] in cache: %w", key, commonerrors.ErrEmpty)
+	}
+	return
+}
+
+func (s *SharedMutableCacheRepository) GetEntryAge(ctx context.Context, key string) (time.Duration, error) {
+	return s.getEntryAge(ctx, key, s.findCachedPackageFromEntryDir)
+}
+
+func (s *SharedMutableCacheRepository) SetEntryAge(ctx context.Context, key string, age time.Duration) error {
+	return s.setEntryAge(ctx, key, age, s.findCachedPackageFromEntryDir)
+}
+
+func getCachedPackagePath(remoteDir string) string {
+	return filepath.Join(remoteDir, defaultCachedPackage)
+}

--- a/utils/sharedcache/sharedcache_test.go
+++ b/utils/sharedcache/sharedcache_test.go
@@ -1,0 +1,554 @@
+package sharedcache
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/filesystem"
+	"github.com/ARM-software/golang-utils/utils/idgen"
+)
+
+func createTestFileTree(fs filesystem.FS, testDir string, fileModTime time.Time, fileAccessTime time.Time) ([]string, error) {
+	// This can be fixed for testing.
+	rand.Seed(time.Now().UnixNano())
+	err := fs.MkDir(testDir)
+	if err != nil {
+		return nil, err
+	}
+	randI := rand.Intn(5) //nolint:gosec //causes G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec), So disable gosec
+	if randI == 0 {
+		randI = 1
+	}
+	for i := 0; i < randI; i++ {
+		c := fmt.Sprintf("test%v", i+1)
+		path := filepath.Join(testDir, c)
+
+		err = fs.MkDir(path)
+		if err != nil {
+			return nil, err
+		}
+		for j := 0; j < rand.Intn(5); j++ { //nolint:gosec //causes G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec), So disable gosec
+			uuid, err := idgen.GenerateUUID4()
+			if err != nil {
+				uuid = "uuid"
+			}
+			c := fmt.Sprintf("test-%v-%v", uuid, j+1)
+			path := filepath.Join(path, c)
+
+			err = fs.MkDir(path)
+			if err != nil {
+				return nil, err
+			}
+			for k := 0; k < rand.Intn(5); k++ { //nolint:gosec //causes G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec), So disable gosec
+				uuid, err = idgen.GenerateUUID4()
+				if err != nil {
+					uuid = "uuid"
+				}
+				c := fmt.Sprintf("test-%v-%v%v", uuid, k+1, ".txt")
+				finalPath := filepath.Join(path, c)
+
+				s := fmt.Sprintf("file-%v-%v%v%v ", uuid, i+1, j+1, k+1)
+				err = fs.WriteFile(finalPath, []byte(s), 0755)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	var tree []string
+	err = fs.ListDirTree(testDir, &tree)
+	if err != nil {
+		return nil, err
+	}
+
+	// unifying timestamps
+	for _, path := range tree {
+		err = fs.Chtimes(path, fileAccessTime, fileModTime)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return tree, nil
+}
+
+func TestNothingInCacheWorkflow(t *testing.T) { // Single fetch with no file previously cached
+	for _, cacheType := range CacheTypes {
+		for _, fsType := range filesystem.FileSystemTypes {
+			testName := fmt.Sprintf("%v_for_fs_%v_and_cache_%v", t.Name(), fsType, cacheType)
+			t.Run(testName, func(t *testing.T) {
+				t.Parallel()
+				ctx := context.Background()
+				fs := filesystem.NewFs(fsType)
+				// set up temp remote directory
+				tmpRemoteDir, err := fs.TempDirInTempDir(fmt.Sprintf("test-%v-remote", testName))
+				require.NoError(t, err)
+				defer func() { _ = fs.Rm(tmpRemoteDir) }()
+
+				tmpDestDir, err := fs.TempDirInTempDir(fmt.Sprintf("test-%v-local", testName))
+				require.NoError(t, err)
+				defer func() { _ = fs.Rm(tmpDestDir) }()
+
+				remoteCache, err := NewCache(cacheType, fs, &Configuration{
+					RemoteStoragePath: tmpRemoteDir,
+					Timeout:           time.Second,
+				})
+				require.NoError(t, err)
+				count, err := remoteCache.EntriesCount(context.TODO())
+				require.NoError(t, err)
+				assert.Zero(t, count)
+
+				key := remoteCache.GenerateKey("test", "cache", strconv.Itoa(cacheType))
+
+				err = remoteCache.Fetch(ctx, key, tmpDestDir)
+				require.NotNil(t, err)
+				assert.True(t, commonerrors.Any(err, commonerrors.ErrNotFound, commonerrors.ErrEmpty))
+			})
+		}
+	}
+}
+
+func TestSimpleCacheWorkflow(t *testing.T) { // Simple store, followed by fetch
+	for _, cacheType := range CacheTypes {
+		for _, fsType := range filesystem.FileSystemTypes {
+			if fsType == filesystem.InMemoryFS && cacheType == CacheMutable {
+				// FIXME There is an error with lock unlock when using in memory fs
+				continue
+			}
+			testName := fmt.Sprintf("%v_for_fs_%v_and_cache_%v", t.Name(), fsType, cacheType)
+			t.Run(testName, func(t *testing.T) {
+				t.Parallel()
+				ctx := context.Background()
+				fs := filesystem.NewFs(fsType)
+				// set up temp remote directory
+				tmpRemoteDir, err := fs.TempDirInTempDir(fmt.Sprintf("test-%v-remote", testName))
+				require.NoError(t, err)
+				defer func() { _ = fs.Rm(tmpRemoteDir) }()
+
+				tmpSrcDir, err := fs.TempDirInTempDir(fmt.Sprintf("test-%v-local", testName))
+				require.NoError(t, err)
+				defer func() { _ = fs.Rm(tmpSrcDir) }()
+
+				tmpDestDir, err := fs.TempDirInTempDir(fmt.Sprintf("test-%v-dest", testName))
+				require.NoError(t, err)
+				defer func() { _ = fs.Rm(tmpDestDir) }()
+				items, err := fs.Ls(tmpDestDir)
+				require.NoError(t, err)
+				require.Empty(t, items)
+
+				tree, err := createTestFileTree(fs, tmpSrcDir, time.Now(), time.Now())
+				require.NoError(t, err)
+				expectedTree, err := fs.ConvertToRelativePath(tmpSrcDir, tree...)
+				require.NoError(t, err)
+
+				remoteCache, err := NewCache(cacheType, fs, &Configuration{
+					RemoteStoragePath: tmpRemoteDir,
+					Timeout:           time.Second,
+				})
+				require.NoError(t, err)
+				count, err := remoteCache.EntriesCount(context.TODO())
+				require.NoError(t, err)
+				assert.Zero(t, count)
+
+				key := remoteCache.GenerateKey("test", "cache", strconv.Itoa(cacheType))
+				err = remoteCache.Store(ctx, key, tmpSrcDir)
+				require.NoError(t, err)
+
+				// check remote directory isn't empty
+				count, err = remoteCache.EntriesCount(context.TODO())
+				require.NoError(t, err)
+				assert.Equal(t, int64(1), count)
+
+				err = remoteCache.Fetch(ctx, key, tmpDestDir)
+				require.NoError(t, err)
+				items, err = fs.Ls(tmpDestDir)
+				require.NoError(t, err)
+				require.NotEmpty(t, items)
+				var content []string
+				err = fs.ListDirTree(tmpDestDir, &content)
+				require.NoError(t, err)
+				actualTree, err := fs.ConvertToRelativePath(tmpDestDir, content...)
+				require.NoError(t, err)
+
+				sort.Strings(expectedTree)
+				sort.Strings(actualTree)
+				require.Equal(t, expectedTree, actualTree)
+			})
+		}
+	}
+}
+
+func TestSimpleCacheWorkflow_WithExcludedFilesystemItems(t *testing.T) { // Simple store, followed by fetch
+	for _, cacheType := range CacheTypes {
+		for _, fsType := range filesystem.FileSystemTypes {
+			if fsType == filesystem.InMemoryFS && cacheType == CacheMutable {
+				// FIXME There is an error with lock unlock when using in memory fs
+				continue
+			}
+			testName := fmt.Sprintf("%v_for_fs_%v_and_cache_%v", t.Name(), fsType, cacheType)
+			t.Run(testName, func(t *testing.T) {
+				t.Parallel()
+				ctx := context.Background()
+				fs := filesystem.NewFs(fsType)
+				// set up temp remote directory
+				tmpRemoteDir, err := fs.TempDirInTempDir(fmt.Sprintf("test-%v-remote", testName))
+				require.NoError(t, err)
+				defer func() { _ = fs.Rm(tmpRemoteDir) }()
+
+				// Add random folders in the cache
+				_, err = fs.TempDir(tmpRemoteDir, ".snapshot-to-ignore")
+				require.NoError(t, err)
+				_, err = fs.TempDir(tmpRemoteDir, "ignore-folder.snapshot-to")
+				require.NoError(t, err)
+				_, err = fs.TempDir(tmpRemoteDir, ".exclude-folder")
+				require.NoError(t, err)
+				_, err = fs.TempDir(tmpRemoteDir, "another-folder-to-exclude")
+				require.NoError(t, err)
+				f, err := fs.TempFile(tmpRemoteDir, ".ignore-file.*.test")
+				require.NoError(t, err)
+				require.NoError(t, f.Close())
+				f, err = fs.TempFile(tmpRemoteDir, "another-file-to-exclude.*.test")
+				require.NoError(t, err)
+				require.NoError(t, f.Close())
+
+				tmpSrcDir, err := fs.TempDirInTempDir(fmt.Sprintf("test-%v-local", testName))
+				require.NoError(t, err)
+				defer func() { _ = fs.Rm(tmpSrcDir) }()
+
+				tmpDestDir, err := fs.TempDirInTempDir(fmt.Sprintf("test-%v-dest", testName))
+				require.NoError(t, err)
+				defer func() { _ = fs.Rm(tmpDestDir) }()
+				items, err := fs.Ls(tmpDestDir)
+				require.NoError(t, err)
+				require.Empty(t, items)
+
+				tree, err := createTestFileTree(fs, tmpSrcDir, time.Now(), time.Now())
+				require.NoError(t, err)
+				expectedTree, err := fs.ConvertToRelativePath(tmpSrcDir, tree...)
+				require.NoError(t, err)
+
+				remoteCache, err := NewCache(cacheType, fs, &Configuration{
+					RemoteStoragePath: tmpRemoteDir,
+					Timeout:           time.Second,
+				})
+				require.NoError(t, err)
+				count, err := remoteCache.EntriesCount(context.TODO())
+				require.NoError(t, err)
+				assert.Equal(t, int64(6), count)
+
+				remoteCache, err = NewCache(cacheType, fs, &Configuration{
+					RemoteStoragePath:       tmpRemoteDir,
+					Timeout:                 time.Second,
+					FilesystemItemsToIgnore: ".*exclude.*,.*ignore.*",
+				})
+				require.NoError(t, err)
+				count, err = remoteCache.EntriesCount(context.TODO())
+				require.NoError(t, err)
+				assert.Zero(t, count)
+
+				key := remoteCache.GenerateKey("test", "cache", strconv.Itoa(cacheType))
+				err = remoteCache.Store(ctx, key, tmpSrcDir)
+				require.NoError(t, err)
+
+				// check remote directory isn't empty
+				count, err = remoteCache.EntriesCount(context.TODO())
+				require.NoError(t, err)
+				assert.Equal(t, int64(1), count)
+
+				err = remoteCache.Fetch(ctx, key, tmpDestDir)
+				require.NoError(t, err)
+				items, err = fs.Ls(tmpDestDir)
+				require.NoError(t, err)
+				require.NotEmpty(t, items)
+				var content []string
+				err = fs.ListDirTree(tmpDestDir, &content)
+				require.NoError(t, err)
+				actualTree, err := fs.ConvertToRelativePath(tmpDestDir, content...)
+				require.NoError(t, err)
+
+				sort.Strings(expectedTree)
+				sort.Strings(actualTree)
+				require.Equal(t, expectedTree, actualTree)
+			})
+		}
+	}
+}
+
+func TestComplexCacheWorkflow(t *testing.T) { // Multiple Store action. The fetch should return the latest files stored in cache.
+	for _, cacheType := range CacheTypes {
+		for _, fsType := range filesystem.FileSystemTypes {
+			if fsType == filesystem.InMemoryFS && cacheType == CacheMutable {
+				// FIXME There is an error with locks and in-memory fs (see details in ILock)
+				continue
+			}
+			testName := fmt.Sprintf("%v_for_fs_%v_and_cache_%v", t.Name(), fsType, cacheType)
+			t.Run(testName, func(t *testing.T) {
+				t.Parallel()
+				ctx := context.Background()
+				fs := filesystem.NewFs(fsType)
+				// set up temp remote directory
+				tmpRemoteDir, err := fs.TempDirInTempDir(fmt.Sprintf("test-%v-remote", testName))
+				require.NoError(t, err)
+				defer func() { _ = fs.Rm(tmpRemoteDir) }()
+
+				tmpSrcDir, err := fs.TempDirInTempDir(fmt.Sprintf("test-%v-local", testName))
+				require.NoError(t, err)
+				defer func() { _ = fs.Rm(tmpSrcDir) }()
+
+				remoteCache, err := NewCache(cacheType, fs, &Configuration{
+					RemoteStoragePath: tmpRemoteDir,
+					Timeout:           time.Second,
+				})
+				require.NoError(t, err)
+				count, err := remoteCache.EntriesCount(context.TODO())
+				require.NoError(t, err)
+				assert.Zero(t, count)
+
+				var expectedTree []string
+				key := remoteCache.GenerateKey("test", "cache", strconv.Itoa(cacheType))
+
+				for i := 0; i < 10; i++ {
+					err = fs.CleanDir(tmpSrcDir)
+					require.NoError(t, err)
+					tree, err := createTestFileTree(fs, tmpSrcDir, time.Now(), time.Now())
+					require.NoError(t, err)
+					expectedTree, err = fs.ConvertToRelativePath(tmpSrcDir, tree...)
+					require.NoError(t, err)
+					err = remoteCache.Store(ctx, key, tmpSrcDir)
+					require.NoError(t, err)
+					time.Sleep(5 * time.Millisecond)
+				}
+
+				// check remote directory isn't empty
+				count, err = remoteCache.EntriesCount(context.TODO())
+				require.NoError(t, err)
+				assert.Equal(t, int64(1), count)
+
+				// Cleaning up src directory
+				err = fs.CleanDir(tmpSrcDir)
+				require.NoError(t, err)
+				items, err := fs.Ls(tmpSrcDir)
+				require.NoError(t, err)
+				require.Empty(t, items)
+
+				err = remoteCache.Fetch(ctx, key, tmpSrcDir)
+				require.NoError(t, err)
+				items, err = fs.Ls(tmpSrcDir)
+				require.NoError(t, err)
+				require.NotEmpty(t, items)
+				var content []string
+				err = fs.ListDirTree(tmpSrcDir, &content)
+				require.NoError(t, err)
+				actualTree, err := fs.ConvertToRelativePath(tmpSrcDir, content...)
+				require.NoError(t, err)
+
+				sort.Strings(expectedTree)
+				sort.Strings(actualTree)
+				require.Equal(t, expectedTree, actualTree)
+			})
+		}
+	}
+}
+
+func TestComplexCacheWorkflowWithCleanCache(t *testing.T) { // Multiple Store action. The fetch should return the latest files stored in cache. A clean entry is performed after the multiple stores
+	for _, cacheType := range CacheTypes {
+		for _, fsType := range filesystem.FileSystemTypes {
+			if fsType == filesystem.InMemoryFS {
+				// FIXME There is an error with locks and in-memory fs (see details in ILock)
+				continue
+			}
+			testName := fmt.Sprintf("%v_for_fs_%v_and_cache_%v", t.Name(), fsType, cacheType)
+			t.Run(testName, func(t *testing.T) {
+				t.Parallel()
+				ctx := context.Background()
+				fs := filesystem.NewFs(fsType)
+				// set up temp remote directory
+				tmpRemoteDir, err := fs.TempDirInTempDir(fmt.Sprintf("test-%v-remote", testName))
+				require.NoError(t, err)
+				defer func() { _ = fs.Rm(tmpRemoteDir) }()
+
+				tmpSrcDir, err := fs.TempDirInTempDir(fmt.Sprintf("test-%v-local", testName))
+				require.NoError(t, err)
+				defer func() { _ = fs.Rm(tmpSrcDir) }()
+
+				remoteCache, err := NewCache(cacheType, fs, &Configuration{
+					RemoteStoragePath: tmpRemoteDir,
+					Timeout:           time.Second,
+				})
+				require.NoError(t, err)
+				count, err := remoteCache.EntriesCount(context.TODO())
+				require.NoError(t, err)
+				assert.Zero(t, count)
+
+				var expectedTree []string
+				key := remoteCache.GenerateKey("test", "cache", strconv.Itoa(cacheType))
+
+				for i := 0; i < 10; i++ {
+					err = fs.CleanDir(tmpSrcDir)
+					require.NoError(t, err)
+					tree, err := createTestFileTree(fs, tmpSrcDir, time.Now(), time.Now())
+					require.NoError(t, err)
+					expectedTree, err = fs.ConvertToRelativePath(tmpSrcDir, tree...)
+					require.NoError(t, err)
+					err = remoteCache.Store(ctx, key, tmpSrcDir)
+					require.NoError(t, err)
+				}
+				err = remoteCache.CleanEntry(ctx, key)
+				require.NoError(t, err)
+
+				// check remote directory isn't empty
+				count, err = remoteCache.EntriesCount(context.TODO())
+				require.NoError(t, err)
+				assert.Equal(t, int64(1), count)
+
+				// Cleaning up src directory
+				err = fs.CleanDir(tmpSrcDir)
+				require.NoError(t, err)
+				items, err := fs.Ls(tmpSrcDir)
+				require.NoError(t, err)
+				require.Empty(t, items)
+
+				err = remoteCache.Fetch(ctx, key, tmpSrcDir)
+				require.NoError(t, err)
+				items, err = fs.Ls(tmpSrcDir)
+				require.NoError(t, err)
+				require.NotEmpty(t, items)
+				var content []string
+				err = fs.ListDirTree(tmpSrcDir, &content)
+				require.NoError(t, err)
+				actualTree, err := fs.ConvertToRelativePath(tmpSrcDir, content...)
+				require.NoError(t, err)
+
+				sort.Strings(expectedTree)
+				sort.Strings(actualTree)
+				require.Equal(t, expectedTree, actualTree)
+			})
+		}
+	}
+}
+
+func TestRemoveEntry(t *testing.T) { // A store followed by a remove entry followed by a fetch
+	for _, cacheType := range CacheTypes {
+		for _, fsType := range filesystem.FileSystemTypes {
+			testName := fmt.Sprintf("%v_for_fs_%v_and_cache_%v", t.Name(), fsType, cacheType)
+			t.Run(testName, func(t *testing.T) {
+				t.Parallel()
+				ctx := context.Background()
+				fs := filesystem.NewFs(fsType)
+				// set up temp remote directory
+				tmpRemoteDir, err := fs.TempDirInTempDir(fmt.Sprintf("test-%v-remote", testName))
+				require.NoError(t, err)
+				defer func() { _ = fs.Rm(tmpRemoteDir) }()
+
+				tmpSrcDir, err := fs.TempDirInTempDir(fmt.Sprintf("test-%v-local", testName))
+				require.NoError(t, err)
+				defer func() { _ = fs.Rm(tmpSrcDir) }()
+
+				remoteCache, err := NewCache(cacheType, fs, &Configuration{
+					RemoteStoragePath: tmpRemoteDir,
+					Timeout:           time.Second,
+				})
+				require.NoError(t, err)
+				count, err := remoteCache.EntriesCount(context.TODO())
+				require.NoError(t, err)
+				assert.Zero(t, count)
+
+				key := remoteCache.GenerateKey("test", "cache", strconv.Itoa(cacheType))
+
+				_, err = createTestFileTree(fs, tmpSrcDir, time.Now(), time.Now())
+				require.NoError(t, err)
+				err = remoteCache.Store(ctx, key, tmpSrcDir)
+				require.NoError(t, err)
+
+				// check remote directory isn't empty
+				count, err = remoteCache.EntriesCount(context.TODO())
+				require.NoError(t, err)
+				assert.Equal(t, int64(1), count)
+
+				// Cleaning up src directory
+				err = fs.CleanDir(tmpSrcDir)
+				require.NoError(t, err)
+				items, err := fs.Ls(tmpSrcDir)
+				require.NoError(t, err)
+				require.Empty(t, items)
+
+				err = remoteCache.RemoveEntry(ctx, key)
+				require.NoError(t, err)
+				count, err = remoteCache.EntriesCount(context.TODO())
+				require.NoError(t, err)
+				assert.Zero(t, count)
+
+				err = remoteCache.Fetch(ctx, key, tmpSrcDir)
+				require.NotNil(t, err)
+				assert.True(t, commonerrors.Any(err, commonerrors.ErrNotFound, commonerrors.ErrEmpty))
+			})
+		}
+	}
+}
+
+func TestEntryAge(t *testing.T) { // A store followed by a remove entry followed by a fetch
+	for _, cacheType := range CacheTypes {
+		for _, fsType := range filesystem.FileSystemTypes {
+			testName := fmt.Sprintf("%v_for_fs_%v_and_cache_%v", t.Name(), fsType, cacheType)
+			t.Run(testName, func(t *testing.T) {
+				t.Parallel()
+				ctx := context.Background()
+				fs := filesystem.NewFs(fsType)
+				// set up temp remote directory
+				tmpRemoteDir, err := fs.TempDirInTempDir(fmt.Sprintf("test-%v-remote", testName))
+				require.NoError(t, err)
+				defer func() { _ = fs.Rm(tmpRemoteDir) }()
+
+				tmpSrcDir, err := fs.TempDirInTempDir(fmt.Sprintf("test-%v-local", testName))
+				require.NoError(t, err)
+				defer func() { _ = fs.Rm(tmpSrcDir) }()
+
+				remoteCache, err := NewCache(cacheType, fs, &Configuration{
+					RemoteStoragePath: tmpRemoteDir,
+					Timeout:           time.Second,
+				})
+				require.NoError(t, err)
+				count, err := remoteCache.EntriesCount(context.TODO())
+				require.NoError(t, err)
+				assert.Zero(t, count)
+
+				key := remoteCache.GenerateKey("test", "cache", strconv.Itoa(cacheType))
+
+				_, err = createTestFileTree(fs, tmpSrcDir, time.Now(), time.Now())
+				require.NoError(t, err)
+				err = remoteCache.Store(ctx, key, tmpSrcDir)
+				require.NoError(t, err)
+
+				// check remote directory isn't empty
+				count, err = remoteCache.EntriesCount(context.TODO())
+				require.NoError(t, err)
+				assert.Equal(t, int64(1), count)
+
+				// Check entry age
+				age, err := remoteCache.GetEntryAge(context.TODO(), key)
+				require.NoError(t, err)
+				assert.True(t, age < 5*time.Second)
+
+				testAge := time.Duration(rand.Intn(24)) * time.Hour //nolint:gosec //causes G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec), So disable gosec
+				err = remoteCache.SetEntryAge(context.TODO(), key, testAge)
+				require.NoError(t, err)
+				age, err = remoteCache.GetEntryAge(context.TODO(), key)
+				require.NoError(t, err)
+				assert.Equal(t, int64(testAge.Seconds()), int64(age.Seconds()))
+
+				err = remoteCache.RemoveEntry(ctx, key)
+				require.NoError(t, err)
+			})
+		}
+	}
+}


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

- Added a way to create and manage shared cache using solely the file system



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
