### PR TITLE
:bug: `[pagination]` Fix panic in contructor

### DIFF
--- a/changes/20230121234948.bugfix
+++ b/changes/20230121234948.bugfix
@@ -1,0 +1,1 @@
+:bug:`[pagination]` Fix panic in contructor

--- a/utils/collection/pagination/stream.go
+++ b/utils/collection/pagination/stream.go
@@ -191,6 +191,9 @@ func NewStaticPageStreamPaginator(ctx context.Context, runOutTimeOut, backoff ti
 	parent, err := newAbstractStreamPaginator(ctx, runOutTimeOut, backoff, func(fCtx context.Context) (IStaticPage, error) {
 		return fetchFirstPageFunc(fCtx)
 	}, fetchNextPageFunc, fetchFutureFunc)
+	if err != nil {
+		return
+	}
 	paginator = &StaticPageStreamPaginator{
 		AbstractStreamPaginator: *parent,
 	}


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description
Fix panic in contructor



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
