### PR TITLE
🔓 `[git]` New test case for git bomb mitigation

### DIFF
--- a/changes/202209211609.bugfix
+++ b/changes/202209211609.bugfix
@@ -1,0 +1,1 @@
+[git] added new test cases to mitigate git bombing, with a large number of files

--- a/utils/git/git_clone_test.go
+++ b/utils/git/git_clone_test.go
@@ -41,6 +41,13 @@ func TestCloneGitBomb(t *testing.T) {
 			limits:                NewLimits(1e5, 1e6, 1e4, 4, 1e6), // max file size: 100KB, max repo size: 1MB, max file count: 100 thousand, max tree depth 10, max entries 1 million
 			maxEntriesChannelSize: 25000,
 		},
+		{
+			name: "git bomb large file count",
+			url: "https://github.com/way2autotesting/DVLA_AutoTest.git",
+			err: fmt.Errorf("%w: maximum file count exceeded", commonerrors.ErrTooLarge),
+			limits: NewLimits(1e6, 1e6, 10, 4, 1e6), // max file size: 100KB, max repo size: 1MB, max file count: 10, max tree depth 10, max entries 1 million
+			maxEntriesChannelSize: 25000,
+		},
 	}
 	fs := filesystem.NewFs(filesystem.StandardFS)
 	destPath, err := fs.TempDirInTempDir("git-bomb")

--- a/utils/git/git_clone_test.go
+++ b/utils/git/git_clone_test.go
@@ -42,10 +42,10 @@ func TestCloneGitBomb(t *testing.T) {
 			maxEntriesChannelSize: 25000,
 		},
 		{
-			name: "git bomb large file count",
-			url: "https://github.com/way2autotesting/DVLA_AutoTest.git",
-			err: fmt.Errorf("%w: maximum file count exceeded", commonerrors.ErrTooLarge),
-			limits: NewLimits(1e6, 1e6, 10, 4, 1e6), // max file size: 100KB, max repo size: 1MB, max file count: 10, max tree depth 10, max entries 1 million
+			name:                  "git bomb large file count",
+			url:                   "https://github.com/way2autotesting/DVLA_AutoTest.git",
+			err:                   fmt.Errorf("%w: maximum file count exceeded", commonerrors.ErrTooLarge),
+			limits:                NewLimits(1e6, 1e6, 10, 4, 1e6), // max file size: 100KB, max repo size: 1MB, max file count: 10, max tree depth 10, max entries 1 million
 			maxEntriesChannelSize: 25000,
 		},
 	}


### PR DESCRIPTION
Checking specific number of files in a repository