### PR TITLE
:bug: `[filesystem]` align the `Copy` of files with `cp <files>`

### DIFF
--- a/changes/20230127113013.bugfix
+++ b/changes/20230127113013.bugfix
@@ -1,0 +1,1 @@
+:bug:`[filesystem]` Fix `Copy` behaviour to match `cp <file>` when destination has a file name


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

align the `Copy` of files with `cp <files>`
if the destination is a file or having a file name (i.e. with extension), the destination should be a file
cp source.txt dest.txt => dest.txt should be a file with the content of the source



### Test Coverage

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
