### PR TITLE
⭐  `[filesystem]` get file ownership

### DIFF
--- a/changes/202208131936.feature
+++ b/changes/202208131936.feature
@@ -1,0 +1,1 @@
+`[filesystem]` Add utility to retrieve file ownership information i.e. `UID` and `GID`

--- a/utils/filesystem/extendedosfs.go
+++ b/utils/filesystem/extendedosfs.go
@@ -8,18 +8,21 @@ import (
 	"os"
 
 	"github.com/spf13/afero"
+
+	"github.com/ARM-software/golang-utils/utils/platform"
 )
 
+// ExtendedOsFs extends afero.OsFs and is a Fs implementation that uses functions provided by the os package.
 type ExtendedOsFs struct {
 	afero.OsFs
 }
 
 func (c *ExtendedOsFs) ChownIfPossible(name string, uid int, gid int) error {
-	return os.Chown(name, uid, gid)
+	return platform.ConvertError(c.OsFs.Chown(name, uid, gid))
 }
 
 func (c *ExtendedOsFs) LinkIfPossible(oldname, newname string) (err error) {
-	return os.Link(oldname, newname)
+	return platform.ConvertError(os.Link(oldname, newname))
 }
 
 func NewExtendedOsFs() afero.Fs {

--- a/utils/filesystem/files_posix.go
+++ b/utils/filesystem/files_posix.go
@@ -1,0 +1,21 @@
+//go:build unix || (js && wasm)
+// +build unix js,wasm
+
+package filesystem
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+)
+
+func determineFileOwners(info os.FileInfo) (uid, gid int, err error) {
+	if raw, ok := info.Sys().(*syscall.Stat_t); ok {
+		gid = int(raw.Gid)
+		uid = int(raw.Uid)
+	} else {
+		err = commonerrors.ErrNotImplemented
+	}
+	return
+}

--- a/utils/filesystem/files_posix.go
+++ b/utils/filesystem/files_posix.go
@@ -4,6 +4,7 @@
 package filesystem
 
 import (
+	"fmt"
 	"os"
 	"syscall"
 
@@ -15,7 +16,7 @@ func determineFileOwners(info os.FileInfo) (uid, gid int, err error) {
 		gid = int(raw.Gid)
 		uid = int(raw.Uid)
 	} else {
-		err = commonerrors.ErrNotImplemented
+		err = fmt.Errorf("%w: file info [%v] is not of type Stat_t", commonerrors.ErrUnsupported, info.Sys())
 	}
 	return
 }

--- a/utils/filesystem/files_test.go
+++ b/utils/filesystem/files_test.go
@@ -211,18 +211,18 @@ func TestChown(t *testing.T) {
 			err = file.Close()
 			require.NoError(t, err)
 			require.True(t, fs.Exists(filePath))
-			uid, gid, err := fs.FetchOwners(filePath)
+			uID, gID, err := fs.FetchOwners(filePath)
 			if err != nil {
 				assert.True(t, commonerrors.Any(err, commonerrors.ErrNotImplemented, commonerrors.ErrUnsupported))
 			} else {
-				err = fs.Chown(filePath, uid, gid)
+				err = fs.Chown(filePath, uID, gID)
 				if err != nil {
 					assert.True(t, commonerrors.Any(err, commonerrors.ErrNotImplemented, commonerrors.ErrUnsupported))
 				} else {
-					newUid, newGid, err := fs.FetchOwners(filePath)
+					newUID, newGID, err := fs.FetchOwners(filePath)
 					require.NoError(t, err)
-					assert.Equal(t, uid, newUid)
-					assert.Equal(t, gid, newGid)
+					assert.Equal(t, uID, newUID)
+					assert.Equal(t, gID, newGID)
 				}
 			}
 			_ = fs.Rm(tmpDir)

--- a/utils/filesystem/files_windows.go
+++ b/utils/filesystem/files_windows.go
@@ -1,0 +1,13 @@
+package filesystem
+
+import (
+	"os"
+	"syscall"
+)
+
+func determineFileOwners(os.FileInfo) (uid, gid int, err error) {
+	uid = syscall.Getuid()
+	gid = syscall.Getgid()
+
+	return
+}

--- a/utils/filesystem/filesystem.go
+++ b/utils/filesystem/filesystem.go
@@ -13,13 +13,15 @@ import (
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 )
 
+type FilesystemType int
+
 const (
-	StandardFS int = iota
+	StandardFS FilesystemType = iota
 	InMemoryFS
 )
 
 var (
-	FileSystemTypes = []int{StandardFS, InMemoryFS}
+	FileSystemTypes = []FilesystemType{StandardFS, InMemoryFS}
 )
 
 func NewInMemoryFileSystem() FS {
@@ -30,7 +32,7 @@ func NewStandardFileSystem() FS {
 	return NewVirtualFileSystem(NewExtendedOsFs(), StandardFS, IdentityPathConverterFunc)
 }
 
-func NewFs(fsType int) FS {
+func NewFs(fsType FilesystemType) FS {
 	switch fsType {
 	case StandardFS:
 		return NewStandardFileSystem()

--- a/utils/filesystem/interfaces.go
+++ b/utils/filesystem/interfaces.go
@@ -18,6 +18,7 @@ import (
 
 //go:generate mockgen -destination=../mocks/mock_$GOPACKAGE.go -package=mocks github.com/ARM-software/golang-utils/utils/$GOPACKAGE IFileHash,Chowner,Linker,File,DiskUsage,FileTimeInfo,ILock,ILimits,FS
 
+// IFileHash defines a file hash.
 // For reference.
 // https://stackoverflow.com/questions/1761607/what-is-the-fastest-hash-algorithm-to-check-if-two-files-are-equal
 type IFileHash interface {
@@ -26,13 +27,13 @@ type IFileHash interface {
 	GetType() string
 }
 
-// Optional interface. It is only implemented by the
+// Chowner is an Optional interface. It is only implemented by the
 // filesystems saying so.
 type Chowner interface {
 	ChownIfPossible(string, int, int) error
 }
 
-// Optional interface. It is only implemented by the
+// Linker is an Optional  interface. It is only implemented by the
 // filesystems saying so.
 type Linker interface {
 	LinkIfPossible(string, string) error
@@ -116,7 +117,7 @@ type FS interface {
 	// StatTimes returns file time information.
 	StatTimes(name string) (FileTimeInfo, error)
 	// GetType returns the type of the file system.
-	GetType() int
+	GetType() FilesystemType
 	// CleanDir removes all the files in a directory (equivalent rm -rf .../*)
 	CleanDir(dir string) (err error)
 	// CleanDirWithContext removes all the files in a directory (equivalent rm -rf .../*)
@@ -195,6 +196,8 @@ type FS interface {
 	Chtimes(name string, atime time.Time, mtime time.Time) error
 	// Chown changes the numeric uid and gid of the named file.
 	Chown(name string, uid, gid int) error
+	// FetchOwners returns the numeric uid and gid of the named file
+	FetchOwners(name string) (uid, gid int, err error)
 	// Link creates newname as a hard link to the oldname file
 	Link(oldname, newname string) error
 	// Readlink returns the destination of the named symbolic link.
@@ -227,7 +230,7 @@ type FS interface {
 	Zip(source string, destination string) error
 	// ZipWithContext compresses a file tree (source) into a zip file (destination)
 	ZipWithContext(ctx context.Context, source string, destination string) error
-	// ZipWithContextAndLimits(ctx context.Context, source string, destination string) error compresses a file tree (source) into a zip file (destination) .Nonetheless, if FileSystemLimits are exceeded, an error will be returned and the process will be stopped.
+	// ZipWithContextAndLimits compresses a file tree (source) into a zip file (destination) .Nonetheless, if FileSystemLimits are exceeded, an error will be returned and the process will be stopped.
 	// It is however the responsibility of the caller to clean any partially created zipped archive if error occurs.
 	ZipWithContextAndLimits(ctx context.Context, source string, destination string, limits ILimits) error
 	// Unzip decompresses a source zip archive into the destination

--- a/utils/filesystem/lockfile.go
+++ b/utils/filesystem/lockfile.go
@@ -223,16 +223,16 @@ func (l *RemoteLockFile) MakeStale(ctx context.Context) error {
 	parallelisation.SleepWithContext(ctx, l.lockHeartBeatPeriod+time.Millisecond)
 	lockPath := l.lockPath()
 	filePath := l.heartBeatFile(lockPath)
-	time := time.Now().Add(-1 * (l.lockHeartBeatPeriod + time.Millisecond))
+	newTime := time.Now().Add(-1 * (l.lockHeartBeatPeriod + time.Millisecond))
 	return retry.Do(
 		func() error {
 			if !l.fs.Exists(lockPath) {
 				return nil
 			}
 			if l.fs.Exists(filePath) {
-				_ = l.fs.Chtimes(filePath, time, time)
+				_ = l.fs.Chtimes(filePath, newTime, newTime)
 			} else {
-				_ = l.fs.Chtimes(lockPath, time, time)
+				_ = l.fs.Chtimes(lockPath, newTime, newTime)
 			}
 			if !l.IsStale() {
 				return fmt.Errorf("cannot make lock [%v] stale", l.id)

--- a/utils/mocks/mock_filesystem.go
+++ b/utils/mocks/mock_filesystem.go
@@ -1101,6 +1101,22 @@ func (mr *MockFSMockRecorder) Exists(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockFS)(nil).Exists), arg0)
 }
 
+// FetchOwners mocks base method.
+func (m *MockFS) FetchOwners(arg0 string) (int, int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchOwners", arg0)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// FetchOwners indicates an expected call of FetchOwners.
+func (mr *MockFSMockRecorder) FetchOwners(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchOwners", reflect.TypeOf((*MockFS)(nil).FetchOwners), arg0)
+}
+
 // FileHash mocks base method.
 func (m *MockFS) FileHash(arg0, arg1 string) (string, error) {
 	m.ctrl.T.Helper()
@@ -1195,10 +1211,10 @@ func (mr *MockFSMockRecorder) GetFileSize(arg0 interface{}) *gomock.Call {
 }
 
 // GetType mocks base method.
-func (m *MockFS) GetType() int {
+func (m *MockFS) GetType() filesystem.FilesystemType {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetType")
-	ret0, _ := ret[0].(int)
+	ret0, _ := ret[0].(filesystem.FilesystemType)
 	return ret0
 }
 

--- a/utils/platform/os.go
+++ b/utils/platform/os.go
@@ -5,21 +5,45 @@
 package platform
 
 import (
+	"errors"
 	"fmt"
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/shirou/gopsutil/v3/host"
 	"github.com/shirou/gopsutil/v3/mem"
 )
 
-// Checks whether we are running on Windows or not.
+var (
+	errNotSupportedByWindows = errors.New("not supported by windows")
+)
+
+// ConvertError converts a platform error into a commonerrors
+func ConvertError(err error) error {
+	switch {
+	case err == nil:
+		return err
+	case commonerrors.Any(err, commonerrors.ErrNotImplemented, commonerrors.ErrUnsupported):
+		return err
+	case IsWindows() && commonerrors.Any(err, errNotSupportedByWindows):
+		return fmt.Errorf("%w: %v", commonerrors.ErrUnsupported, err.Error())
+	case strings.Contains(err.Error(), "not supported"):
+		return fmt.Errorf("%w: %v", commonerrors.ErrUnsupported, err.Error())
+	default:
+		return err
+		// TODO extend with more platform specific errors
+	}
+}
+
+// IsWindows checks whether we are running on Windows or not.
 func IsWindows() bool {
 	return runtime.GOOS == "windows"
 }
 
-// Returns the line separator.
+// LineSeparator returns the line separator.
 func LineSeparator() string {
 	if IsWindows() {
 		return "\r\n"
@@ -27,17 +51,17 @@ func LineSeparator() string {
 	return UnixLineSeparator()
 }
 
-// Returns the line separator on Unix platform.
+// UnixLineSeparator returns the line separator on Unix platform.
 func UnixLineSeparator() string {
 	return "\n"
 }
 
-// Gets hostname.
+// Hostname returns the hostname.
 func Hostname() (string, error) {
 	return os.Hostname()
 }
 
-// Gets system uptime.
+// UpTime returns system uptime.
 func UpTime() (uptime time.Duration, err error) {
 	_uptime, err := host.Uptime()
 	if err != nil {
@@ -47,7 +71,7 @@ func UpTime() (uptime time.Duration, err error) {
 	return
 }
 
-// Gets system uptime.
+// BootTime returns system uptime.
 func BootTime() (bootime time.Time, err error) {
 	_bootime, err := host.BootTime()
 	if err != nil {
@@ -58,7 +82,7 @@ func BootTime() (bootime time.Time, err error) {
 
 }
 
-// Gets system node name (equivalent to uname -n).
+// NodeName returns the system node name (equivalent to uname -n).
 func NodeName() (nodename string, err error) {
 	info, err := host.Info()
 	if err != nil {
@@ -68,7 +92,7 @@ func NodeName() (nodename string, err error) {
 	return
 }
 
-// Gets platform information (equivalent to uname -s).
+// PlatformInformation returns the platform information (equivalent to uname -s).
 func PlatformInformation() (information string, err error) {
 	platform, family, version, err := host.PlatformInformation()
 	if err != nil {
@@ -78,7 +102,7 @@ func PlatformInformation() (information string, err error) {
 	return
 }
 
-// Gets system information (equivalent to uname -a)
+// SystemInformation returns the system information (equivalent to uname -a)
 func SystemInformation() (information string, err error) {
 	hostname, err := Hostname()
 	if err != nil {
@@ -109,15 +133,15 @@ func Uname() (string, error) {
 }
 
 type RAM interface {
-	// Gets total amount of RAM on this system
+	// GetTotal returns total amount of RAM on this system
 	GetTotal() uint64
-	// Gets RAM available for programs to allocate
+	// GetAvailable returns RAM available for programs to allocate
 	GetAvailable() uint64
-	// Gets RAM used by programs
+	// GetUsed returns RAM used by programs
 	GetUsed() uint64
-	// Gets Percentage of RAM used by programs
+	// GetUsedPercent returns Percentage of RAM used by programs
 	GetUsedPercent() float64
-	// Gets kernel's notion of free memory
+	// GetFree returns kernel's notion of free memory
 	GetFree() uint64
 }
 

--- a/utils/platform/os.go
+++ b/utils/platform/os.go
@@ -7,7 +7,6 @@ package platform
 import (
 	"errors"
 	"fmt"
-	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"os"
 	"runtime"
 	"strings"
@@ -15,6 +14,8 @@ import (
 
 	"github.com/shirou/gopsutil/v3/host"
 	"github.com/shirou/gopsutil/v3/mem"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
 )
 
 var (


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

`[filesystem]` get file ownership information.
This is to cover what is discussed here: https://github.com/golang/go/issues/14753



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
