### PR TITLE
:bug:`filesystem` fix regression with `Subdirectories`

### DIFF
--- a/changes/202210051012.bugfix
+++ b/changes/202210051012.bugfix
@@ -1,0 +1,1 @@
+`[filesystem]`: Fix the exclusion regex used in `subDirectories` to filter "hidden" folders

--- a/utils/filesystem/files.go
+++ b/utils/filesystem/files.go
@@ -1136,7 +1136,7 @@ func (fs *VFS) SubDirectories(directory string) ([]string, error) {
 }
 
 func (fs *VFS) SubDirectoriesWithContext(ctx context.Context, directory string) ([]string, error) {
-	return fs.SubDirectoriesWithContextAndExclusionPatterns(ctx, directory, "[.].*")
+	return fs.SubDirectoriesWithContextAndExclusionPatterns(ctx, directory, "^[.].*$")
 }
 func (fs *VFS) SubDirectoriesWithContextAndExclusionPatterns(ctx context.Context, directory string, exclusionPatterns ...string) (directories []string, err error) {
 	err = parallelisation.DetermineContextError(ctx)

--- a/utils/filesystem/files_test.go
+++ b/utils/filesystem/files_test.go
@@ -1122,6 +1122,8 @@ func TestSubDirectories(t *testing.T) {
 			testInput := filepath.Join(tmpDir, "ARM")
 			require.NoError(t, fs.MkDir(filepath.Join(testInput, ".CMSIS")))
 			require.NoError(t, fs.MkDir(filepath.Join(testInput, ".git")))
+			require.NoError(t, fs.MkDir(filepath.Join(testInput, "1Test")))
+			require.NoError(t, fs.MkDir(filepath.Join(testInput, "Test.Test")))
 			require.NoError(t, fs.MkDir(filepath.Join(testInput, "CMSIS")))
 			require.NoError(t, fs.MkDir(filepath.Join(testInput, "Tools")))
 			file, err := fs.CreateFile(filepath.Join(testInput, "testfile.ini"))
@@ -1130,12 +1132,11 @@ func TestSubDirectories(t *testing.T) {
 
 			dirlist, err = fs.SubDirectories(testInput)
 			assert.NoError(t, err)
-			assert.Len(t, dirlist, 2)
+			assert.Len(t, dirlist, 4)
 			sort.Strings(dirlist)
 
-			expected := []string{"CMSIS", "Tools"}
+			expected := []string{"1Test", "CMSIS", "Test.Test", "Tools"}
 			assert.Equal(t, expected, dirlist)
-
 			require.NoError(t, fs.Rm(testInput))
 		})
 	}


### PR DESCRIPTION


<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

Fix exclusion regex


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
