### PR TITLE
:lock: `[filesystem]` improve file writing and reading robustness

### DIFF
--- a/changes/20230105170818.feature
+++ b/changes/20230105170818.feature
@@ -1,0 +1,1 @@
+`[filesystem]` Extended potentially long running actions such as writing or reading files to be controlled by a context

--- a/utils/filesystem/interfaces.go
+++ b/utils/filesystem/interfaces.go
@@ -6,6 +6,7 @@ package filesystem
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -193,14 +194,26 @@ type FS interface {
 	TempDirectory() string
 	// CurrentDirectory returns current directory.
 	CurrentDirectory() (string, error)
-	// ReadFile reads a file and return its content.
+	// ReadFile reads a file and returns its content.
 	ReadFile(filename string) ([]byte, error)
-	// ReadFileWithLimits reads a file and return its content. Nonetheless, it stops with EOF after FileSystemLimits are exceeded.
+	// ReadFileWithContext reads a file but with control of a context and returns its content.
+	ReadFileWithContext(ctx context.Context, filename string) ([]byte, error)
+	// ReadFileWithLimits reads a file and returns its content. Nonetheless, it stops with EOF after FileSystemLimits are exceeded.
 	ReadFileWithLimits(filename string, limits ILimits) ([]byte, error)
+	// ReadFileWithContextAndLimits reads a file and returns its content. Limits and context are taken into account during the reading process.
+	ReadFileWithContextAndLimits(ctx context.Context, filename string, limits ILimits) ([]byte, error)
 	// WriteFile writes data to a file named by filename.
 	// If the file does not exist, WriteFile creates it with permissions perm;
 	// otherwise WriteFile truncates it before writing.
 	WriteFile(filename string, data []byte, perm os.FileMode) error
+	// WriteFileWithContext writes data to a file named by filename.
+	// It works like WriteFile but is also controlled by a context.
+	WriteFileWithContext(ctx context.Context, filename string, data []byte, perm os.FileMode) error
+	// WriteToFile writes data from a reader to a file named by filename.
+	// If the file does not exist, WriteToFile creates it with permissions perm;
+	// otherwise WriteFile truncates it before writing.
+	// It returns the number of bytes written.
+	WriteToFile(ctx context.Context, filename string, reader io.Reader, perm os.FileMode) (written int64, err error)
 	// GarbageCollect runs the Garbage collector on the filesystem (removes any file which has not been accessed for a certain duration)
 	GarbageCollect(root string, durationSinceLastAccess time.Duration) error
 	// GarbageCollectWithContext runs the Garbage collector on the filesystem (removes any file which has not been accessed for a certain duration)

--- a/utils/go.mod
+++ b/utils/go.mod
@@ -39,6 +39,8 @@ require (
 	golang.org/x/text v0.6.0
 )
 
+require github.com/dolmen-go/contextio v0.0.0-20220904134943-e50796217f5f
+
 require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect

--- a/utils/go.sum
+++ b/utils/go.sum
@@ -256,6 +256,8 @@ github.com/deckarep/golang-set v1.8.0 h1:sk9/l/KqpunDwP7pSjUg0keiOOLEnOBHzykLrsP
 github.com/deckarep/golang-set v1.8.0/go.mod h1:5nI87KwE7wgsBU1F4GKAw2Qod7p5kyS383rP6+o6qqo=
 github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
 github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=
+github.com/dolmen-go/contextio v0.0.0-20220904134943-e50796217f5f h1:ORMUh1YgoSZoBGaO/i1rGDNeEavjhSnDBQTH9OG8H+o=
+github.com/dolmen-go/contextio v0.0.0-20220904134943-e50796217f5f/go.mod h1:cxc20xI7fOgsFHWgt+PenlDDnMcrvh7Ocuj5hEFIdEk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
@@ -914,7 +916,6 @@ golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
-golang.org/x/text v0.5.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.6.0 h1:3XmdazWV+ubf7QgHSTWeykHOci5oeekaGJBLkrkaw4k=
 golang.org/x/text v0.6.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

- extended methods for writing and reading files so that they take a context into account and long running actions can be terminated



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
