### PR TITLE
:bug: `[filesystem]` Align `Copy` behaviour to `cp -r`

### DIFF
--- a/changes/20230126194148.bugfix
+++ b/changes/20230126194148.bugfix
@@ -1,0 +1,1 @@
+:bug:`[filesystem]` Fix `Copy` behaviour to match `cp -r` when destination does not exists

--- a/utils/filesystem/files.go
+++ b/utils/filesystem/files.go
@@ -1027,6 +1027,7 @@ func CopyBetweenFSWithExclusionRegexes(ctx context.Context, srcFs FS, src string
 		err = fmt.Errorf("path [%v] does not exist: %w", src, commonerrors.ErrNotFound)
 		return
 	}
+	destExists := destFs.Exists(dest)
 	err = destFs.MkDir(dest)
 	if err != nil {
 		return
@@ -1036,7 +1037,12 @@ func CopyBetweenFSWithExclusionRegexes(ctx context.Context, srcFs FS, src string
 	if err != nil {
 		return
 	}
-	dst := filepath.Join(dest, filepath.Base(src))
+	var dst string
+	if !(isDir && !destExists) {
+		dst = filepath.Join(dest, filepath.Base(src))
+	} else {
+		dst = dest
+	}
 	if isDir {
 		err = copyFolderBetweenFSWithExclusionRegexes(ctx, srcFs, src, destFs, dst, exclusionSrcFsRegexes, exclusionDestFsRegexes)
 	} else {

--- a/utils/filesystem/files_test.go
+++ b/utils/filesystem/files_test.go
@@ -8,8 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -298,70 +296,6 @@ func TestChown(t *testing.T) {
 	}
 }
 
-func createTestFileTree(t *testing.T, fs FS, testDir, basePath string, withLinks bool, fileModTime time.Time, fileAccessTime time.Time) []string {
-	err := fs.MkDir(testDir)
-	require.NoError(t, err)
-
-	var sLinks []string
-	rand.Seed(time.Now().UnixMilli())                                        //nolint:gosec //causes G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec), So disable gosec
-	for i := 0; i < int(math.Max(float64(1), float64(rand.Intn(10)))); i++ { //nolint:gosec //causes G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec), So disable gosec
-		c := fmt.Sprint("test", i+1)
-		path := filepath.Join(testDir, c)
-
-		err := fs.MkDir(path)
-		require.NoError(t, err)
-
-		for j := 0; j < int(math.Max(float64(1), float64(rand.Intn(10)))); j++ { //nolint:gosec //causes G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec), So disable gosec
-			c := fmt.Sprint("test", j+1)
-			path := filepath.Join(path, c)
-
-			err := fs.MkDir(path)
-			require.NoError(t, err)
-
-			if withLinks {
-				if len(sLinks) > 0 {
-					c1 := fmt.Sprint("link", j+1)
-					c2 := filepath.Join(path, c1)
-					err = fs.Symlink(sLinks[0], c2)
-					require.NoError(t, err)
-					if len(sLinks) > 1 {
-						sLinks = sLinks[1:]
-					} else {
-						sLinks = nil
-					}
-				}
-			}
-
-			for k := 0; k < int(math.Max(float64(1), float64(rand.Intn(10)))); k++ { //nolint:gosec //causes G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec), So disable gosec
-				c := fmt.Sprint("test", k+1, ".txt")
-				finalPath := filepath.Join(path, c)
-
-				// pick a couple of files to make symlinks (1 in 10)
-				r := rand.Intn(10) //nolint:gosec //causes G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec), So disable gosec
-				if r == 4 {
-					fPath := filepath.Join(basePath, path, c)
-					sLinks = append(sLinks, fPath)
-				}
-
-				s := fmt.Sprint("file ", i+1, j+1, k+1)
-				err = fs.WriteFile(finalPath, []byte(s), 0755)
-				require.NoError(t, err)
-			}
-		}
-	}
-	var tree []string
-	err = fs.ListDirTree(testDir, &tree)
-	require.NoError(t, err)
-
-	// unifying timestamps
-	for _, path := range tree {
-		err = fs.Chtimes(path, fileAccessTime, fileModTime)
-		require.NoError(t, err)
-	}
-
-	return tree
-}
-
 func TestConvertPaths(t *testing.T) {
 	for _, fsType := range FileSystemTypes {
 		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
@@ -373,7 +307,7 @@ func TestConvertPaths(t *testing.T) {
 			defer func() { _ = fs.Rm(tmpDir) }()
 
 			// create a directory for the test
-			tree := createTestFileTree(t, fs, tmpDir, "", false, time.Now(), time.Now())
+			tree := GenerateTestFileTree(t, fs, tmpDir, "", false, time.Now(), time.Now())
 			relTree, err := fs.ConvertToRelativePath(tmpDir, tree...)
 			require.NoError(t, err)
 			absTree, err := fs.ConvertToAbsolutePath(tmpDir, relTree...)
@@ -788,7 +722,7 @@ func TestWalk(t *testing.T) {
 			_ = fs.Rm(testDir)
 
 			// create a directory for the test
-			tree := createTestFileTree(t, fs, testDir, "", false, time.Now(), time.Now())
+			tree := GenerateTestFileTree(t, fs, testDir, "", false, time.Now(), time.Now())
 			tree = append(tree, testDir) // Walk requires root too
 
 			var walkList []string
@@ -822,7 +756,7 @@ func TestWalkWithExclusions(t *testing.T) {
 			_ = fs.Rm(testDir)
 
 			// create a directory for the test
-			tree := createTestFileTree(t, fs, testDir, "", false, time.Now(), time.Now())
+			tree := GenerateTestFileTree(t, fs, testDir, "", false, time.Now(), time.Now())
 			tree = append(tree, testDir) // Walk requires root too
 
 			exclusionPatterns := ".*test2.*"
@@ -1080,6 +1014,74 @@ func TestCopyFolderWithExclusion(t *testing.T) {
 
 			checkNotEmpty(t, fs, parentDir)
 			checkCopyDir(t, fs, parentDir, filepath.Join(testDir, "newDir"), "childDir-.*")
+		})
+	}
+}
+
+func TestCopyTreeWithExistingDestination(t *testing.T) {
+	for _, fsType := range FileSystemTypes {
+		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
+			fs := NewFs(fsType)
+			tmpDir, err := fs.TempDirInTempDir("test-copy-tree-with-existing-destination-")
+			require.NoError(t, err)
+			defer func() {
+				_ = fs.Rm(tmpDir)
+			}()
+			srcFolderName := "src"
+			src := filepath.Join(tmpDir, srcFolderName)
+			dest := filepath.Join(tmpDir, "dest")
+			err = fs.MkDir(dest)
+			require.NoError(t, err)
+
+			srcFileList := GenerateTestFileTree(t, fs, src, "", false, time.Now(), time.Now())
+			srcFileList, err = fs.ConvertToRelativePath(tmpDir, srcFileList...)
+			require.NoError(t, err)
+
+			err = fs.Copy(src, dest)
+			require.NoError(t, err)
+
+			var destFileList []string
+			err = fs.ListDirTree(dest, &destFileList)
+			require.NoError(t, err)
+			destFileList, err = fs.ConvertToRelativePath(dest, destFileList...)
+			require.NoError(t, err)
+
+			// the srcFolderName is present in the destination
+			srcFileList = append(srcFileList, srcFolderName)
+
+			assert.ElementsMatch(t, srcFileList, destFileList, "all items should have been copied and under the srcFolderName path")
+		})
+	}
+}
+
+func TestCopyTreeWithMissingDestination(t *testing.T) {
+	for _, fsType := range FileSystemTypes {
+		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
+			fs := NewFs(fsType)
+			tmpDir, err := fs.TempDirInTempDir("test-copy-tree-with-missing-destination-")
+			require.NoError(t, err)
+			defer func() {
+				_ = fs.Rm(tmpDir)
+			}()
+			srcFolderName := "src"
+			src := filepath.Join(tmpDir, srcFolderName)
+			dest := filepath.Join(tmpDir, "dest")
+
+			srcFileList := GenerateTestFileTree(t, fs, src, "", false, time.Now(), time.Now())
+			srcFileList, err = fs.ConvertToRelativePath(src, srcFileList...)
+			require.NoError(t, err)
+
+			err = fs.Copy(src, dest)
+			require.NoError(t, err)
+
+			var destFileList []string
+			err = fs.ListDirTree(dest, &destFileList)
+			require.NoError(t, err)
+			destFileList, err = fs.ConvertToRelativePath(dest, destFileList...)
+			require.NoError(t, err)
+
+			// the src folder must not be present in the destination
+			assert.ElementsMatch(t, srcFileList, destFileList, "all items should have been copied right under the destination root. srcFolderName should not be present in destination")
 		})
 	}
 }
@@ -1359,6 +1361,8 @@ func TestListDirTreeWithExclusion(t *testing.T) {
 func checkCopyDir(t *testing.T, fs FS, src string, dest string, exclusionPattern ...string) {
 	assert.True(t, fs.Exists(src))
 	assert.False(t, fs.Exists(dest))
+	require.NoError(t, fs.MkDir(dest))
+	assert.True(t, fs.Exists(dest))
 	var err error
 	if reflection.IsEmpty(exclusionPattern) {
 		err = fs.Copy(src, dest)

--- a/utils/filesystem/testing.go
+++ b/utils/filesystem/testing.go
@@ -1,0 +1,80 @@
+package filesystem
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// GenerateTestFileTree generates a file tree for testing purposes and returns a list of all the files and filesystem items created.
+// testDir corresponds to the folder where the tree is createed
+// basePath corresponds to the base path for sym links
+// fileModTime, fileAccessTime are for specifying created files ch times
+func GenerateTestFileTree(t *testing.T, fs FS, testDir, basePath string, withLinks bool, fileModTime time.Time, fileAccessTime time.Time) []string {
+	err := fs.MkDir(testDir)
+	require.NoError(t, err)
+
+	var sLinks []string
+	rand.Seed(time.Now().UnixMilli())                                        //nolint:gosec //causes G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec), So disable gosec
+	for i := 0; i < int(math.Max(float64(1), float64(rand.Intn(10)))); i++ { //nolint:gosec //causes G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec), So disable gosec
+		c := fmt.Sprint("test", i+1)
+		path := filepath.Join(testDir, c)
+
+		err := fs.MkDir(path)
+		require.NoError(t, err)
+
+		for j := 0; j < int(math.Max(float64(1), float64(rand.Intn(10)))); j++ { //nolint:gosec //causes G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec), So disable gosec
+			c := fmt.Sprint("test", j+1)
+			path := filepath.Join(path, c)
+
+			err := fs.MkDir(path)
+			require.NoError(t, err)
+
+			if withLinks {
+				if len(sLinks) > 0 {
+					c1 := fmt.Sprint("link", j+1)
+					c2 := filepath.Join(path, c1)
+					err = fs.Symlink(sLinks[0], c2)
+					require.NoError(t, err)
+					if len(sLinks) > 1 {
+						sLinks = sLinks[1:]
+					} else {
+						sLinks = nil
+					}
+				}
+			}
+
+			for k := 0; k < int(math.Max(float64(1), float64(rand.Intn(10)))); k++ { //nolint:gosec //causes G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec), So disable gosec
+				c := fmt.Sprint("test", k+1, ".txt")
+				finalPath := filepath.Join(path, c)
+
+				// pick a couple of files to make symlinks (1 in 10)
+				r := rand.Intn(10) //nolint:gosec //causes G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec), So disable gosec
+				if r == 4 {
+					fPath := filepath.Join(basePath, path, c)
+					sLinks = append(sLinks, fPath)
+				}
+
+				s := fmt.Sprint("file ", i+1, j+1, k+1)
+				err = fs.WriteFile(finalPath, []byte(s), 0755)
+				require.NoError(t, err)
+			}
+		}
+	}
+	var tree []string
+	err = fs.ListDirTree(testDir, &tree)
+	require.NoError(t, err)
+
+	// unifying timestamps
+	for _, path := range tree {
+		err = fs.Chtimes(path, fileAccessTime, fileModTime)
+		require.NoError(t, err)
+	}
+
+	return tree
+}

--- a/utils/filesystem/zip_test.go
+++ b/utils/filesystem/zip_test.go
@@ -41,7 +41,7 @@ func TestZip(t *testing.T) {
 					// see Section 4.4.6 of the spec https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
 					// As a result, the built-in timestamp resolution of files in a ZIP archive is only two seconds and so, file timestamps will not be fully preserved when a zip/unzip is performed.
 					// Making the FS think the tree was made 3 seconds ago.
-					tree := createTestFileTree(t, fs, testDir, "", false, time.Now().Add(-3*time.Second), time.Now())
+					tree := GenerateTestFileTree(t, fs, testDir, "", false, time.Now().Add(-3*time.Second), time.Now())
 
 					// zip the directory into the zipfile
 					err = fs.Zip(testDir, zipfile)
@@ -127,7 +127,7 @@ func TestZipWithExclusion(t *testing.T) {
 					outDir := filepath.Join(tmpDir, "output")
 
 					// create a file tree for the test
-					tree := createTestFileTree(t, fs, testDir, "", false, time.Now().Add(-3*time.Second), time.Now())
+					tree := GenerateTestFileTree(t, fs, testDir, "", false, time.Now().Add(-3*time.Second), time.Now())
 
 					exclusionPatterns := []string{".*test2.*", ".*test3.*"}
 


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

the behaviour of `filesystem.Copy` was not fully aligned with `cp -r` as described in #195 .
This makes sure this misalignment is fixed



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
