### PR TITLE
`git`: Add checks for true repository size, not just the virtual size

### DIFF
--- a/changes/202210031606.feature
+++ b/changes/202210031606.feature
@@ -1,0 +1,1 @@
+git: Add checks for true repository size, not just the virtual size

--- a/utils/git/git_clone_test.go
+++ b/utils/git/git_clone_test.go
@@ -19,33 +19,49 @@ func TestCloneGitBomb(t *testing.T) {
 		limits                ILimits
 		maxEntriesChannelSize int
 	}{
+		// /*
 		// See: https://kate.io/blog/git-bomb/
 		{
 			name:                  "git bomb small channel saturated",
 			url:                   "https://github.com/Katee/git-bomb.git",
 			err:                   fmt.Errorf("%w: entry channel saturated with tree entries", commonerrors.ErrTooLarge),
-			limits:                NewLimits(1e10, 1e10, 1e10, 10, 1e10),
+			limits:                NewLimits(1e10, 1e10, 1e10, 10, 1e10, 1e10),
 			maxEntriesChannelSize: 1000,
 		},
 		{
 			name:                  "git bomb large channel",
 			url:                   "https://github.com/Katee/git-bomb.git",
 			err:                   fmt.Errorf("%w: maximum file count exceeded", commonerrors.ErrTooLarge),
-			limits:                NewLimits(1e5, 1e6, 1e2, 10, 1e6), // max file size: 100KB, max repo size: 1MB, max file count: 1 hundred, max tree depth 10, max entries 1 million
+			limits:                NewLimits(1e5, 1e6, 1e2, 100, 1e6, 1e10), // max file size: 100KB, max repo size: 1MB, max file count: 1 hundred, max tree depth 10, max entries 1 million, max true size: 10gb
 			maxEntriesChannelSize: 25000,
 		},
 		{
 			name:                  "git bomb seg fault",
 			url:                   "https://github.com/Katee/git-bomb-segfault.git",
 			err:                   fmt.Errorf("%w: maximum tree depth exceeded", commonerrors.ErrTooLarge),
-			limits:                NewLimits(1e5, 1e6, 1e4, 4, 1e6), // max file size: 100KB, max repo size: 1MB, max file count: 100 thousand, max tree depth 10, max entries 1 million
+			limits:                NewLimits(1e5, 1e6, 1e4, 4, 1e6, 1e10), // max file size: 100KB, max repo size: 1MB, max file count: 100 thousand, max tree depth 10, max entries 1 million, max true size: 10gb
 			maxEntriesChannelSize: 25000,
 		},
 		{
 			name:                  "git bomb large file count",
 			url:                   "https://github.com/way2autotesting/DVLA_AutoTest.git",
 			err:                   fmt.Errorf("%w: maximum file count exceeded", commonerrors.ErrTooLarge),
-			limits:                NewLimits(1e6, 1e6, 10, 4, 1e6), // max file size: 100KB, max repo size: 1MB, max file count: 10, max tree depth 10, max entries 1 million
+			limits:                NewLimits(1e9, 1e9, 10, 4, 1e9, 1e10), // max file size: 100KB, max repo size: 1MB, max file count: 10, max tree depth 10, max entries 1 million, max true size: 10GB
+			maxEntriesChannelSize: 25000,
+		},
+		{
+			name:                  "git bomb max true size",
+			url:                   "https://github.com/way2autotesting/DVLA_AutoTest.git",
+			err:                   fmt.Errorf("%w: maximum true size exceeded", commonerrors.ErrTooLarge),
+			limits:                NewLimits(1e9, 1e9, 10, 4, 1e9, 100), // max file size: 100KB, max repo size: 1MB, max file count: 10, max tree depth 10, max entries 1 million, max true size: 100b
+			maxEntriesChannelSize: 25000,
+		},
+
+		{
+			name:                  "known repo that can meet limits",
+			url:                   "https://github.com/bulislaw/TrustZone-DevSummit22-Demo",
+			err:                   nil,
+			limits:                DefaultLimits(), // max file size: 100MB, max repo size: 10gb, max file count: 1 million, max tree depth 12, max entries 100 million, max true size: 1gb
 			maxEntriesChannelSize: 25000,
 		},
 	}
@@ -68,8 +84,13 @@ func TestCloneGitBomb(t *testing.T) {
 				URL: test.url,
 			}
 			err = CloneWithLimits(context.Background(), destPath, test.limits, &cloneOptions)
-			require.Error(t, err)
-			require.ErrorContains(t, err, test.err.Error())
+			if test.err != nil {
+				require.Error(t, err)
+				require.ErrorContains(t, err, test.err.Error())
+			} else {
+				require.NoError(t, err)
+				require.Nil(t, err)
+			}
 		})
 	}
 
@@ -84,7 +105,7 @@ func TestCloneNormalRepo(t *testing.T) {
 		{
 			name:   "with limits",
 			url:    "https://github.com/Arm-Examples/Blinky_MIMXRT1064-EVK_RTX",
-			limits: NewLimits(1e8, 1e10, 1e6, 20, 1e6), // max file size: 100MB, max repo size: 1GB, max file count: 1 million, max tree depth 1, max entries 1 million
+			limits: NewLimits(1e8, 1e10, 1e6, 20, 1e6, 1e10), // max file size: 100MB, max repo size: 1GB, max file count: 1 million, max tree depth 1, max entries 1 million
 		},
 		{
 			name:   "no limits",
@@ -134,27 +155,32 @@ func TestValidationNormalReposErrors(t *testing.T) {
 		{
 			name:   "too big file",
 			err:    fmt.Errorf("%w: maximum individual file size exceeded", commonerrors.ErrTooLarge),
-			limits: NewLimits(1, 1e10, 1e10, 1e10, 1e10),
+			limits: NewLimits(1, 1e10, 1e10, 1e10, 1e10, 1e10),
 		},
 		{
 			name:   "too big repo",
 			err:    fmt.Errorf("%w: maximum repository size exceeded", commonerrors.ErrTooLarge),
-			limits: NewLimits(1e10, 1, 1e10, 1e10, 1e10),
+			limits: NewLimits(1e10, 1, 1e10, 1e10, 1e10, 1e10),
 		},
 		{
 			name:   "too many files",
 			err:    fmt.Errorf("%w: maximum file count exceeded", commonerrors.ErrTooLarge),
-			limits: NewLimits(1e10, 1e10, 1, 1e10, 1e10),
+			limits: NewLimits(1e10, 1e10, 1, 1e10, 1e10, 1e10),
 		},
 		{
 			name:   "too deep tree",
 			err:    fmt.Errorf("%w: maximum tree depth exceeded", commonerrors.ErrTooLarge),
-			limits: NewLimits(1e10, 1e10, 1e10, 1, 1e10),
+			limits: NewLimits(1e10, 1e10, 1e10, 1, 1e10, 1e10),
 		},
 		{
 			name:   "too many entries",
 			err:    fmt.Errorf("%w: maximum entries count exceeded", commonerrors.ErrTooLarge),
-			limits: NewLimits(1e10, 1e10, 1e10, 1e10, 1000), // entries must be greater than MaxEntriesChannelSize
+			limits: NewLimits(1e10, 1e10, 1e10, 1e10, 1000, 1e10), // entries must be greater than MaxEntriesChannelSize
+		},
+		{
+			name:   "too large true size",
+			err:    fmt.Errorf("%w: maximum true size exceeded", commonerrors.ErrTooLarge),
+			limits: NewLimits(1e10, 1e10, 1e10, 1e10, 1e10, 1000), // entries must be greater than MaxEntriesChannelSize
 		},
 	}
 
@@ -228,7 +254,7 @@ func TestCloneNonExistentRepo(t *testing.T) {
 	destPath, err := fs.TempDirInTempDir("git-test")
 	require.NoError(t, err)
 	defer func() { _ = fs.Rm(destPath) }()
-	limits := NewLimits(1e8, 1e10, 1e6, 20, 1e6) // max file size: 100MB, max repo size: 1GB, max file count: 1 million, max tree depth 1, max entries 1 million
+	limits := NewLimits(1e8, 1e10, 1e6, 20, 1e6, 1e10) // max file size: 100MB, max repo size: 1GB, max file count: 1 million, max tree depth 1, max entries 1 million
 
 	empty, err := fs.IsEmpty(destPath)
 	require.NoError(t, err)
@@ -263,7 +289,7 @@ func TestClone(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, isEmpty)
 	defer func() { _ = fs.Rm(destPath) }()
-	limits := NewLimits(1e8, 1e10, 1e6, 20, 1e6) // max file size: 100MB, max repo size: 1GB, max file count: 1 million, max tree depth 1, max entries 1 million
+	limits := NewLimits(1e8, 1e10, 1e6, 20, 1e6, 1e10) // max file size: 100MB, max repo size: 1GB, max file count: 1 million, max tree depth 1, max entries 1 million
 	c := NewCloneObject()
 
 	// Cleanup and make sure cloning git bomb with no checkout doesn't crash

--- a/utils/git/interfaces.go
+++ b/utils/git/interfaces.go
@@ -22,6 +22,8 @@ type ILimits interface {
 	GetMaxTreeDepth() int64
 	// GetMaxEntries returns the maximum total entries allowed in the it repo
 	GetMaxEntries() int64
+	// GetMaxTrueSize returns the maximum true size of the repo based on blobs
+	GetMaxTrueSize() int64
 }
 
 type IGitActionConfig interface {

--- a/utils/git/limits.go
+++ b/utils/git/limits.go
@@ -33,6 +33,10 @@ func (n *noLimits) GetMaxEntries() int64 {
 	return 0
 }
 
+func (n *noLimits) GetMaxTrueSize() int64 {
+	return 0
+}
+
 func (n *noLimits) Validate() error {
 	return nil
 }
@@ -44,6 +48,7 @@ type Limits struct {
 	MaxFileCount int64 `mapstructure:"max_file_count"`
 	MaxTreeDepth int64 `mapstructure:"max_tree_depth"`
 	MaxEntries   int64 `mapstructure:"max_entries"`
+	MaxTrueSize  int64 `mapstructure:"max_true_size"`
 }
 
 func (l *Limits) Apply() bool {
@@ -65,8 +70,13 @@ func (l *Limits) GetMaxFileCount() int64 {
 func (l *Limits) GetMaxTreeDepth() int64 {
 	return l.MaxTreeDepth
 }
+
 func (l *Limits) GetMaxEntries() int64 {
 	return l.MaxEntries
+}
+
+func (l *Limits) GetMaxTrueSize() int64 {
+	return l.MaxTrueSize
 }
 
 func (l *Limits) Validate() error {
@@ -92,17 +102,18 @@ func NoLimits() ILimits {
 }
 
 // NewLimits defines file system FileSystemLimits.
-func NewLimits(maxFileSize, maxTotalSize, maxFileCount, maxTreeDepth, maxEntries int64) ILimits {
+func NewLimits(maxFileSize, maxTotalSize, maxFileCount, maxTreeDepth, maxEntries, maxTrueSize int64) ILimits {
 	return &Limits{
 		MaxFileSize:  maxFileSize,
 		MaxTotalSize: maxTotalSize,
 		MaxFileCount: maxFileCount,
 		MaxTreeDepth: maxTreeDepth,
 		MaxEntries:   maxEntries,
+		MaxTrueSize:  maxTrueSize,
 	}
 }
 
 // DefaultLimits defines default file system FileSystemLimits
 func DefaultLimits() ILimits {
-	return NewLimits(1e8, 1e9, 1e6, 12, 1e8) // 100MB, 1GB, 1 million, 12, 100 million
+	return NewLimits(1e8, 10e9, 1e6, 12, 1e8, 1e9) // 100MB, 10GB, 1 million, 12, 100 million 1GB
 }

--- a/utils/go.mod
+++ b/utils/go.mod
@@ -38,4 +38,8 @@ require (
 	golang.org/x/text v0.3.7
 )
 
-require golang.org/x/tools v0.1.7 // indirect
+require (
+	github.com/deckarep/golang-set v1.8.0
+	github.com/deckarep/golang-set/v2 v2.1.0
+	golang.org/x/tools v0.1.7 // indirect
+)

--- a/utils/go.sum
+++ b/utils/go.sum
@@ -121,6 +121,10 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set v1.8.0 h1:sk9/l/KqpunDwP7pSjUg0keiOOLEnOBHzykLrsPppp4=
+github.com/deckarep/golang-set v1.8.0/go.mod h1:5nI87KwE7wgsBU1F4GKAw2Qod7p5kyS383rP6+o6qqo=
+github.com/deckarep/golang-set/v2 v2.1.0 h1:g47V4Or+DUdzbs8FxCCmgb6VYd+ptPAngjM6dtGktsI=
+github.com/deckarep/golang-set/v2 v2.1.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
 github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Add checks for true repository size, not just the virtual size

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [X]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
