### PR TITLE
:star: `[filesystem]` Expand APIs to enable `negation patterns`

### DIFF
--- a/changes/202210040057.feature
+++ b/changes/202210040057.feature
@@ -1,0 +1,1 @@
+`[filesystem]` Expanded most recursive filesystem APIs so that exclusion patterns can be used to ignore some paths during the processing

--- a/utils/filesystem/exclusion.go
+++ b/utils/filesystem/exclusion.go
@@ -1,0 +1,70 @@
+package filesystem
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/reflection"
+)
+
+func ExcludeFiles(files []string, regexes []*regexp.Regexp) (cleansedList []string, err error) {
+	cleansedList = []string{}
+	for i := range files {
+		f := files[i]
+		if !IsPathExcluded(f, regexes...) {
+			cleansedList = append(cleansedList, f)
+		}
+	}
+	return
+}
+
+func NewExclusionRegexList(pathSeparator rune, exclusionPatterns ...string) ([]*regexp.Regexp, error) {
+	var regexes []*regexp.Regexp
+	var patternsExtendedList []string
+	for i := range exclusionPatterns {
+		pattern := exclusionPatterns[i]
+
+		if !reflection.IsEmpty(pattern) {
+			patternsExtendedList = append(patternsExtendedList, pattern, fmt.Sprintf(".*/%v/.*", pattern), fmt.Sprintf(".*%v%v%v.*", pathSeparator, pattern, pathSeparator))
+		}
+	}
+	for i := range patternsExtendedList {
+		r, err := regexp.Compile(patternsExtendedList[i])
+		if err != nil {
+			return nil, fmt.Errorf("%w: could not compile pattern [%v]: %v", commonerrors.ErrInvalid, patternsExtendedList[i], err.Error())
+		}
+		regexes = append(regexes, r)
+	}
+	return regexes, nil
+}
+
+func IsPathExcludedFromPatterns(path string, pathSeparator rune, exclusionPatterns ...string) bool {
+	regexes, err := NewExclusionRegexList(pathSeparator, exclusionPatterns...)
+	if err != nil {
+		return false
+	}
+	return IsPathExcluded(path, regexes...)
+}
+
+func IsPathExcluded(path string, exclusionPatterns ...*regexp.Regexp) bool {
+	for i := range exclusionPatterns {
+		if exclusionPatterns[i].MatchString(path) {
+			return true
+		}
+	}
+	return false
+}
+
+// ExcludeAll excludes files
+func ExcludeAll(files []string, exclusionPatterns ...string) ([]string, error) {
+	return globalFileSystem.ExcludeAll(files, exclusionPatterns...)
+}
+
+func (fs *VFS) ExcludeAll(files []string, exclusionPatterns ...string) ([]string, error) {
+	regexes, err := NewExclusionRegexList(fs.PathSeparator(), exclusionPatterns...)
+	if err != nil {
+		return nil, err
+	}
+	return ExcludeFiles(files, regexes)
+}

--- a/utils/filesystem/exclusion_test.go
+++ b/utils/filesystem/exclusion_test.go
@@ -240,7 +240,6 @@ func TestIsPathExcludedFromPatterns(t *testing.T) {
 	for i := range tests {
 		test := tests[i]
 		t.Run(fmt.Sprintf("exlusions [%v]", test.exclusionPatterns), func(t *testing.T) {
-			//t.Parallel()
 			if test.exclude {
 				assert.True(t, IsPathExcludedFromPatterns(test.path, test.pathSeparator, test.exclusionPatterns...))
 			} else {

--- a/utils/filesystem/exclusion_test.go
+++ b/utils/filesystem/exclusion_test.go
@@ -1,0 +1,252 @@
+package filesystem
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/bxcodec/faker/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+)
+
+func TestExcludeFiles(t *testing.T) {
+	test0Entry := fmt.Sprintf("%v test0", faker.Sentence())
+	test3Entry := fmt.Sprintf("%vtest3%v", faker.Name(), faker.Word())
+	fileList := []string{
+		test0Entry,
+		fmt.Sprintf("test1&£&(%v", faker.URL()),
+		fmt.Sprintf("%vtest2%v", faker.URL(), faker.Sentence()),
+		test3Entry,
+		fmt.Sprintf("%v()T$^test4%v", faker.IPv4(), faker.UUIDHyphenated()),
+	}
+
+	tests := []struct {
+		files             []string
+		exclusionPatterns []string
+		expectedError     error
+		expectedResult    []string
+	}{
+		{
+			files:             fileList,
+			exclusionPatterns: nil,
+			expectedError:     nil,
+			expectedResult:    fileList,
+		},
+		{
+			files:             fileList,
+			exclusionPatterns: []string{".*test0.*", ".*test1.*", ".*test2.*", ".*test3.*", ".*test4.*"},
+			expectedError:     nil,
+			expectedResult:    []string{},
+		},
+		{
+			files:             fileList,
+			exclusionPatterns: []string{".*test1.*", ".*test2.*", ".*test4.*"},
+			expectedError:     nil,
+			expectedResult:    []string{test0Entry, test3Entry},
+		},
+		{
+			files:             fileList,
+			exclusionPatterns: []string{".*test1.*", ".*test2.*", ".*test3.*", ".*test4.*"},
+			expectedError:     nil,
+			expectedResult:    []string{test0Entry},
+		},
+		{
+			files:             fileList,
+			exclusionPatterns: []string{".*test0.*", ".*test1.*", ".*test2.*", ".*test4.*"},
+			expectedError:     nil,
+			expectedResult:    []string{test3Entry},
+		},
+		{
+			files:             fileList,
+			exclusionPatterns: []string{"*test0**"},
+			expectedError:     commonerrors.ErrInvalid,
+			expectedResult:    []string{},
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(fmt.Sprintf("exlusions [%v]", test.exclusionPatterns), func(t *testing.T) {
+			regexes, err := NewExclusionRegexList(globalFileSystem.PathSeparator(), test.exclusionPatterns...)
+			if test.expectedError != nil {
+				require.Error(t, err)
+				assert.True(t, commonerrors.Any(err, test.expectedError))
+			} else {
+				newList, err := ExcludeFiles(test.files, regexes)
+				require.NoError(t, err)
+				sort.Strings(newList)
+				sort.Strings(test.expectedResult)
+				assert.Equal(t, test.expectedResult, newList)
+				for i := range newList {
+					assert.False(t, IsPathExcludedFromPatterns(newList[i], globalFileSystem.PathSeparator(), test.exclusionPatterns...))
+				}
+			}
+
+		})
+	}
+}
+
+func TestExcludes(t *testing.T) {
+	t.Parallel() // marks TLog as capable of running in parallel with other tests
+	var listOfPaths = []string{
+		"some/path", "somepath", ".snapshot", ".snapshot/path", "test/.snapshot/some/path", ".snapshot123", ".snapshot123/path", "test/.snapshot123/some-path", "test/.snapshot123/some/path",
+	}
+	tests := []struct {
+		inputlist       []string
+		exclusions      []string
+		expectedResults []string
+	}{
+		{
+			inputlist:       listOfPaths,
+			exclusions:      []string{},
+			expectedResults: listOfPaths,
+		},
+		{
+			inputlist:       listOfPaths,
+			exclusions:      []string{"noexclusion"},
+			expectedResults: listOfPaths,
+		},
+		{
+			inputlist:       []string{},
+			exclusions:      []string{"any"},
+			expectedResults: []string{},
+		},
+		{
+			inputlist:       listOfPaths,
+			exclusions:      []string{""},
+			expectedResults: listOfPaths,
+		},
+		{
+			inputlist:       listOfPaths,
+			exclusions:      []string{"some.*"},
+			expectedResults: []string{".snapshot", ".snapshot/path", ".snapshot123", ".snapshot123/path"},
+		},
+		{
+			inputlist:       listOfPaths,
+			exclusions:      []string{".*path"},
+			expectedResults: []string{".snapshot", ".snapshot123"},
+		},
+		{
+			inputlist:       listOfPaths,
+			exclusions:      []string{"[.]snapshot.*"},
+			expectedResults: []string{"some/path", "somepath"},
+		},
+		{
+			inputlist:       listOfPaths,
+			exclusions:      []string{"[.]snapshot.*/.*"},
+			expectedResults: []string{"some/path", "somepath", ".snapshot", ".snapshot123"},
+		},
+		{
+			inputlist:       listOfPaths,
+			exclusions:      []string{"[.]snapshot.*", ".*path"},
+			expectedResults: []string{},
+		},
+	}
+	for i := range tests {
+		test := tests[i] // NOTE: https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
+		t.Run(fmt.Sprintf("%v: %v", i, test.exclusions), func(t *testing.T) {
+			t.Parallel() // marks each test case as capable of running in parallel with each other
+			actualList, err := ExcludeAll(test.inputlist, test.exclusions...)
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedResults, actualList)
+		})
+	}
+
+}
+
+func TestIsPathExcludedFromPatterns(t *testing.T) {
+	tests := []struct {
+		path              string
+		pathSeparator     rune
+		exclusionPatterns []string
+		exclude           bool
+	}{
+		{
+			path:              "",
+			pathSeparator:     '\\',
+			exclusionPatterns: []string{},
+			exclude:           false,
+		},
+		{
+			path:              "",
+			pathSeparator:     '\\',
+			exclusionPatterns: []string{".*[.]test[^13]"},
+			exclude:           false,
+		},
+		{
+			path:              "C:\\Users\\adrcab01\\AppData\\Local\\Temp\\test-findall-929837903\\level1\\level2\\test-findall-309750873.test2",
+			pathSeparator:     '\\',
+			exclusionPatterns: []string{},
+			exclude:           false,
+		},
+		{
+			path:              "C:\\Users\\adrcab01\\AppData\\Local\\Temp\\test-findall-929837903\\level1\\level2\\test-findall-309750873.test2",
+			pathSeparator:     '\\',
+			exclusionPatterns: []string{".*[.]test[^13]"},
+			exclude:           true,
+		},
+		{
+			path:              "C:/Users/adrcab01/AppData/Local/Temp/test-findall-929837903/level1/level2/test-findall-309750873.test2",
+			pathSeparator:     '/',
+			exclusionPatterns: []string{".*[.]test[^13]"},
+			exclude:           true,
+		},
+		{
+			path:              "C:\\Users\\adrcab01\\AppData\\Local\\Temp\\test-findall-929837903\\level1\\level2\\test-findall-309750873.test3",
+			pathSeparator:     '\\',
+			exclusionPatterns: []string{".*[.]test[^13]"},
+			exclude:           false,
+		},
+		{
+			path:              "C:/Users/adrcab01/AppData/Local/Temp/test-findall-929837903/level1/level2/test-findall-309750873.test3",
+			pathSeparator:     '/',
+			exclusionPatterns: []string{".*[.]test[^13]"},
+			exclude:           false,
+		},
+		{
+			path:              "C:\\Users\\adrcab01\\AppData\\Local\\Temp\\test-findall-929837903\\level1\\level2\\test-findall-309750873.test2",
+			pathSeparator:     '\\',
+			exclusionPatterns: []string{".*[.]test2"},
+			exclude:           true,
+		},
+		{
+			path:              "C:\\Users\\adrcab01\\AppData\\Local\\Temp\\test-findall-929837903\\level1\\level2\\test-findall-309750873.test3",
+			pathSeparator:     '\\',
+			exclusionPatterns: []string{".*[.]test2"},
+			exclude:           false,
+		},
+		{
+			path:              "C:\\Users\\adrcab01\\AppData\\Local\\Temp\\test-findall-929837903\\level1\\level2\\test-findall-309750873.test3",
+			pathSeparator:     '\\',
+			exclusionPatterns: []string{".*"},
+			exclude:           true,
+		},
+		{
+			path:              "C:\\Users\\adrcab01\\AppData\\Local\\Temp\\test-findall-929837903\\level1\\level2\\test-findall-309750873.test3",
+			pathSeparator:     '\\',
+			exclusionPatterns: []string{".*test3"},
+			exclude:           true,
+		},
+		{
+			path:              "C:\\Users\\adrcab01\\AppData\\Local\\Temp\\test-findall-929837903\\level1\\level2\\test-findall-309750873.test3",
+			pathSeparator:     '\\',
+			exclusionPatterns: []string{".*test2"},
+			exclude:           false,
+		},
+	}
+	for i := range tests {
+		test := tests[i]
+		t.Run(fmt.Sprintf("exlusions [%v]", test.exclusionPatterns), func(t *testing.T) {
+			//t.Parallel()
+			if test.exclude {
+				assert.True(t, IsPathExcludedFromPatterns(test.path, test.pathSeparator, test.exclusionPatterns...))
+			} else {
+				assert.False(t, IsPathExcludedFromPatterns(test.path, test.pathSeparator, test.exclusionPatterns...))
+			}
+
+		})
+	}
+}

--- a/utils/filesystem/files.go
+++ b/utils/filesystem/files.go
@@ -2,10 +2,10 @@
  * Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package filesystem
 
 import (
-	"archive/zip"
 	"bytes"
 	"context"
 	"errors"
@@ -16,15 +16,11 @@ import (
 	"regexp"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/bmatcuk/doublestar/v3"
 	"github.com/shirou/gopsutil/v3/disk"
 	"github.com/spf13/afero"
-	"go.uber.org/atomic"
-	"golang.org/x/text/encoding/unicode"
 
-	"github.com/ARM-software/golang-utils/utils/charset"
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/parallelisation"
 	"github.com/ARM-software/golang-utils/utils/platform"
@@ -94,11 +90,23 @@ func (fs *VFS) Walk(root string, fn filepath.WalkFunc) error {
 }
 
 func (fs *VFS) WalkWithContext(ctx context.Context, root string, fn filepath.WalkFunc) error {
+	return fs.WalkWithContextAndExclusionPatterns(ctx, root, fn)
+}
+
+func (fs *VFS) WalkWithContextAndExclusionPatterns(ctx context.Context, root string, fn filepath.WalkFunc, exclusionPatterns ...string) (err error) {
+	exclusionRegex, err := NewExclusionRegexList(fs.PathSeparator(), exclusionPatterns...)
+	if err != nil {
+		return
+	}
+	if IsPathExcluded(root, exclusionRegex...) {
+		// In this case, the whole tree is excluded and so, we can stop here
+		return
+	}
 	info, err := fs.Lstat(root)
 	if err != nil {
 		err = fn(root, nil, err)
 	} else {
-		err = fs.walk(ctx, root, info, fn)
+		err = fs.walk(ctx, root, info, exclusionRegex, fn)
 	}
 	if commonerrors.Any(err, filepath.SkipDir) {
 		return nil
@@ -108,7 +116,7 @@ func (fs *VFS) WalkWithContext(ctx context.Context, root string, fn filepath.Wal
 }
 
 // walks recursively descends path, calling fn.
-func (fs *VFS) walk(ctx context.Context, path string, info os.FileInfo, fn filepath.WalkFunc) (err error) {
+func (fs *VFS) walk(ctx context.Context, path string, info os.FileInfo, exclusions []*regexp.Regexp, fn filepath.WalkFunc) (err error) {
 	err = parallelisation.DetermineContextError(ctx)
 	if err != nil {
 		return
@@ -127,19 +135,27 @@ func (fs *VFS) walk(ctx context.Context, path string, info os.FileInfo, fn filep
 			return
 		}
 	}
-	for _, name := range items {
+	cleansedList, err := ExcludeFiles(items, exclusions)
+	if err != nil {
+		err = fn(path, info, err)
+		if err != nil {
+			return
+		}
+	}
+	for i := range cleansedList {
+		itemName := cleansedList[i]
 		subErr := parallelisation.DetermineContextError(ctx)
 		if subErr != nil {
 			return subErr
 		}
-		filename := filepath.Join(path, name)
+		filename := filepath.Join(path, itemName)
 		fileInfo, subErr := fs.Lstat(filename)
 		if subErr != nil {
 			if err := fn(filename, fileInfo, subErr); err != nil && err != filepath.SkipDir {
 				return err
 			}
 		} else {
-			subErr = fs.walk(ctx, filename, fileInfo, fn)
+			subErr = fs.walk(ctx, filename, fileInfo, exclusions, fn)
 			if subErr != nil {
 				if !fileInfo.IsDir() || subErr != filepath.SkipDir {
 					return subErr
@@ -372,7 +388,10 @@ func (fs *VFS) CleanDir(dir string) error {
 	return fs.CleanDirWithContext(context.Background(), dir)
 }
 
-func (fs *VFS) CleanDirWithContext(ctx context.Context, dir string) (err error) {
+func (fs *VFS) CleanDirWithContext(ctx context.Context, dir string) error {
+	return fs.CleanDirWithContextAndExclusionPatterns(ctx, dir)
+}
+func (fs *VFS) CleanDirWithContextAndExclusionPatterns(ctx context.Context, dir string, exclusionPatterns ...string) (err error) {
 	err = parallelisation.DetermineContextError(ctx)
 	if err != nil {
 		return
@@ -384,7 +403,7 @@ func (fs *VFS) CleanDirWithContext(ctx context.Context, dir string) (err error) 
 	if empty || err != nil {
 		return
 	}
-	files, err := fs.Ls(dir)
+	files, err := fs.LsWithExclusionPatterns(dir, exclusionPatterns...)
 	if err != nil {
 		return
 	}
@@ -407,7 +426,7 @@ func (fs *VFS) removeFileWithContext(ctx context.Context, dir, f string) (err er
 	return
 }
 
-// Checks if a file or folder exists
+// Exists checks if a file or folder exists
 func Exists(path string) bool {
 	return globalFileSystem.Exists(path)
 }
@@ -452,7 +471,10 @@ func (fs *VFS) Rm(dir string) error {
 	return fs.RemoveWithContext(context.Background(), dir)
 }
 
-func (fs *VFS) RemoveWithContext(ctx context.Context, dir string) (err error) {
+func (fs *VFS) RemoveWithContext(ctx context.Context, dir string) error {
+	return fs.RemoveWithContextAndExclusionPatterns(ctx, dir)
+}
+func (fs *VFS) RemoveWithContextAndExclusionPatterns(ctx context.Context, dir string, exclusionPatterns ...string) (err error) {
 	if dir == "" {
 		return
 	}
@@ -468,19 +490,29 @@ func (fs *VFS) RemoveWithContext(ctx context.Context, dir string) (err error) {
 		return
 	}
 	if isDir && !isEmpty {
-		err = fs.CleanDirWithContext(ctx, dir)
+		err = fs.CleanDirWithContextAndExclusionPatterns(ctx, dir, exclusionPatterns...)
 	}
 	if err != nil {
 		return
 	}
+	isEmpty, err = fs.IsEmpty(dir) // Checking again if empty as some files may have been ignored.
+	if err != nil {
+		return
+	}
+	if isDir && !isEmpty {
+		return
+	} // some files may have been ignored and so, the removal should stop
 	err = parallelisation.DetermineContextError(ctx)
 	if err != nil {
+		return
+	}
+	if IsPathExcludedFromPatterns(dir, fs.PathSeparator(), exclusionPatterns...) {
 		return
 	}
 	return fs.vfs.Remove(dir)
 }
 
-// States whether it is a file or not
+// IsFile states whether it is a file or not
 func IsFile(path string) (result bool, err error) {
 	return globalFileSystem.IsFile(path)
 }
@@ -616,44 +648,6 @@ func (fs *VFS) MkDirAll(dir string, perm os.FileMode) (err error) {
 	return
 }
 
-// ExcludeAll excludes files
-func ExcludeAll(files []string, exclusionPatterns ...string) ([]string, error) {
-	return globalFileSystem.ExcludeAll(files, exclusionPatterns...)
-}
-
-func (fs *VFS) ExcludeAll(files []string, exclusionPatterns ...string) ([]string, error) {
-	regexes := []*regexp.Regexp{}
-	patternsExtendedList := []string{}
-	for _, p := range exclusionPatterns {
-		if p != "" {
-			patternsExtendedList = append(patternsExtendedList, p, fmt.Sprintf(".*/%v/.*", p), fmt.Sprintf(".*%v%v%v.*", fs.PathSeparator(), p, fs.PathSeparator()))
-		}
-	}
-	for _, p := range patternsExtendedList {
-		r, err := regexp.Compile(p)
-		if err != nil {
-			return nil, err
-		}
-		regexes = append(regexes, r)
-	}
-	cleansedList := []string{}
-	for _, f := range files {
-		if !isExcluded(f, regexes...) {
-			cleansedList = append(cleansedList, f)
-		}
-	}
-	return cleansedList, nil
-}
-
-func isExcluded(path string, exclusionPatterns ...*regexp.Regexp) bool {
-	for _, p := range exclusionPatterns {
-		if p.MatchString(path) {
-			return true
-		}
-	}
-	return false
-}
-
 // FindAll finds all the files with extensions
 func FindAll(dir string, extensions ...string) (files []string, err error) {
 	return globalFileSystem.FindAll(dir, extensions...)
@@ -673,7 +667,11 @@ func (fs *VFS) FindAll(dir string, extensions ...string) (files []string, err er
 	return
 }
 func (fs *VFS) findAllOfExtension(dir string, ext string) (files []string, err error) {
-	return doublestar.GlobOS(fs, filepath.Join(dir, "**", fmt.Sprintf("*.%v", strings.TrimPrefix(ext, "."))))
+	files, err = doublestar.GlobOS(fs, filepath.Join(dir, "**", fmt.Sprintf("*.%v", strings.TrimPrefix(ext, "."))))
+	if commonerrors.Any(err, doublestar.ErrBadPattern) {
+		err = fmt.Errorf("%w: %v", commonerrors.ErrInvalid, err.Error())
+	}
+	return
 }
 
 func (fs *VFS) Chmod(name string, mode os.FileMode) error {
@@ -749,17 +747,36 @@ func Ls(dir string) (files []string, err error) {
 	return globalFileSystem.Ls(dir)
 }
 func (fs *VFS) Ls(dir string) (names []string, err error) {
-	if isDir, err := fs.IsDir(dir); !isDir || err != nil {
-		err = fmt.Errorf("path [%v] is not a directory: %w", dir, commonerrors.ErrInvalid)
-		return nil, err
-	}
-	f, err := fs.GenericOpen(dir)
+	return fs.LsWithExclusionPatterns(dir)
+}
+
+func (fs *VFS) LsWithExclusionPatterns(dir string, exclusionPatterns ...string) (names []string, err error) {
+	regexes, err := NewExclusionRegexList(fs.PathSeparator(), exclusionPatterns...)
 	if err != nil {
 		return nil, err
 	}
-	names, err = fs.LsFromOpenedDirectory(f)
+	names, err = LsWithExclusionPatterns(fs, dir, regexes)
+	return
+}
+
+func LsWithExclusionPatterns(fs FS, dir string, regexes []*regexp.Regexp) (names []string, err error) {
+	if isDir, subErr := fs.IsDir(dir); !isDir || subErr != nil {
+		err = fmt.Errorf("path [%v] is not a directory: %w", dir, commonerrors.ErrInvalid)
+		return
+	}
+	f, err := fs.GenericOpen(dir)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+	AllNames, err := fs.LsFromOpenedDirectory(f)
 	_ = f.Close()
-	return names, err
+	if err != nil {
+		return
+	}
+	names, err = ExcludeFiles(AllNames, regexes)
+	return
+
 }
 
 func (fs *VFS) LsFromOpenedDirectory(dir File) ([]string, error) {
@@ -909,7 +926,7 @@ func (fs *VFS) moveFile(ctx context.Context, src string, dest string) (err error
 	if src == dest {
 		return
 	}
-	err = copyFileBetweenFS(ctx, fs, src, fs, dest)
+	err = copyFolderBetweenFSWithExclusionRegexes(ctx, fs, src, fs, dest, []*regexp.Regexp{}, []*regexp.Regexp{})
 	if err != nil {
 		return
 	}
@@ -937,7 +954,11 @@ func (fs *VFS) Copy(src string, dest string) (err error) {
 }
 
 func (fs *VFS) CopyWithContext(ctx context.Context, src string, dest string) (err error) {
-	return CopyBetweenFS(ctx, fs, src, fs, dest)
+	return fs.CopyWithContextAndExclusionPatterns(ctx, src, dest)
+}
+
+func (fs *VFS) CopyWithContextAndExclusionPatterns(ctx context.Context, src string, dest string, exclusionPatterns ...string) (err error) {
+	return CopyBetweenFSWithExclusionPatterns(ctx, fs, src, fs, dest, exclusionPatterns...)
 }
 
 func MoveBetweenFS(ctx context.Context, srcFs FS, src string, destFs FS, dest string) (err error) {
@@ -956,6 +977,29 @@ func MoveBetweenFS(ctx context.Context, srcFs FS, src string, destFs FS, dest st
 }
 
 func CopyBetweenFS(ctx context.Context, srcFs FS, src string, destFs FS, dest string) (err error) {
+	return CopyBetweenFSWithExclusionPatterns(ctx, srcFs, src, destFs, dest)
+}
+func CopyBetweenFSWithExclusionPatterns(ctx context.Context, srcFs FS, src string, destFs FS, dest string, exclusionPatterns ...string) (err error) {
+	exclusionSrcFsRegexes, err := NewExclusionRegexList(srcFs.PathSeparator(), exclusionPatterns...)
+	if err != nil {
+		return
+	}
+	exclusionDestFsRegexes, err := NewExclusionRegexList(destFs.PathSeparator(), exclusionPatterns...)
+	if err != nil {
+		return
+	}
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+	err = CopyBetweenFSWithExclusionRegexes(ctx, srcFs, src, destFs, dest, exclusionSrcFsRegexes, exclusionDestFsRegexes)
+	return
+}
+
+func CopyBetweenFSWithExclusionRegexes(ctx context.Context, srcFs FS, src string, destFs FS, dest string, exclusionSrcFsRegexes []*regexp.Regexp, exclusionDestFsRegexes []*regexp.Regexp) (err error) {
+	if IsPathExcluded(src, exclusionSrcFsRegexes...) || IsPathExcluded(dest, exclusionDestFsRegexes...) {
+		return
+	}
 	err = parallelisation.DetermineContextError(ctx)
 	if err != nil {
 		return
@@ -978,14 +1022,17 @@ func CopyBetweenFS(ctx context.Context, srcFs FS, src string, destFs FS, dest st
 	}
 	dst := filepath.Join(dest, filepath.Base(src))
 	if isDir {
-		err = copyFolderBetweenFS(ctx, srcFs, src, destFs, dst)
+		err = copyFolderBetweenFSWithExclusionRegexes(ctx, srcFs, src, destFs, dst, exclusionSrcFsRegexes, exclusionDestFsRegexes)
 	} else {
-		err = copyFileBetweenFS(ctx, srcFs, src, destFs, dst)
+		err = copyFileBetweenFSWithExclusionPatternsWithExclusionRegexes(ctx, srcFs, src, destFs, dst, exclusionSrcFsRegexes, exclusionDestFsRegexes)
 	}
 	return
 }
 
-func copyFolderBetweenFS(ctx context.Context, srcFs FS, src string, destFs FS, dest string) (err error) {
+func copyFolderBetweenFSWithExclusionRegexes(ctx context.Context, srcFs FS, src string, destFs FS, dest string, exclusionSrcFsRegexes []*regexp.Regexp, exclusionDestFsRegexes []*regexp.Regexp) (err error) {
+	if IsPathExcluded(src, exclusionSrcFsRegexes...) || IsPathExcluded(dest, exclusionDestFsRegexes...) {
+		return
+	}
 	err = parallelisation.DetermineContextError(ctx)
 	if err != nil {
 		return
@@ -999,13 +1046,13 @@ func copyFolderBetweenFS(ctx context.Context, srcFs FS, src string, destFs FS, d
 		return
 	}
 	if !empty {
-		files, err := srcFs.Ls(src)
+		files, err := LsWithExclusionPatterns(srcFs, src, exclusionSrcFsRegexes)
 		if err != nil {
 			return err
 		}
 		for i := range files {
 			srcPath := filepath.Join(src, files[i])
-			err = CopyBetweenFS(ctx, srcFs, srcPath, destFs, dest)
+			err = CopyBetweenFSWithExclusionRegexes(ctx, srcFs, srcPath, destFs, dest, exclusionSrcFsRegexes, exclusionDestFsRegexes)
 			if err != nil {
 				return err
 			}
@@ -1014,7 +1061,10 @@ func copyFolderBetweenFS(ctx context.Context, srcFs FS, src string, destFs FS, d
 	return
 }
 
-func copyFileBetweenFS(ctx context.Context, srcFs FS, src string, destFs FS, dest string) (err error) {
+func copyFileBetweenFSWithExclusionPatternsWithExclusionRegexes(ctx context.Context, srcFs FS, src string, destFs FS, dest string, exclusionSrcFsRegexes []*regexp.Regexp, exclusionDestFsRegexes []*regexp.Regexp) (err error) {
+	if IsPathExcluded(src, exclusionSrcFsRegexes...) || IsPathExcluded(dest, exclusionDestFsRegexes...) {
+		return
+	}
 	err = parallelisation.DetermineContextError(ctx)
 	if err != nil {
 		return
@@ -1077,335 +1127,6 @@ func (fs *VFS) GetFileSize(name string) (size int64, err error) {
 	return
 }
 
-func Zip(source string, destination string) error {
-	return globalFileSystem.Zip(source, destination)
-}
-
-func (fs *VFS) Zip(source, destination string) error {
-	return fs.ZipWithContext(context.Background(), source, destination)
-}
-
-func (fs *VFS) ZipWithContext(ctx context.Context, source, destination string) (err error) {
-	return fs.ZipWithContextAndLimits(ctx, source, destination, NoLimits())
-}
-
-func (fs *VFS) ZipWithContextAndLimits(ctx context.Context, source, destination string, limits ILimits) (err error) {
-	if limits == nil {
-		err = fmt.Errorf("%w: missing file system limits", commonerrors.ErrUndefined)
-		return
-	}
-	err = parallelisation.DetermineContextError(ctx)
-	if err != nil {
-		return
-	}
-
-	file, err := fs.CreateFile(destination)
-	if err != nil {
-		return
-	}
-	defer func() { _ = file.Close() }()
-
-	// create a new zip archive
-	w := zip.NewWriter(file)
-	defer func() { _ = w.Close() }()
-
-	walker := func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if limits.Apply() && info.Size() > limits.GetMaxFileSize() {
-			err = fmt.Errorf("%w: file [%v] is too big (%v B) and beyond limits (max: %v B)", commonerrors.ErrTooLarge, path, info.Size(), limits.GetMaxFileSize())
-			return err
-		}
-
-		// Get the relative path
-		relPath, err := filepath.Rel(source, path)
-		if err != nil {
-			return err
-		}
-
-		// If directory
-		if info.IsDir() {
-			if path == source {
-				return nil
-			}
-			header := &zip.FileHeader{
-				Name:     relPath + "/",
-				Method:   zip.Deflate,
-				Modified: info.ModTime(),
-			}
-			_, err = w.CreateHeader(header)
-			return err
-		}
-
-		// if file
-		src, err := fs.GenericOpen(path)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = src.Close() }()
-
-		// create file in archive
-		relPath, err = filepath.Rel(source, path)
-		if err != nil {
-			return err
-		}
-		header := &zip.FileHeader{
-			Name:     relPath,
-			Method:   zip.Deflate,
-			Modified: info.ModTime(),
-		}
-		dest, err := w.CreateHeader(header)
-		if err != nil {
-			return err
-		}
-		n, err := io.Copy(dest, src)
-		if err != nil {
-			return err
-		}
-
-		if info.Size() != n && !IsSymLink(info) {
-			return fmt.Errorf("could not write the full file [%v] content (wrote %v/%v bytes)", relPath, n, info.Size())
-		}
-		return nil
-	}
-	err = fs.WalkWithContext(ctx, source, walker)
-
-	if limits.Apply() {
-		stat, subErr := file.Stat()
-		if subErr != nil {
-			return subErr
-		}
-		if stat.Size() > limits.GetMaxFileSize() {
-			subErr = fmt.Errorf("%w: file [%v] is too big (%v B) and beyond limits (max: %v B)", commonerrors.ErrTooLarge, destination, stat.Size(), limits.GetMaxFileSize())
-			return subErr
-		}
-	}
-	return
-}
-
-// Prevents any ZipSlip (files outside extraction dirPath) https://snyk.io/research/zip-slip-vulnerability#go
-func sanitiseZipExtractPath(fs FS, filePath string, destination string) (destPath string, err error) {
-	destPath = filepath.Join(destination, filePath) // join cleans the destpath so we can check for ZipSlip
-	if destPath == destination {
-		return
-	}
-	if strings.HasPrefix(destPath, fmt.Sprintf("%v%v", destination, string(fs.PathSeparator()))) {
-		return
-	}
-	if strings.HasPrefix(destPath, fmt.Sprintf("%v/", destination)) {
-		return
-	}
-	err = fmt.Errorf("%w: zipslip security breach detected, file dirPath '%s' not in destination directory '%s'", commonerrors.ErrInvalidDestination, filePath, destination)
-	return
-}
-
-func Unzip(source, destination string) ([]string, error) {
-	return globalFileSystem.Unzip(source, destination)
-}
-
-func (fs *VFS) Unzip(source, destination string) ([]string, error) {
-	return fs.UnzipWithContext(context.Background(), source, destination)
-}
-
-func (fs *VFS) UnzipWithContext(ctx context.Context, source string, destination string) (fileList []string, err error) {
-	return fs.unzip(ctx, source, destination, NoLimits())
-}
-func (fs *VFS) UnzipWithContextAndLimits(ctx context.Context, source string, destination string, limits ILimits) (fileList []string, err error) {
-	return fs.unzip(ctx, source, destination, limits)
-}
-func (fs *VFS) unzip(ctx context.Context, source string, destination string, limits ILimits) (fileList []string, err error) {
-	if limits == nil {
-		err = fmt.Errorf("%w: missing file system limits", commonerrors.ErrUndefined)
-		return
-	}
-	err = parallelisation.DetermineContextError(ctx)
-	if err != nil {
-		return
-	}
-
-	fileCounter := atomic.NewUint64(0)
-
-	// List of file paths to return
-	totalSizeOnDisk := atomic.NewUint64(0)
-
-	info, err := fs.Lstat(source)
-	if err != nil {
-		return
-	}
-	f, err := fs.GenericOpen(source)
-	if err != nil {
-		return
-	}
-	defer func() { _ = f.Close() }()
-
-	zipFileSize := info.Size()
-
-	if limits.Apply() && zipFileSize > limits.GetMaxFileSize() {
-		err = fmt.Errorf("%w: zip file [%v] is too big (%v B) and beyond limits (max: %v B)", commonerrors.ErrTooLarge, source, zipFileSize, limits.GetMaxFileSize())
-		return
-	}
-
-	zipReader, err := zip.NewReader(f, zipFileSize)
-	if err != nil {
-		return
-	}
-
-	// Clean the destination to find shortest dirPath
-	destination = filepath.Clean(destination)
-	err = fs.MkDir(destination)
-	if err != nil {
-		return
-	}
-	directoryInfo := map[string]os.FileInfo{}
-
-	// For each file in the zip file
-	for i := range zipReader.File {
-		fileCounter.Inc()
-
-		zippedFile := zipReader.File[i]
-		subErr := parallelisation.DetermineContextError(ctx)
-		if subErr != nil {
-			return fileList, subErr
-		}
-
-		// Calculate file dirPath
-		filePath, subErr := sanitiseZipExtractPath(fs, zippedFile.Name, destination)
-		if subErr != nil {
-			return fileList, subErr
-		}
-
-		// Keep list of files unzipped
-		fileList = append(fileList, filePath)
-
-		if zippedFile.FileInfo().IsDir() {
-			// Create directory
-			subErr = fs.MkDir(filePath)
-
-			if subErr != nil {
-				return fileList, fmt.Errorf("unable to create directory [%s]: %w", filePath, subErr)
-			}
-			// recording directory dirInfo to preserve timestamps
-			directoryInfo[filePath] = zippedFile.FileInfo()
-			// Nothing more to do for a directory, move to next zip file
-			continue
-		}
-
-		// If a file create the dirPath into which to write the file
-		directoryPath := filepath.Dir(filePath)
-		subErr = fs.MkDir(directoryPath)
-		if subErr != nil {
-			return fileList, fmt.Errorf("unable to create directory '%s': %w", directoryPath, subErr)
-		}
-
-		fileSizeOnDisk, subErr := fs.unzipZipFile(ctx, filePath, zippedFile, limits)
-		if subErr != nil {
-			return fileList, subErr
-		}
-		totalSizeOnDisk.Add(uint64(fileSizeOnDisk))
-		if limits.Apply() && totalSizeOnDisk.Load() > limits.GetMaxTotalSize() {
-			return fileList, fmt.Errorf("%w: more than %v B of disk space was used while unzipping %v (%v B used already)", commonerrors.ErrTooLarge, limits.GetMaxTotalSize(), source, totalSizeOnDisk.Load())
-		}
-		if limits.Apply() && int64(fileCounter.Load()) > limits.GetMaxFileCount() {
-			return fileList, fmt.Errorf("%w: more than %v files were created while unzipping %v (%v files created already)", commonerrors.ErrTooLarge, limits.GetMaxFileCount(), source, fileCounter)
-		}
-	}
-
-	// Ensuring directory timestamps are preserved (this needs to be done after all the files have been created).
-	for dirPath, dirInfo := range directoryInfo {
-		subErr := parallelisation.DetermineContextError(ctx)
-		if subErr != nil {
-			return fileList, subErr
-		}
-		times := newDefaultTimeInfo(dirInfo)
-		subErr = fs.Chtimes(dirPath, times.AccessTime(), times.ModTime())
-		if subErr != nil {
-			return fileList, fmt.Errorf("unable to set directory timestamp [%s]: %w", dirPath, subErr)
-		}
-	}
-
-	return fileList, nil
-}
-
-// unzipZipFile unzips file to destination directory
-func (fs *VFS) unzipZipFile(ctx context.Context, dest string, zippedFile *zip.File, limits ILimits) (fileSizeOnDisk int64, err error) {
-	err = parallelisation.DetermineContextError(ctx)
-	if err != nil {
-		return
-	}
-
-	destinationPath, err := determineUnzippedFilepath(dest)
-	if err != nil {
-		return
-	}
-
-	destinationFile, err := fs.OpenFile(destinationPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, zippedFile.Mode())
-	if err != nil {
-		err = fmt.Errorf("%w: unable to open file '%s': %v", commonerrors.ErrUnexpected, destinationPath, err.Error())
-		return
-	}
-	defer func() { _ = destinationFile.Close() }()
-
-	sourceFile, err := zippedFile.Open()
-	if err != nil {
-		err = fmt.Errorf("%w: unable to open zipped file '%s': %v", commonerrors.ErrUnsupported, zippedFile.Name, err.Error())
-		return
-	}
-	defer func() { _ = sourceFile.Close() }()
-
-	info := zippedFile.FileInfo()
-	fileSizeOnDisk = info.Size()
-	if limits.Apply() {
-		if fileSizeOnDisk > limits.GetMaxFileSize() {
-			err = fmt.Errorf("%w: zipped file [%v] is too big (%v B) and above max size (%v B)", commonerrors.ErrTooLarge, info.Name(), info.Size(), limits.GetMaxFileSize())
-			return
-		}
-	}
-
-	_, err = io.CopyN(destinationFile, sourceFile, fileSizeOnDisk)
-	if err != nil {
-		err = fmt.Errorf("copy of zipped file to '%s' failed: %w", destinationPath, err)
-		return
-	}
-	err = destinationFile.Close()
-	if err != nil {
-		return
-	}
-	// Ensuring the timestamp is preserved.
-	times := newDefaultTimeInfo(info)
-	err = fs.Chtimes(destinationPath, times.AccessTime(), times.ModTime())
-	// Nothing more to do for a directory, move to next zip file
-	return
-}
-
-func determineUnzippedFilepath(destinationPath string) (string, error) {
-
-	// See https://go-review.googlesource.com/c/go/+/75592/
-	// Character encodings other than CP-437 and UTF-8
-	// are not officially supported by the ZIP specification, pragmatically
-	// the world has permitted use of them.
-	//
-	// When a non-standard encoding is used, it is the user's responsibility
-	// to ensure that the target system is expecting the encoding used
-	// (e.g., producing a ZIP file you know is used on a Chinese version of Windows).
-	if utf8.ValidString(destinationPath) {
-		return destinationPath, nil
-	}
-	// Nonetheless, instead of raising an error when non-UTF8 characters are present in filepath,
-	// we try to guess the encoding and then, convert the string to UTF-8.
-	encoding, charsetName, err := charset.DetectTextEncoding([]byte(destinationPath))
-	if err != nil {
-		return "", fmt.Errorf("%w: file path [%s] is not a valid utf-8 string and charset could not be detected: %v", commonerrors.ErrInvalid, destinationPath, err.Error())
-	}
-	convertedDestinationPath, err := charset.IconvString(destinationPath, encoding, unicode.UTF8)
-	if err != nil {
-		return "", fmt.Errorf("%w: file path [%s] is encoded using charset [%v] but could not be converted to valid utf-8: %v", commonerrors.ErrUnexpected, destinationPath, charsetName, err.Error())
-		// If zip file paths must be accepted even when their encoding is unknown, or conversion to utf-8 failed, then the following can be done.
-		// destinationPath = strings.ToValidUTF8(dest, charset.InvalidUTF8CharacterReplacement)
-	}
-	return convertedDestinationPath, err
-}
-
 func SubDirectories(directory string) ([]string, error) {
 	return globalFileSystem.SubDirectories(directory)
 }
@@ -1414,7 +1135,10 @@ func (fs *VFS) SubDirectories(directory string) ([]string, error) {
 	return fs.SubDirectoriesWithContext(context.Background(), directory)
 }
 
-func (fs *VFS) SubDirectoriesWithContext(ctx context.Context, directory string) (directories []string, err error) {
+func (fs *VFS) SubDirectoriesWithContext(ctx context.Context, directory string) ([]string, error) {
+	return fs.SubDirectoriesWithContextAndExclusionPatterns(ctx, directory, "[.].*")
+}
+func (fs *VFS) SubDirectoriesWithContextAndExclusionPatterns(ctx context.Context, directory string, exclusionPatterns ...string) (directories []string, err error) {
 	err = parallelisation.DetermineContextError(ctx)
 	if err != nil {
 		return
@@ -1423,7 +1147,10 @@ func (fs *VFS) SubDirectoriesWithContext(ctx context.Context, directory string) 
 	if err != nil {
 		return
 	}
-
+	regexes, err := NewExclusionRegexList(fs.PathSeparator(), exclusionPatterns...)
+	if err != nil {
+		return
+	}
 	for i := range files {
 		subErr := parallelisation.DetermineContextError(ctx)
 		if subErr != nil {
@@ -1431,10 +1158,11 @@ func (fs *VFS) SubDirectoriesWithContext(ctx context.Context, directory string) 
 			return
 		}
 		file := files[i]
-		if file.IsDir() && !strings.HasPrefix(file.Name(), ".") {
+		if file.IsDir() && !IsPathExcluded(file.Name(), regexes...) {
 			directories = append(directories, file.Name())
 		}
 	}
+
 	return
 }
 
@@ -1447,7 +1175,23 @@ func (fs *VFS) ListDirTree(dirPath string, list *[]string) error {
 	return fs.ListDirTreeWithContext(context.Background(), dirPath, list)
 }
 
-func (fs *VFS) ListDirTreeWithContext(ctx context.Context, dirPath string, list *[]string) (err error) {
+func (fs *VFS) ListDirTreeWithContext(ctx context.Context, dirPath string, list *[]string) error {
+	return fs.ListDirTreeWithContextAndExclusionPatterns(ctx, dirPath, list)
+}
+func (fs *VFS) ListDirTreeWithContextAndExclusionPatterns(ctx context.Context, dirPath string, list *[]string, exclusionPatterns ...string) (err error) {
+	regexes, err := NewExclusionRegexList(fs.PathSeparator(), exclusionPatterns...)
+	if err != nil {
+		return
+	}
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+	err = ListDirTreeWithContextAndExclusionPatterns(ctx, fs, dirPath, list, regexes)
+	return
+}
+
+func ListDirTreeWithContextAndExclusionPatterns(ctx context.Context, fs FS, dirPath string, list *[]string, regexes []*regexp.Regexp) (err error) {
 	err = parallelisation.DetermineContextError(ctx)
 	if err != nil {
 		return
@@ -1457,7 +1201,7 @@ func (fs *VFS) ListDirTreeWithContext(ctx context.Context, dirPath string, list 
 		return
 	}
 
-	elements, err := fs.Ls(dirPath)
+	elements, err := LsWithExclusionPatterns(fs, dirPath, regexes)
 	if err != nil {
 		return err
 	}
@@ -1471,7 +1215,7 @@ func (fs *VFS) ListDirTreeWithContext(ctx context.Context, dirPath string, list 
 		path := filepath.Join(dirPath, elements[i])
 		*list = append(*list, path)
 		if isDir, _ := fs.IsDir(path); isDir {
-			subErr = fs.ListDirTreeWithContext(ctx, path, list)
+			subErr = ListDirTreeWithContextAndExclusionPatterns(ctx, fs, path, list, regexes)
 			if subErr != nil {
 				err = subErr
 				return
@@ -1525,7 +1269,7 @@ func (fs *VFS) garbageCollectDir(ctx context.Context, durationSinceLastAccess ti
 		return
 	}
 	if deletePath && platform.IsWindows() {
-		// On linux and potentially MacOs, the access/modification of files in a directory do not affect those times for the parent folder.
+		// On linux and potentially macOS, the access/modification of files in a directory do not affect those times for the parent folder.
 		// Therefore, we cannot rely on the times of a directory to make a decision.
 		// See https://superuser.com/questions/1039003/linux-how-does-file-modification-time-affect-directory-modification-time-and-di
 		err = fs.garbageCollectFile(ctx, durationSinceLastAccess, path)

--- a/utils/filesystem/files_test.go
+++ b/utils/filesystem/files_test.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/ARM-software/golang-utils/utils/collection"
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
-	"github.com/ARM-software/golang-utils/utils/hashing"
 	"github.com/ARM-software/golang-utils/utils/idgen"
 	"github.com/ARM-software/golang-utils/utils/platform"
+	"github.com/ARM-software/golang-utils/utils/reflection"
 )
 
 func TestExists(t *testing.T) {
@@ -323,97 +323,6 @@ func TestConvertPaths(t *testing.T) {
 	}
 }
 
-func TestZip(t *testing.T) {
-	for _, fsType := range FileSystemTypes {
-		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
-			fs := NewFs(fsType)
-
-			for i := 0; i < 10; i++ {
-				func() {
-					// create a directory for the test
-					tmpDir, err := fs.TempDirInTempDir("temp")
-					require.NoError(t, err)
-					defer func() { _ = fs.Rm(tmpDir) }()
-
-					testDir := filepath.Join(tmpDir, "test") // remember to read tmpdir at beginning
-					zipfile := filepath.Join(tmpDir, "test.zip")
-					outDir := filepath.Join(tmpDir, "output")
-
-					// create a file tree for the test
-					// Regarding timestamp preservation, the following link should be read as it gives some insight about how zip tools work or behave
-					// https://blog.joshlemon.com.au/dfir-for-compressed-files/
-					// The bottom line though is that the zip specification stipulates that file timestamp is stored using MS-DOS format which has a 2-second precision.
-					// see Section 4.4.6 of the spec https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
-					// As a result, the built-in timestamp resolution of files in a ZIP archive is only two seconds and so, file timestamps will not be fully preserved when a zip/unzip is performed.
-					// Making the FS think the tree was made 3 seconds ago.
-					tree := createTestFileTree(t, fs, testDir, "", false, time.Now().Add(-3*time.Second), time.Now())
-
-					// zip the directory into the zipfile
-					err = fs.Zip(testDir, zipfile)
-					require.NoError(t, err)
-
-					// unzip
-					tree2, err := fs.Unzip(zipfile, outDir)
-					require.NoError(t, err)
-
-					// Check no files were lost in the zip/unzip process.
-					relativeSrcTree, err := fs.ConvertToRelativePath(testDir, tree...)
-					require.NoError(t, err)
-					relativeResultTree, err := fs.ConvertToRelativePath(outDir, tree2...)
-					require.NoError(t, err)
-					sort.Strings(relativeSrcTree)
-					sort.Strings(relativeResultTree)
-					require.Equal(t, relativeSrcTree, relativeResultTree)
-
-					hasher, err := NewFileHash(hashing.HashXXHash)
-					require.NoError(t, err)
-
-					// check for size, timestamp, hash preservation
-					for _, path := range relativeSrcTree {
-						srcFilePath := filepath.Join(testDir, path)
-						fileinfoSrc, err := fs.Lstat(srcFilePath)
-						require.NoError(t, err)
-						resultFilePath := filepath.Join(outDir, path)
-						fileinfoResult, err := fs.Lstat(resultFilePath)
-						require.NoError(t, err)
-						// TODO handle links separately
-						if IsSymLink(fileinfoSrc) {
-							continue
-						}
-						// Check sizes
-						assert.Equal(t, fileinfoSrc.Size(), fileinfoResult.Size())
-
-						// Check file timestamps
-						// FIXME understand why the timestamp is not preserved when using the FS in memory
-						if fs.GetType() != InMemoryFS {
-							// Allowing some tolerance in case of time rounding or truncation happening (https://golang.org/pkg/os/#Chtimes) + the 2-second time resolution of zip
-							// see comment above
-							assert.True(t, math.Abs(fileinfoSrc.ModTime().Sub(fileinfoResult.ModTime()).Seconds()) <= 2)
-
-							fileTimesSrc, err := fs.StatTimes(filepath.Join(testDir, path))
-							require.NoError(t, err)
-							fileTimeResult, err := fs.StatTimes(filepath.Join(outDir, path))
-							require.NoError(t, err)
-							assert.True(t, math.Abs(fileTimesSrc.ModTime().Sub(fileTimeResult.ModTime()).Seconds()) <= 2)
-						}
-
-						// perform hash comparison
-						if IsRegularFile(fileinfoSrc) {
-							hashSrc, err := hasher.CalculateFile(fs, srcFilePath)
-							require.NoError(t, err)
-							hashResult, err := hasher.CalculateFile(fs, resultFilePath)
-							require.NoError(t, err)
-							assert.Equal(t, hashSrc, hashResult)
-						}
-					}
-					err = fs.Rm(tmpDir)
-					require.NoError(t, err)
-				}()
-			}
-		})
-	}
-}
-
 func TestLink(t *testing.T) {
 	if platform.IsWindows() {
 		fmt.Println("In order to run TestLink on Windows, Developer mode must be enabled: https://github.com/golang/go/pull/24307")
@@ -633,6 +542,105 @@ func TestCleanDir(t *testing.T) {
 	}
 }
 
+func TestCleanDirWithExclusion(t *testing.T) {
+	for _, fsType := range FileSystemTypes {
+		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
+			fs := NewFs(fsType)
+			tmpDir, err := fs.TempDirInTempDir("test-cleandir-with-exclusion-")
+			require.NoError(t, err)
+			defer func() { _ = fs.Rm(tmpDir) }()
+
+			empty, err := fs.IsEmpty(tmpDir)
+			require.NoError(t, err)
+			assert.True(t, empty)
+
+			tmpFile, err := fs.TempFile(tmpDir, "test-cleandir-*.test")
+			require.NoError(t, err)
+			err = tmpFile.Close()
+			require.NoError(t, err)
+
+			checkNotEmpty(t, fs, tmpDir)
+
+			testDir := filepath.Join(tmpDir, "testDirToIgnorePlease")
+			err = fs.MkDir(testDir)
+			require.NoError(t, err)
+
+			err = fs.MkDir(filepath.Join(tmpDir, "testDirToRemove"))
+			require.NoError(t, err)
+
+			checkNotEmpty(t, fs, tmpDir)
+
+			err = fs.CleanDirWithContextAndExclusionPatterns(context.TODO(), tmpDir, ".*ToIgnore.*")
+			require.NoError(t, err)
+			assert.True(t, fs.Exists(tmpDir))
+
+			empty, err = fs.IsEmpty(tmpDir)
+			require.NoError(t, err)
+			assert.False(t, empty)
+
+			var tree []string
+			err = fs.ListDirTree(tmpDir, &tree)
+			require.NoError(t, err)
+			require.Len(t, tree, 1)
+			assert.Equal(t, "testDirToIgnorePlease", filepath.Base(tree[0]))
+			_ = fs.Rm(tmpDir)
+		})
+	}
+}
+func TestRemoveWithExclusion(t *testing.T) {
+	for _, fsType := range FileSystemTypes {
+		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
+			fs := NewFs(fsType)
+			tmpDir, err := fs.TempDirInTempDir("test-rm-with-exclusion-")
+			require.NoError(t, err)
+			defer func() { _ = fs.Rm(tmpDir) }()
+
+			empty, err := fs.IsEmpty(tmpDir)
+			require.NoError(t, err)
+			assert.True(t, empty)
+
+			tmpFile, err := fs.TempFile(tmpDir, "test-rm-*.test")
+			require.NoError(t, err)
+			err = tmpFile.Close()
+			require.NoError(t, err)
+
+			checkNotEmpty(t, fs, tmpDir)
+
+			testDir := filepath.Join(tmpDir, "testDirToIgnorePlease")
+			err = fs.MkDir(testDir)
+			require.NoError(t, err)
+
+			err = fs.MkDir(filepath.Join(tmpDir, "testDirToRemove"))
+			require.NoError(t, err)
+
+			checkNotEmpty(t, fs, tmpDir)
+
+			err = fs.RemoveWithContextAndExclusionPatterns(context.TODO(), tmpDir, ".*ToIgnore.*")
+			require.NoError(t, err)
+			assert.True(t, fs.Exists(tmpDir))
+
+			empty, err = fs.IsEmpty(tmpDir)
+			require.NoError(t, err)
+			assert.False(t, empty)
+
+			var tree []string
+			err = fs.ListDirTree(tmpDir, &tree)
+			require.NoError(t, err)
+			require.Len(t, tree, 1)
+			assert.Equal(t, "testDirToIgnorePlease", filepath.Base(tree[0]))
+
+			err = fs.RemoveWithContextAndExclusionPatterns(context.TODO(), tmpDir, "test-rm-with-exclusion-.*")
+			require.NoError(t, err)
+			assert.True(t, fs.Exists(tmpDir))
+			empty, err = fs.IsEmpty(tmpDir)
+			require.NoError(t, err)
+			assert.True(t, empty)
+
+			_ = fs.Rm(tmpDir)
+		})
+	}
+}
+
 func TestLs(t *testing.T) {
 	for _, fsType := range FileSystemTypes {
 		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
@@ -663,13 +671,48 @@ func TestLs(t *testing.T) {
 	}
 }
 
+func TestLsWithExclusion(t *testing.T) {
+	for _, fsType := range FileSystemTypes {
+		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
+			fs := NewFs(fsType)
+			tmpDir, err := fs.TempDirInTempDir("test-ls-with-exclusion-")
+			require.NoError(t, err)
+			defer func() { _ = fs.Rm(tmpDir) }()
+
+			tmpDir1, err := fs.TempDir(tmpDir, "test-ls-")
+			require.NoError(t, err)
+			tmpFile, err := fs.TempFile(tmpDir, "test-ls-*.test")
+			require.NoError(t, err)
+
+			err = tmpFile.Close()
+			require.NoError(t, err)
+
+			fileName := tmpFile.Name()
+
+			files, err := fs.Ls(tmpDir)
+			require.NoError(t, err)
+			assert.Len(t, files, 2)
+
+			files, err = fs.LsWithExclusionPatterns(tmpDir, ".*[.]test")
+			require.NoError(t, err)
+			assert.Len(t, files, 1)
+
+			_, found := collection.Find(&files, filepath.Base(fileName))
+			assert.False(t, found)
+			_, found = collection.Find(&files, filepath.Base(tmpDir1))
+			assert.True(t, found)
+			_ = fs.Rm(tmpDir)
+		})
+	}
+}
+
 func TestWalk(t *testing.T) {
 	for _, fsType := range FileSystemTypes {
 		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
 			fs := NewFs(fsType)
 
 			// set up temp directory
-			tmpDir, err := fs.TempDirInTempDir("temp")
+			tmpDir, err := fs.TempDirInTempDir("test_walk")
 			require.NoError(t, err)
 			defer func() { _ = fs.Rm(tmpDir) }()
 
@@ -693,6 +736,51 @@ func TestWalk(t *testing.T) {
 
 			// check if equal
 			require.Equal(t, walkList, tree)
+		})
+	}
+}
+
+func TestWalkWithExclusions(t *testing.T) {
+	for _, fsType := range FileSystemTypes {
+		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
+			fs := NewFs(fsType)
+
+			// set up temp directory
+			tmpDir, err := fs.TempDirInTempDir("test_walk_with_exclusion")
+			require.NoError(t, err)
+			defer func() { _ = fs.Rm(tmpDir) }()
+
+			testDir := filepath.Join(tmpDir, "tree")
+			_ = fs.Rm(testDir)
+
+			// create a directory for the test
+			tree := createTestFileTree(t, fs, testDir, "", false, time.Now(), time.Now())
+			tree = append(tree, testDir) // Walk requires root too
+
+			exclusionPatterns := ".*test2.*"
+			var walkList []string
+			walkFunc := func(path string, info os.FileInfo, err error) error {
+				walkList = append(walkList, path)
+				return nil
+			}
+			err = fs.WalkWithContextAndExclusionPatterns(context.TODO(), testDir, walkFunc, exclusionPatterns)
+			require.NoError(t, err)
+
+			cleansedTree, err := ExcludeAll(tree, exclusionPatterns)
+			require.NoError(t, err)
+			assert.GreaterOrEqual(t, len(tree), len(cleansedTree))
+
+			// Sort lists so that equal works better
+			sort.Strings(cleansedTree)
+			sort.Strings(walkList)
+
+			// check if equal
+			require.Equal(t, walkList, cleansedTree)
+
+			walkList = nil
+			err = fs.WalkWithContextAndExclusionPatterns(context.TODO(), testDir, walkFunc, ".*tree.*")
+			require.NoError(t, err)
+			assert.Empty(t, walkList)
 		})
 	}
 }
@@ -759,74 +847,6 @@ func TestGarbageCollection(t *testing.T) {
 	}
 }
 
-func TestExcludes(t *testing.T) {
-	t.Parallel() // marks TLog as capable of running in parallel with other tests
-	var listOfPaths = []string{
-		"some/path", "somepath", ".snapshot", ".snapshot/path", "test/.snapshot/some/path", ".snapshot123", ".snapshot123/path", "test/.snapshot123/some-path", "test/.snapshot123/some/path",
-	}
-	tests := []struct {
-		inputlist       []string
-		exclusions      []string
-		expectedResults []string
-	}{
-		{
-			inputlist:       listOfPaths,
-			exclusions:      []string{},
-			expectedResults: listOfPaths,
-		},
-		{
-			inputlist:       listOfPaths,
-			exclusions:      []string{"noexclusion"},
-			expectedResults: listOfPaths,
-		},
-		{
-			inputlist:       []string{},
-			exclusions:      []string{"any"},
-			expectedResults: []string{},
-		},
-		{
-			inputlist:       listOfPaths,
-			exclusions:      []string{""},
-			expectedResults: listOfPaths,
-		},
-		{
-			inputlist:       listOfPaths,
-			exclusions:      []string{"some.*"},
-			expectedResults: []string{".snapshot", ".snapshot/path", ".snapshot123", ".snapshot123/path"},
-		},
-		{
-			inputlist:       listOfPaths,
-			exclusions:      []string{".*path"},
-			expectedResults: []string{".snapshot", ".snapshot123"},
-		},
-		{
-			inputlist:       listOfPaths,
-			exclusions:      []string{"[.]snapshot.*"},
-			expectedResults: []string{"some/path", "somepath"},
-		},
-		{
-			inputlist:       listOfPaths,
-			exclusions:      []string{"[.]snapshot.*/.*"},
-			expectedResults: []string{"some/path", "somepath", ".snapshot", ".snapshot123"},
-		},
-		{
-			inputlist:       listOfPaths,
-			exclusions:      []string{"[.]snapshot.*", ".*path"},
-			expectedResults: []string{},
-		},
-	}
-	for i, tt := range tests {
-		tt := tt // NOTE: https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
-		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
-			t.Parallel() // marks each test case as capable of running in parallel with each other
-			actualList, err := ExcludeAll(tt.inputlist, tt.exclusions...)
-			require.NoError(t, err)
-			assert.Equal(t, tt.expectedResults, actualList)
-		})
-	}
-
-}
-
 func TestFindAll(t *testing.T) {
 	for _, fsType := range FileSystemTypes {
 		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
@@ -868,9 +888,14 @@ func TestFindAll(t *testing.T) {
 			err = tmpFile3.Close()
 			require.NoError(t, err)
 
+			var tree []string
+			require.NoError(t, fs.ListDirTreeWithContextAndExclusionPatterns(context.TODO(), tmpDir, &tree, ".*[.]test[^13]"))
+			require.NotEmpty(t, tree)
+			assert.Len(t, tree, 5)
+
 			list, err := fs.FindAll(tmpDir, ".test1", "test3")
 			require.NoError(t, err)
-			assert.Equal(t, 2, len(list))
+			assert.Len(t, list, 2)
 
 			for _, file := range list {
 				ext := filepath.Ext(file)
@@ -907,6 +932,30 @@ func TestCopy(t *testing.T) {
 	}
 }
 
+func TestCopyWithExclusion(t *testing.T) {
+	for _, fsType := range FileSystemTypes {
+		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
+			fs := NewFs(fsType)
+			tmpDir, err := fs.TempDirInTempDir("test-copy-with-exclusion-")
+			require.NoError(t, err)
+			defer func() { _ = fs.Rm(tmpDir) }()
+
+			empty, err := fs.IsEmpty(tmpDir)
+			require.NoError(t, err)
+			assert.True(t, empty)
+
+			tmpFile, err := fs.TempFile(tmpDir, "test-copy-*.test")
+			require.NoError(t, err)
+			err = tmpFile.Close()
+			require.NoError(t, err)
+
+			checkNotEmpty(t, fs, tmpDir)
+			checkCopy(t, fs, tmpFile.Name(), filepath.Join(tmpDir, "newDir"), "test-copy-with-exclusion-.*")
+			_ = fs.Rm(tmpDir)
+		})
+	}
+}
+
 func TestCopyFolder(t *testing.T) {
 	for _, fsType := range FileSystemTypes {
 		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
@@ -932,6 +981,37 @@ func TestCopyFolder(t *testing.T) {
 
 			checkNotEmpty(t, fs, parentDir)
 			checkCopyDir(t, fs, parentDir, filepath.Join(testDir, "newDir"))
+		})
+	}
+}
+
+func TestCopyFolderWithExclusion(t *testing.T) {
+	for _, fsType := range FileSystemTypes {
+		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
+			fs := NewFs(fsType)
+			tmpDir, err := fs.TempDirInTempDir("test-src-copy-with-exclusion-")
+			require.NoError(t, err)
+			defer func() {
+				_ = fs.Rm(tmpDir)
+			}()
+
+			parentDir, err := fs.TempDir(tmpDir, "parentDir-")
+			require.NoError(t, err)
+
+			childDir, err := fs.TempDir(parentDir, "childDir-")
+			require.NoError(t, err)
+
+			_, err = fs.TempDir(childDir, "gcDir-")
+			require.NoError(t, err)
+
+			testDir, err := fs.TempDirInTempDir("test-dest-dir-")
+			require.NoError(t, err)
+			defer func() {
+				_ = fs.Rm(testDir)
+			}()
+
+			checkNotEmpty(t, fs, parentDir)
+			checkCopyDir(t, fs, parentDir, filepath.Join(testDir, "newDir"), "childDir-.*")
 		})
 	}
 }
@@ -1023,223 +1103,77 @@ func TestGetFileSize(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestUnzip_Limits(t *testing.T) {
-	fs := NewFs(StandardFS)
-
-	testInDir := "testdata"
-	testFile := "validlargezipfile"
-	srcPath := filepath.Join(testInDir, testFile+".zip")
-	destPath, err := fs.TempDirInTempDir("unzip-limits-")
-	require.NoError(t, err)
-	defer func() { _ = fs.Rm(destPath) }()
-	limits := NewLimits(1<<30, 1<<10, 1000000) // Total size limited to 10 Kb
-
-	empty, err := fs.IsEmpty(destPath)
-	assert.NoError(t, err)
-	assert.True(t, empty)
-	_, err = fs.Unzip(srcPath, destPath)
-	assert.NoError(t, err)
-	empty, err = fs.IsEmpty(destPath)
-	assert.NoError(t, err)
-	assert.False(t, empty)
-
-	err = fs.CleanDirWithContext(context.Background(), destPath)
-	require.NoError(t, err)
-	empty, err = fs.IsEmpty(destPath)
-	assert.NoError(t, err)
-	assert.True(t, empty)
-
-	contextWithTimeOut, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
-	defer cancel()
-	_, err = fs.UnzipWithContext(contextWithTimeOut, srcPath, destPath)
-	assert.Error(t, err)
-	assert.True(t, commonerrors.Any(err, commonerrors.ErrTimeout))
-
-	err = fs.CleanDirWithContext(context.Background(), destPath)
-	require.NoError(t, err)
-	empty, err = fs.IsEmpty(destPath)
-	assert.NoError(t, err)
-	assert.True(t, empty)
-
-	_, err = fs.UnzipWithContextAndLimits(context.Background(), srcPath, destPath, limits)
-	assert.Error(t, err)
-	assert.True(t, commonerrors.Any(err, commonerrors.ErrTooLarge))
-}
-
-func TestUnzip_ZipBomb(t *testing.T) {
-	// See description of ZIP bombs https://en.wikipedia.org/wiki/Zip_bomb
-	// Until protection is part of Go https://github.com/golang/go/issues/33026 & https://github.com/golang/go/issues/33036
-	tests := []struct {
-		testFile string
-	}{
-		{
-			testFile: "42", // See https://unforgettable.dk/
-		},
-		{
-			testFile: "zbsm", // See https://www.bamsoftware.com/hacks/zipbomb/
-		},
-	}
-
-	fs := NewFs(StandardFS)
-	testInDir := "testdata"
-	destPath, err := fs.TempDirInTempDir("unzip-limits-")
-	require.NoError(t, err)
-	defer func() { _ = fs.Rm(destPath) }()
-	limits := NewLimits(1<<30, 1<<20, 1000000) // Total size limited to 1 Mb
-
-	empty, err := fs.IsEmpty(destPath)
-	assert.NoError(t, err)
-	assert.True(t, empty)
-
-	for i := range tests {
-		test := tests[i]
-		t.Run(test.testFile, func(t *testing.T) {
-			srcPath := filepath.Join(testInDir, test.testFile+".zip")
-
-			_, err = fs.UnzipWithContextAndLimits(context.Background(), srcPath, destPath, limits)
-			assert.Error(t, err)
-			assert.True(t, commonerrors.Any(err, commonerrors.ErrUnsupported, commonerrors.ErrTooLarge))
-		})
-	}
-
-}
-
-func TestUnzip(t *testing.T) {
-	fs := NewFs(StandardFS)
-
-	testInDir := "testdata"
-	testFile := "testunzip"
-	srcPath := filepath.Join(testInDir, testFile+".zip")
-	destPath, err := fs.TempDirInTempDir("unzip")
-	require.NoError(t, err)
-	defer func() { _ = fs.Rm(destPath) }()
-	outPath := filepath.Join(destPath, testFile)
-	expectedfileList := []string{
-		filepath.Join(outPath, "readme.txt"),
-		filepath.Join(outPath, "test.txt"),
-		filepath.Join(outPath, "todo.txt"),
-		filepath.Join(outPath, "child.zip"),
-		filepath.Join(outPath, "L'irrǸsolution est toujours une marque de faiblesse.txt"),
-		filepath.Join(outPath, "ไป ไหน มา.txt"),
-	}
-	sort.Strings(expectedfileList)
-
-	/* Check Unzip */
-	fileList, err := fs.Unzip(srcPath, destPath)
-
-	sort.Strings(fileList)
-	assert.NoError(t, err)
-	assert.Equal(t, len(fileList), 6)
-	assert.Equal(t, expectedfileList, fileList)
-
-	/* Source zip file not available */
-	srcPath = filepath.Join(testInDir, "unknownfile.zip")
-	_, err = fs.Unzip(srcPath, destPath)
-	assert.Error(t, err)
-
-	/* Invalid source path */
-	srcPath = filepath.Join(testInDir, "invalidzipfile.zip")
-	_, err = fs.Unzip(srcPath, destPath)
-	assert.Error(t, err)
-}
-
-func TestUnzipWithNonUTF8Filenames(t *testing.T) {
-	fs := NewFs(StandardFS)
-	// Testing zip file attached to https://github.com/golang/go/issues/10741
-	testInDir := "testdata"
-	tests := []struct {
-		zipFile       string
-		expectedFiles []string
-		expectedError error
-	}{
-		{
-			zipFile: "zipwithnonutf8.zip",
-			expectedFiles: []string{
-				"La douceur du miel ne console pas de la piq�re de l'abeille.txt",
-				"\x83T\x83\x93\x83v\x83\x8b.txt",
-			},
-			expectedError: nil,
-		},
-		{
-			zipFile: "zipwithnonutf8filenames2.zip",
-			expectedFiles: []string{"examples",
-				filepath.Join("examples", "AN-32013 FT32F0XX\xb2\xce\xca\xfd.pdf"),
-				filepath.Join("examples", "BAT32G133_Packʹ\xd3\xc3˵\xc3\xf7.pdf"),
-				filepath.Join("examples", "OpenAtomFoundation_TencentOS-tiny_ \xcc\xdaѶ\xce\xef\xc1\xaa\xcd\xf8\xd6ն˲\xd9\xd7\xf7ϵͳ.html"),
-				filepath.Join("examples", "hello_world.c"),
-				filepath.Join("examples", "main.c"),
-			},
-			expectedError: nil,
-		},
-		// TODO create a zip file with non supported encoding
-		// {
-		//	zipFile:       ,
-		//	expectedFiles: nil,
-		//	expectedError: commonerrors.ErrInvalid,
-		// },
-	}
-	for i := range tests {
-		test := tests[i]
-		t.Run(fmt.Sprintf("zipfile_%v", test.zipFile), func(t *testing.T) {
-			srcPath := filepath.Join(testInDir, test.zipFile)
-			destPath, err := fs.TempDirInTempDir("unzip")
-			require.NoError(t, err)
-			defer func() { _ = fs.Rm(destPath) }()
-			/* Check Unzip */
-			fileList, err := fs.Unzip(srcPath, destPath)
-			if test.expectedError != nil {
-				require.Error(t, err)
-				assert.True(t, commonerrors.Any(err, test.expectedError))
-				assert.Empty(t, fileList)
-			} else {
-				require.NoError(t, err)
-				sort.Strings(fileList)
-				var expectedFiles []string
-				for j := range test.expectedFiles {
-					expectedFiles = append(expectedFiles, filepath.Join(destPath, test.expectedFiles[j]))
-				}
-				sort.Strings(expectedFiles)
-				assert.NoError(t, err)
-
-				assert.Equal(t, len(fileList), len(test.expectedFiles))
-				assert.Equal(t, expectedFiles, fileList)
-			}
-			_ = fs.Rm(destPath)
-		})
-	}
-
-}
-
 func TestSubDirectories(t *testing.T) {
-	fs := NewFs(StandardFS)
-	testDir := "testdata"
+	for _, fsType := range FileSystemTypes {
+		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
+			fs := NewFs(fsType)
+			tmpDir, err := fs.TempDirInTempDir("test-subdirectories-")
 
-	// Test empty directory
-	dirlist, err := fs.SubDirectories(testDir)
-	assert.Nil(t, dirlist)
-	assert.Nil(t, err)
+			// Test empty directory
+			dirlist, err := fs.SubDirectories(tmpDir)
+			assert.Empty(t, dirlist)
+			assert.NoError(t, err)
+			empty, err := fs.IsEmpty(tmpDir)
+			assert.NoError(t, err)
+			assert.True(t, empty)
 
-	// Test directory with subdirectories
-	testInput := filepath.Join(testDir, "ARM")
-	_ = fs.MkDir(filepath.Join(testInput, "CMSIS"))
-	_ = fs.MkDir(filepath.Join(testInput, "Tools"))
-	file, _ := fs.CreateFile(filepath.Join(testInput, "testfile.ini"))
-	defer func() {
-		_ = file.Close()
-		_ = fs.Rm(testInput)
-	}()
+			// Test directory with subdirectories
+			testInput := filepath.Join(tmpDir, "ARM")
+			require.NoError(t, fs.MkDir(filepath.Join(testInput, ".CMSIS")))
+			require.NoError(t, fs.MkDir(filepath.Join(testInput, ".git")))
+			require.NoError(t, fs.MkDir(filepath.Join(testInput, "CMSIS")))
+			require.NoError(t, fs.MkDir(filepath.Join(testInput, "Tools")))
+			file, err := fs.CreateFile(filepath.Join(testInput, "testfile.ini"))
+			require.NoError(t, err)
+			require.NoError(t, file.Close())
 
-	dirlist, err = fs.SubDirectories(testInput)
-	expected := []string{"CMSIS", "Tools"}
-	assert.Equal(t, expected, dirlist)
-	assert.Nil(t, err)
+			dirlist, err = fs.SubDirectories(testInput)
+			assert.NoError(t, err)
+			assert.Len(t, dirlist, 2)
+			sort.Strings(dirlist)
+
+			expected := []string{"CMSIS", "Tools"}
+			assert.Equal(t, expected, dirlist)
+
+			require.NoError(t, fs.Rm(testInput))
+		})
+	}
+}
+
+func TestSubDirectoriesWithExclusion(t *testing.T) {
+	for _, fsType := range FileSystemTypes {
+		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
+			fs := NewFs(fsType)
+			tmpDir, err := fs.TempDirInTempDir("test-subdirectories-with-exclusion-")
+
+			// Test directory with subdirectories
+			testInput := filepath.Join(tmpDir, "ARM")
+			require.NoError(t, fs.MkDir(filepath.Join(testInput, ".CMSIS")))
+			require.NoError(t, fs.MkDir(filepath.Join(testInput, ".git")))
+			require.NoError(t, fs.MkDir(filepath.Join(testInput, "CMSIS")))
+			require.NoError(t, fs.MkDir(filepath.Join(testInput, "Tools")))
+			file, err := fs.CreateFile(filepath.Join(testInput, "testfile.ini"))
+			require.NoError(t, err)
+			require.NoError(t, file.Close())
+
+			dirlist, err := fs.SubDirectoriesWithContextAndExclusionPatterns(context.TODO(), testInput, ".*CMSIS.*")
+			assert.NoError(t, err)
+			assert.Len(t, dirlist, 2)
+			sort.Strings(dirlist)
+
+			expected := []string{".git", "Tools"}
+			assert.Equal(t, expected, dirlist)
+
+			require.NoError(t, fs.Rm(testInput))
+		})
+	}
 }
 
 func TestListDirTree(t *testing.T) {
 	for _, fsType := range FileSystemTypes {
 		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
 			fs := NewFs(fsType)
-			testDir, err := fs.TempDirInTempDir("test-list-Dir")
+			testDir, err := fs.TempDirInTempDir("test-list-tree")
 			require.NoError(t, err)
 			defer func() { _ = fs.Rm(testDir) }()
 
@@ -1263,9 +1197,9 @@ func TestListDirTree(t *testing.T) {
 
 			checkNotEmpty(t, fs, testDir)
 
-			list := []string{}
+			var list []string
 			err = fs.ListDirTree(testDir, &list)
-			assert.Equal(t, 4, len(list))
+			assert.Len(t, list, 4)
 			require.NoError(t, err)
 
 			parentDir := filepath.Base(parentDirPath)
@@ -1279,6 +1213,65 @@ func TestListDirTree(t *testing.T) {
 				filepath.Join(string(fs.PathSeparator()), parentDir, childDir),
 				filepath.Join(string(fs.PathSeparator()), parentDir, childDir, gcDir),
 				filepath.Join(string(fs.PathSeparator()), testFileName)}
+
+			for _, item := range list {
+				fileList = append(fileList, strings.ReplaceAll(item, filepath.Dir(parentDirPath), ""))
+			}
+
+			sort.Strings(fileList)
+			sort.Strings(expectedList)
+			assert.True(t, reflect.DeepEqual(fileList, expectedList))
+		})
+	}
+}
+
+func TestListDirTreeWithExclusion(t *testing.T) {
+	for _, fsType := range FileSystemTypes {
+		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
+			fs := NewFs(fsType)
+			testDir, err := fs.TempDirInTempDir("test-list-tree-with-exclusion")
+			require.NoError(t, err)
+			defer func() { _ = fs.Rm(testDir) }()
+
+			empty, err := fs.IsEmpty(testDir)
+			require.NoError(t, err)
+			assert.True(t, empty)
+
+			parentDirPath, err := fs.TempDir(testDir, "parentDir-")
+			require.NoError(t, err)
+
+			testFile, err := fs.TempFile(testDir, "test-file-*.test")
+			require.NoError(t, err)
+			err = testFile.Close()
+			require.NoError(t, err)
+
+			childDirPath, err := fs.TempDir(parentDirPath, "childDir-")
+			require.NoError(t, err)
+
+			_, err = fs.TempDir(childDirPath, "gcDir-")
+			require.NoError(t, err)
+			_, err = fs.TempDir(childDirPath, "gcDir-1234-")
+			require.NoError(t, err)
+
+			checkNotEmpty(t, fs, testDir)
+
+			var list []string
+			err = fs.ListDirTree(testDir, &list)
+			assert.Len(t, list, 5)
+			require.NoError(t, err)
+			list = nil
+			err = fs.ListDirTreeWithContextAndExclusionPatterns(context.TODO(), testDir, &list, ".*[.]test", "gcDir-.*")
+			assert.Len(t, list, 2)
+			require.NoError(t, err)
+
+			parentDir := filepath.Base(parentDirPath)
+			childDir := filepath.Base(childDirPath)
+
+			var fileList []string
+			var expectedList = []string{
+				filepath.Join(string(fs.PathSeparator()), parentDir),
+				filepath.Join(string(fs.PathSeparator()), parentDir, childDir),
+			}
 
 			for _, item := range list {
 				fileList = append(fileList, strings.ReplaceAll(item, filepath.Dir(parentDirPath), ""))
@@ -1306,63 +1299,29 @@ func TestFilepathStem(t *testing.T) {
 	})
 }
 
-func TestUnzipFileCountLimit(t *testing.T) {
-	fs := NewFs(StandardFS)
-
-	testInDir := "testdata"
-	limits := NewLimits(1<<30, 10<<30, 10)
-
-	t.Run("unzip file above file count limit", func(t *testing.T) {
-		testFile := "abovefilecountlimitzip"
-		srcPath := filepath.Join(testInDir, testFile+".zip")
-
-		destPath, err := fs.TempDirInTempDir("unzip-limits-")
-		assert.NoError(t, err)
-		defer func() {
-			_ = fs.Rm(destPath)
-		}()
-
-		_, err = fs.UnzipWithContextAndLimits(context.TODO(), srcPath, destPath, limits)
-		assert.True(t, commonerrors.Any(err, commonerrors.ErrTooLarge))
-	})
-
-	t.Run("unzip file below file count limit", func(t *testing.T) {
-		testFile := "belowfilecountlimitzip"
-		srcPath := filepath.Join(testInDir, testFile+".zip")
-
-		destPath, err := fs.TempDirInTempDir("unzip-limits-")
-		assert.NoError(t, err)
-
-		defer func() {
-			if tempErr := fs.Rm(destPath); tempErr != nil {
-				err = tempErr
-			}
-		}()
-
-		_, err = fs.UnzipWithContextAndLimits(context.TODO(), srcPath, destPath, limits)
-		assert.NoError(t, err)
-	})
-}
-
-func checkCopyDir(t *testing.T, fs FS, src string, dest string) {
+func checkCopyDir(t *testing.T, fs FS, src string, dest string, exclusionPattern ...string) {
 	assert.True(t, fs.Exists(src))
 	assert.False(t, fs.Exists(dest))
-
-	err := fs.Copy(src, dest)
+	var err error
+	if reflection.IsEmpty(exclusionPattern) {
+		err = fs.Copy(src, dest)
+	} else {
+		err = fs.CopyWithContextAndExclusionPatterns(context.TODO(), src, dest, exclusionPattern...)
+	}
 	require.NoError(t, err)
 
 	defer func() { _ = fs.Rm(dest) }()
 	assert.True(t, fs.Exists(src))
 	assert.True(t, fs.Exists(dest))
 
-	srcFiles := []string{}
-	destFiles := []string{}
+	var srcFiles []string
+	var destFiles []string
 
-	err = fs.ListDirTree(src, &srcFiles)
+	err = fs.ListDirTreeWithContextAndExclusionPatterns(context.TODO(), src, &srcFiles, exclusionPattern...)
 	require.NoError(t, err)
 
 	destPath := filepath.Join(dest, filepath.Base(src))
-	err = fs.ListDirTree(destPath, &destFiles)
+	err = fs.ListDirTreeWithContextAndExclusionPatterns(context.TODO(), destPath, &destFiles, exclusionPattern...)
 	require.NoError(t, err)
 
 	var srcContent []string
@@ -1380,7 +1339,7 @@ func checkCopyDir(t *testing.T, fs FS, src string, dest string) {
 	assert.True(t, reflect.DeepEqual(srcContent, destContent))
 }
 
-func checkCopy(t *testing.T, fs FS, oldFile string, dest string) {
+func checkCopy(t *testing.T, fs FS, oldFile string, dest string, exclusionPattern ...string) {
 
 	assert.True(t, fs.Exists(oldFile))
 	assert.False(t, fs.Exists(dest))
@@ -1388,16 +1347,29 @@ func checkCopy(t *testing.T, fs FS, oldFile string, dest string) {
 	empty, err := fs.IsEmpty(oldFile)
 	require.NoError(t, err)
 
-	err = fs.Copy(oldFile, dest)
+	if reflection.IsEmpty(exclusionPattern) {
+		err = fs.Copy(oldFile, dest)
+	} else {
+		err = fs.CopyWithContextAndExclusionPatterns(context.TODO(), oldFile, dest, exclusionPattern...)
+	}
 	require.NoError(t, err)
-
 	defer func() { _ = fs.Rm(dest) }()
-	assert.True(t, fs.Exists(oldFile))
-	assert.True(t, fs.Exists(dest))
 
-	empty2, err := fs.IsEmpty(filepath.Join(dest, filepath.Base(oldFile)))
-	require.NoError(t, err)
-	assert.Equal(t, empty, empty2)
+	assert.True(t, fs.Exists(oldFile))
+	if reflection.IsEmpty(exclusionPattern) {
+		assert.True(t, fs.Exists(dest))
+
+		empty2, err := fs.IsEmpty(filepath.Join(dest, filepath.Base(oldFile)))
+		require.NoError(t, err)
+		assert.Equal(t, empty, empty2)
+	} else {
+		if IsPathExcludedFromPatterns(dest, fs.PathSeparator(), exclusionPattern...) || IsPathExcludedFromPatterns(oldFile, fs.PathSeparator(), exclusionPattern...) {
+			assert.False(t, fs.Exists(dest))
+		} else {
+			assert.True(t, fs.Exists(dest))
+		}
+	}
+	require.NoError(t, fs.Rm(dest))
 }
 
 func checkMove(t *testing.T, fs FS, oldFile string, newFile string) {

--- a/utils/filesystem/files_test.go
+++ b/utils/filesystem/files_test.go
@@ -1108,6 +1108,7 @@ func TestSubDirectories(t *testing.T) {
 		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
 			fs := NewFs(fsType)
 			tmpDir, err := fs.TempDirInTempDir("test-subdirectories-")
+			require.NoError(t, err)
 
 			// Test empty directory
 			dirlist, err := fs.SubDirectories(tmpDir)
@@ -1145,6 +1146,7 @@ func TestSubDirectoriesWithExclusion(t *testing.T) {
 		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
 			fs := NewFs(fsType)
 			tmpDir, err := fs.TempDirInTempDir("test-subdirectories-with-exclusion-")
+			require.NoError(t, err)
 
 			// Test directory with subdirectories
 			testInput := filepath.Join(tmpDir, "ARM")

--- a/utils/filesystem/zip.go
+++ b/utils/filesystem/zip.go
@@ -1,0 +1,355 @@
+package filesystem
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"go.uber.org/atomic"
+	"golang.org/x/text/encoding/unicode"
+
+	"github.com/ARM-software/golang-utils/utils/charset"
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/parallelisation"
+)
+
+// Zip zips a source directory into a destination archive
+func Zip(source string, destination string) error {
+	return globalFileSystem.Zip(source, destination)
+}
+
+func (fs *VFS) Zip(source, destination string) error {
+	return fs.ZipWithContext(context.Background(), source, destination)
+}
+
+func (fs *VFS) ZipWithContext(ctx context.Context, source, destination string) (err error) {
+	return fs.ZipWithContextAndLimits(ctx, source, destination, NoLimits())
+}
+
+func (fs *VFS) ZipWithContextAndLimits(ctx context.Context, source, destination string, limits ILimits) error {
+	return fs.ZipWithContextAndLimitsAndExclusionPatterns(ctx, source, destination, limits)
+}
+
+func (fs *VFS) ZipWithContextAndLimitsAndExclusionPatterns(ctx context.Context, source string, destination string, limits ILimits, exclusionPatterns ...string) (err error) {
+	if limits == nil {
+		err = fmt.Errorf("%w: missing file system limits", commonerrors.ErrUndefined)
+		return
+	}
+
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+
+	file, err := fs.CreateFile(destination)
+	if err != nil {
+		return
+	}
+	defer func() { _ = file.Close() }()
+
+	// create a new zip archive
+	w := zip.NewWriter(file)
+	defer func() { _ = w.Close() }()
+
+	walker := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if limits.Apply() && info.Size() > limits.GetMaxFileSize() {
+			err = fmt.Errorf("%w: file [%v] is too big (%v B) and beyond limits (max: %v B)", commonerrors.ErrTooLarge, path, info.Size(), limits.GetMaxFileSize())
+			return err
+		}
+
+		// Get the relative path
+		relPath, err := filepath.Rel(source, path)
+		if err != nil {
+			return err
+		}
+
+		// If directory
+		if info.IsDir() {
+			if path == source {
+				return nil
+			}
+			header := &zip.FileHeader{
+				Name:     relPath + "/",
+				Method:   zip.Deflate,
+				Modified: info.ModTime(),
+			}
+			_, err = w.CreateHeader(header)
+			return err
+		}
+
+		// if file
+		src, err := fs.GenericOpen(path)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = src.Close() }()
+
+		// create file in archive
+		relPath, err = filepath.Rel(source, path)
+		if err != nil {
+			return err
+		}
+		header := &zip.FileHeader{
+			Name:     relPath,
+			Method:   zip.Deflate,
+			Modified: info.ModTime(),
+		}
+		dest, err := w.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+		n, err := io.Copy(dest, src)
+		if err != nil {
+			return err
+		}
+
+		if info.Size() != n && !IsSymLink(info) {
+			return fmt.Errorf("could not write the full file [%v] content (wrote %v/%v bytes)", relPath, n, info.Size())
+		}
+		return nil
+	}
+	err = fs.WalkWithContextAndExclusionPatterns(ctx, source, walker, exclusionPatterns...)
+
+	if limits.Apply() {
+		stat, subErr := file.Stat()
+		if subErr != nil {
+			return subErr
+		}
+		if stat.Size() > limits.GetMaxFileSize() {
+			subErr = fmt.Errorf("%w: file [%v] is too big (%v B) and beyond limits (max: %v B)", commonerrors.ErrTooLarge, destination, stat.Size(), limits.GetMaxFileSize())
+			return subErr
+		}
+	}
+	return
+}
+
+// Prevents any ZipSlip (files outside extraction dirPath) https://snyk.io/research/zip-slip-vulnerability#go
+func sanitiseZipExtractPath(fs FS, filePath string, destination string) (destPath string, err error) {
+	destPath = filepath.Join(destination, filePath) // join cleans the destpath so we can check for ZipSlip
+	if destPath == destination {
+		return
+	}
+	if strings.HasPrefix(destPath, fmt.Sprintf("%v%v", destination, string(fs.PathSeparator()))) {
+		return
+	}
+	if strings.HasPrefix(destPath, fmt.Sprintf("%v/", destination)) {
+		return
+	}
+	err = fmt.Errorf("%w: zipslip security breach detected, file dirPath '%s' not in destination directory '%s'", commonerrors.ErrInvalidDestination, filePath, destination)
+	return
+}
+
+// Unzip unzips an source archive file into destination.
+func Unzip(source, destination string) ([]string, error) {
+	return globalFileSystem.Unzip(source, destination)
+}
+
+func (fs *VFS) Unzip(source, destination string) ([]string, error) {
+	return fs.UnzipWithContext(context.Background(), source, destination)
+}
+
+func (fs *VFS) UnzipWithContext(ctx context.Context, source string, destination string) (fileList []string, err error) {
+	return fs.unzip(ctx, source, destination, NoLimits())
+}
+func (fs *VFS) UnzipWithContextAndLimits(ctx context.Context, source string, destination string, limits ILimits) (fileList []string, err error) {
+	return fs.unzip(ctx, source, destination, limits)
+}
+func (fs *VFS) unzip(ctx context.Context, source string, destination string, limits ILimits) (fileList []string, err error) {
+	if limits == nil {
+		err = fmt.Errorf("%w: missing file system limits", commonerrors.ErrUndefined)
+		return
+	}
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+
+	fileCounter := atomic.NewUint64(0)
+
+	// List of file paths to return
+	totalSizeOnDisk := atomic.NewUint64(0)
+
+	info, err := fs.Lstat(source)
+	if err != nil {
+		return
+	}
+	f, err := fs.GenericOpen(source)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+
+	zipFileSize := info.Size()
+
+	if limits.Apply() && zipFileSize > limits.GetMaxFileSize() {
+		err = fmt.Errorf("%w: zip file [%v] is too big (%v B) and beyond limits (max: %v B)", commonerrors.ErrTooLarge, source, zipFileSize, limits.GetMaxFileSize())
+		return
+	}
+
+	zipReader, err := zip.NewReader(f, zipFileSize)
+	if err != nil {
+		return
+	}
+
+	// Clean the destination to find shortest dirPath
+	destination = filepath.Clean(destination)
+	err = fs.MkDir(destination)
+	if err != nil {
+		return
+	}
+	directoryInfo := map[string]os.FileInfo{}
+
+	// For each file in the zip file
+	for i := range zipReader.File {
+		fileCounter.Inc()
+
+		zippedFile := zipReader.File[i]
+		subErr := parallelisation.DetermineContextError(ctx)
+		if subErr != nil {
+			return fileList, subErr
+		}
+
+		// Calculate file dirPath
+		filePath, subErr := sanitiseZipExtractPath(fs, zippedFile.Name, destination)
+		if subErr != nil {
+			return fileList, subErr
+		}
+
+		// Keep list of files unzipped
+		fileList = append(fileList, filePath)
+
+		if zippedFile.FileInfo().IsDir() {
+			// Create directory
+			subErr = fs.MkDir(filePath)
+
+			if subErr != nil {
+				return fileList, fmt.Errorf("unable to create directory [%s]: %w", filePath, subErr)
+			}
+			// recording directory dirInfo to preserve timestamps
+			directoryInfo[filePath] = zippedFile.FileInfo()
+			// Nothing more to do for a directory, move to next zip file
+			continue
+		}
+
+		// If a file create the dirPath into which to write the file
+		directoryPath := filepath.Dir(filePath)
+		subErr = fs.MkDir(directoryPath)
+		if subErr != nil {
+			return fileList, fmt.Errorf("unable to create directory '%s': %w", directoryPath, subErr)
+		}
+
+		fileSizeOnDisk, subErr := fs.unzipZipFile(ctx, filePath, zippedFile, limits)
+		if subErr != nil {
+			return fileList, subErr
+		}
+		totalSizeOnDisk.Add(uint64(fileSizeOnDisk))
+		if limits.Apply() && totalSizeOnDisk.Load() > limits.GetMaxTotalSize() {
+			return fileList, fmt.Errorf("%w: more than %v B of disk space was used while unzipping %v (%v B used already)", commonerrors.ErrTooLarge, limits.GetMaxTotalSize(), source, totalSizeOnDisk.Load())
+		}
+		if limits.Apply() && int64(fileCounter.Load()) > limits.GetMaxFileCount() {
+			return fileList, fmt.Errorf("%w: more than %v files were created while unzipping %v (%v files created already)", commonerrors.ErrTooLarge, limits.GetMaxFileCount(), source, fileCounter)
+		}
+	}
+
+	// Ensuring directory timestamps are preserved (this needs to be done after all the files have been created).
+	for dirPath, dirInfo := range directoryInfo {
+		subErr := parallelisation.DetermineContextError(ctx)
+		if subErr != nil {
+			return fileList, subErr
+		}
+		times := newDefaultTimeInfo(dirInfo)
+		subErr = fs.Chtimes(dirPath, times.AccessTime(), times.ModTime())
+		if subErr != nil {
+			return fileList, fmt.Errorf("unable to set directory timestamp [%s]: %w", dirPath, subErr)
+		}
+	}
+
+	return fileList, nil
+}
+
+// unzipZipFile unzips file to destination directory
+func (fs *VFS) unzipZipFile(ctx context.Context, dest string, zippedFile *zip.File, limits ILimits) (fileSizeOnDisk int64, err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+
+	destinationPath, err := determineUnzippedFilepath(dest)
+	if err != nil {
+		return
+	}
+
+	destinationFile, err := fs.OpenFile(destinationPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, zippedFile.Mode())
+	if err != nil {
+		err = fmt.Errorf("%w: unable to open file '%s': %v", commonerrors.ErrUnexpected, destinationPath, err.Error())
+		return
+	}
+	defer func() { _ = destinationFile.Close() }()
+
+	sourceFile, err := zippedFile.Open()
+	if err != nil {
+		err = fmt.Errorf("%w: unable to open zipped file '%s': %v", commonerrors.ErrUnsupported, zippedFile.Name, err.Error())
+		return
+	}
+	defer func() { _ = sourceFile.Close() }()
+
+	info := zippedFile.FileInfo()
+	fileSizeOnDisk = info.Size()
+	if limits.Apply() {
+		if fileSizeOnDisk > limits.GetMaxFileSize() {
+			err = fmt.Errorf("%w: zipped file [%v] is too big (%v B) and above max size (%v B)", commonerrors.ErrTooLarge, info.Name(), info.Size(), limits.GetMaxFileSize())
+			return
+		}
+	}
+
+	_, err = io.CopyN(destinationFile, sourceFile, fileSizeOnDisk)
+	if err != nil {
+		err = fmt.Errorf("copy of zipped file to '%s' failed: %w", destinationPath, err)
+		return
+	}
+	err = destinationFile.Close()
+	if err != nil {
+		return
+	}
+	// Ensuring the timestamp is preserved.
+	times := newDefaultTimeInfo(info)
+	err = fs.Chtimes(destinationPath, times.AccessTime(), times.ModTime())
+	// Nothing more to do for a directory, move to next zip file
+	return
+}
+
+func determineUnzippedFilepath(destinationPath string) (string, error) {
+
+	// See https://go-review.googlesource.com/c/go/+/75592/
+	// Character encodings other than CP-437 and UTF-8
+	// are not officially supported by the ZIP specification, pragmatically
+	// the world has permitted use of them.
+	//
+	// When a non-standard encoding is used, it is the user's responsibility
+	// to ensure that the target system is expecting the encoding used
+	// (e.g., producing a ZIP file you know is used on a Chinese version of Windows).
+	if utf8.ValidString(destinationPath) {
+		return destinationPath, nil
+	}
+	// Nonetheless, instead of raising an error when non-UTF8 characters are present in filepath,
+	// we try to guess the encoding and then, convert the string to UTF-8.
+	encoding, charsetName, err := charset.DetectTextEncoding([]byte(destinationPath))
+	if err != nil {
+		return "", fmt.Errorf("%w: file path [%s] is not a valid utf-8 string and charset could not be detected: %v", commonerrors.ErrInvalid, destinationPath, err.Error())
+	}
+	convertedDestinationPath, err := charset.IconvString(destinationPath, encoding, unicode.UTF8)
+	if err != nil {
+		return "", fmt.Errorf("%w: file path [%s] is encoded using charset [%v] but could not be converted to valid utf-8: %v", commonerrors.ErrUnexpected, destinationPath, charsetName, err.Error())
+		// If zip file paths must be accepted even when their encoding is unknown, or conversion to utf-8 failed, then the following can be done.
+		// destinationPath = strings.ToValidUTF8(dest, charset.InvalidUTF8CharacterReplacement)
+	}
+	return convertedDestinationPath, err
+}

--- a/utils/mocks/mock_filesystem.go
+++ b/utils/mocks/mock_filesystem.go
@@ -954,6 +954,25 @@ func (mr *MockFSMockRecorder) CleanDirWithContext(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanDirWithContext", reflect.TypeOf((*MockFS)(nil).CleanDirWithContext), arg0, arg1)
 }
 
+// CleanDirWithContextAndExclusionPatterns mocks base method.
+func (m *MockFS) CleanDirWithContextAndExclusionPatterns(arg0 context.Context, arg1 string, arg2 ...string) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CleanDirWithContextAndExclusionPatterns", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanDirWithContextAndExclusionPatterns indicates an expected call of CleanDirWithContextAndExclusionPatterns.
+func (mr *MockFSMockRecorder) CleanDirWithContextAndExclusionPatterns(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanDirWithContextAndExclusionPatterns", reflect.TypeOf((*MockFS)(nil).CleanDirWithContextAndExclusionPatterns), varargs...)
+}
+
 // ConvertFilePath mocks base method.
 func (m *MockFS) ConvertFilePath(arg0 string) string {
 	m.ctrl.T.Helper()
@@ -1034,6 +1053,25 @@ func (m *MockFS) CopyWithContext(arg0 context.Context, arg1, arg2 string) error 
 func (mr *MockFSMockRecorder) CopyWithContext(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyWithContext", reflect.TypeOf((*MockFS)(nil).CopyWithContext), arg0, arg1, arg2)
+}
+
+// CopyWithContextAndExclusionPatterns mocks base method.
+func (m *MockFS) CopyWithContextAndExclusionPatterns(arg0 context.Context, arg1, arg2 string, arg3 ...string) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CopyWithContextAndExclusionPatterns", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CopyWithContextAndExclusionPatterns indicates an expected call of CopyWithContextAndExclusionPatterns.
+func (mr *MockFSMockRecorder) CopyWithContextAndExclusionPatterns(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyWithContextAndExclusionPatterns", reflect.TypeOf((*MockFS)(nil).CopyWithContextAndExclusionPatterns), varargs...)
 }
 
 // CreateFile mocks base method.
@@ -1340,6 +1378,25 @@ func (mr *MockFSMockRecorder) ListDirTreeWithContext(arg0, arg1, arg2 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDirTreeWithContext", reflect.TypeOf((*MockFS)(nil).ListDirTreeWithContext), arg0, arg1, arg2)
 }
 
+// ListDirTreeWithContextAndExclusionPatterns mocks base method.
+func (m *MockFS) ListDirTreeWithContextAndExclusionPatterns(arg0 context.Context, arg1 string, arg2 *[]string, arg3 ...string) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListDirTreeWithContextAndExclusionPatterns", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ListDirTreeWithContextAndExclusionPatterns indicates an expected call of ListDirTreeWithContextAndExclusionPatterns.
+func (mr *MockFSMockRecorder) ListDirTreeWithContextAndExclusionPatterns(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDirTreeWithContextAndExclusionPatterns", reflect.TypeOf((*MockFS)(nil).ListDirTreeWithContextAndExclusionPatterns), varargs...)
+}
+
 // Lls mocks base method.
 func (m *MockFS) Lls(arg0 string) ([]fs.FileInfo, error) {
 	m.ctrl.T.Helper()
@@ -1398,6 +1455,26 @@ func (m *MockFS) LsFromOpenedDirectory(arg0 filesystem.File) ([]string, error) {
 func (mr *MockFSMockRecorder) LsFromOpenedDirectory(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LsFromOpenedDirectory", reflect.TypeOf((*MockFS)(nil).LsFromOpenedDirectory), arg0)
+}
+
+// LsWithExclusionPatterns mocks base method.
+func (m *MockFS) LsWithExclusionPatterns(arg0 string, arg1 ...string) ([]string, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "LsWithExclusionPatterns", varargs...)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LsWithExclusionPatterns indicates an expected call of LsWithExclusionPatterns.
+func (mr *MockFSMockRecorder) LsWithExclusionPatterns(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LsWithExclusionPatterns", reflect.TypeOf((*MockFS)(nil).LsWithExclusionPatterns), varargs...)
 }
 
 // Lstat mocks base method.
@@ -1588,6 +1665,25 @@ func (mr *MockFSMockRecorder) RemoveWithContext(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveWithContext", reflect.TypeOf((*MockFS)(nil).RemoveWithContext), arg0, arg1)
 }
 
+// RemoveWithContextAndExclusionPatterns mocks base method.
+func (m *MockFS) RemoveWithContextAndExclusionPatterns(arg0 context.Context, arg1 string, arg2 ...string) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RemoveWithContextAndExclusionPatterns", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveWithContextAndExclusionPatterns indicates an expected call of RemoveWithContextAndExclusionPatterns.
+func (mr *MockFSMockRecorder) RemoveWithContextAndExclusionPatterns(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveWithContextAndExclusionPatterns", reflect.TypeOf((*MockFS)(nil).RemoveWithContextAndExclusionPatterns), varargs...)
+}
+
 // Rm mocks base method.
 func (m *MockFS) Rm(arg0 string) error {
 	m.ctrl.T.Helper()
@@ -1660,6 +1756,26 @@ func (m *MockFS) SubDirectoriesWithContext(arg0 context.Context, arg1 string) ([
 func (mr *MockFSMockRecorder) SubDirectoriesWithContext(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubDirectoriesWithContext", reflect.TypeOf((*MockFS)(nil).SubDirectoriesWithContext), arg0, arg1)
+}
+
+// SubDirectoriesWithContextAndExclusionPatterns mocks base method.
+func (m *MockFS) SubDirectoriesWithContextAndExclusionPatterns(arg0 context.Context, arg1 string, arg2 ...string) ([]string, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "SubDirectoriesWithContextAndExclusionPatterns", varargs...)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SubDirectoriesWithContextAndExclusionPatterns indicates an expected call of SubDirectoriesWithContextAndExclusionPatterns.
+func (mr *MockFSMockRecorder) SubDirectoriesWithContextAndExclusionPatterns(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubDirectoriesWithContextAndExclusionPatterns", reflect.TypeOf((*MockFS)(nil).SubDirectoriesWithContextAndExclusionPatterns), varargs...)
 }
 
 // Symlink mocks base method.
@@ -1823,6 +1939,25 @@ func (mr *MockFSMockRecorder) WalkWithContext(arg0, arg1, arg2 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WalkWithContext", reflect.TypeOf((*MockFS)(nil).WalkWithContext), arg0, arg1, arg2)
 }
 
+// WalkWithContextAndExclusionPatterns mocks base method.
+func (m *MockFS) WalkWithContextAndExclusionPatterns(arg0 context.Context, arg1 string, arg2 filepath.WalkFunc, arg3 ...string) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WalkWithContextAndExclusionPatterns", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WalkWithContextAndExclusionPatterns indicates an expected call of WalkWithContextAndExclusionPatterns.
+func (mr *MockFSMockRecorder) WalkWithContextAndExclusionPatterns(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WalkWithContextAndExclusionPatterns", reflect.TypeOf((*MockFS)(nil).WalkWithContextAndExclusionPatterns), varargs...)
+}
+
 // WriteFile mocks base method.
 func (m *MockFS) WriteFile(arg0 string, arg1 []byte, arg2 fs.FileMode) error {
 	m.ctrl.T.Helper()
@@ -1877,4 +2012,23 @@ func (m *MockFS) ZipWithContextAndLimits(arg0 context.Context, arg1, arg2 string
 func (mr *MockFSMockRecorder) ZipWithContextAndLimits(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ZipWithContextAndLimits", reflect.TypeOf((*MockFS)(nil).ZipWithContextAndLimits), arg0, arg1, arg2, arg3)
+}
+
+// ZipWithContextAndLimitsAndExclusionPatterns mocks base method.
+func (m *MockFS) ZipWithContextAndLimitsAndExclusionPatterns(arg0 context.Context, arg1, arg2 string, arg3 filesystem.ILimits, arg4 ...string) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2, arg3}
+	for _, a := range arg4 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ZipWithContextAndLimitsAndExclusionPatterns", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ZipWithContextAndLimitsAndExclusionPatterns indicates an expected call of ZipWithContextAndLimitsAndExclusionPatterns.
+func (mr *MockFSMockRecorder) ZipWithContextAndLimitsAndExclusionPatterns(arg0, arg1, arg2, arg3 interface{}, arg4 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2, arg3}, arg4...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ZipWithContextAndLimitsAndExclusionPatterns", reflect.TypeOf((*MockFS)(nil).ZipWithContextAndLimitsAndExclusionPatterns), varargs...)
 }


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description
Expand APIs in the `filesystem` module to enable `negation patterns`



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
