### PR TITLE
:bug: Improve the consistency of the behaviour of `copy` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,13 @@ beta releases are not included in this history.
 
 "" "1.25.1" (2023-01-27)
 ========================
-
+:warning: the change of bevahiour of `filesystem.Copy` when destination does not exist may result in a breaking change
 Bugfixes
 --------
 
 - Dependency upgrade: fetch-metadata-1.3.6 (#20230124111318, #20230124111321)
 - Dependency upgrade: uuid-4.4.0incompatible (#20230126110437, #20230126110454, #20230126110522, #20230126110538, #20230126110604, #20230126110651)
-- :bug:`[filesystem]` Fix `Copy` behaviour to match `cp -r` when destination does not exists (#20230126194148)
+- :bug:`[filesystem]` Fix `Copy` behaviour to match `cp -r` when destination does not exist (#20230126194148)
 - Dependency upgrade: zerolog-1.29.0 (#20230126195900, #20230126195917, #20230126195937, #20230126195956, #20230126200018, #20230126200036, #20230126200111)
 - :bug:`[filesystem]` Fix `Copy` behaviour to match `cp <file>` when destination has a file name (#20230127113013)
 

--- a/changes/20230130162624.bugfix
+++ b/changes/20230130162624.bugfix
@@ -1,0 +1,1 @@
+:bug:`[filesystem]` Clarified the behaviour of `Copy` for files so that there is no wrong assumptions about the type of the destination if not existing

--- a/changes/20230130162704.doc
+++ b/changes/20230130162704.doc
@@ -1,0 +1,1 @@
+Clarified the documentation with regards to `filesystem.Copy`

--- a/changes/20230131184530.feature
+++ b/changes/20230131184530.feature
@@ -1,0 +1,1 @@
+:sparkle:`[filesystem]` Added more copy functions `CopyToFile` and `CopyToDirectory` to cover more copy usecases

--- a/utils/filesystem/filepath.go
+++ b/utils/filesystem/filepath.go
@@ -29,3 +29,8 @@ func FileTreeDepth(fs FS, root, filePath string) (depth int64, err error) {
 	depth = int64(len(strings.Split(diff, "/")) - 1)
 	return
 }
+
+// EndsWithPathSeparator states whether a path is ending with a path separator of not
+func EndsWithPathSeparator(fs FS, filePath string) bool {
+	return strings.HasSuffix(filePath, "/") || strings.HasSuffix(filePath, string(fs.PathSeparator()))
+}

--- a/utils/filesystem/filepath_test.go
+++ b/utils/filesystem/filepath_test.go
@@ -100,3 +100,20 @@ func TestFileTreeDepth(t *testing.T) {
 		})
 	}
 }
+
+func TestEndsWithPathSeparator(t *testing.T) {
+	for fsType := range FileSystemTypes {
+		t.Run(fmt.Sprintf("%v_for_fs_%v", t.Name(), fsType), func(t *testing.T) {
+			fs := NewFs(FileSystemTypes[fsType])
+
+			assert.True(t, EndsWithPathSeparator(fs, "test fsdfs .fsdffs /"))
+			assert.False(t, EndsWithPathSeparator(fs, "test fsdfs .fsdffs "))
+			assert.False(t, EndsWithPathSeparator(fs, filepath.Join(faker.DomainName(), "test fsdfs .fsdffs ")))
+			assert.True(t, EndsWithPathSeparator(fs, filepath.Join(faker.DomainName(), "test fsdfs .fsdffs ")+"/"))
+			assert.False(t, EndsWithPathSeparator(fs, filepath.Join(faker.DomainName(), "test fsdfs .fsdffs /")), "join should trim the tailing separator")
+			assert.True(t, EndsWithPathSeparator(fs, "test fsdfs .fsdffs "+string(fs.PathSeparator())))
+			assert.True(t, EndsWithPathSeparator(fs, filepath.Join(faker.DomainName(), "test fsdfs .fsdffs ")+string(fs.PathSeparator())))
+			assert.False(t, EndsWithPathSeparator(fs, filepath.Join(faker.DomainName(), "test fsdfs .fsdffs "+string(fs.PathSeparator()))), "join should trim the tailing separator")
+		})
+	}
+}

--- a/utils/filesystem/interfaces.go
+++ b/utils/filesystem/interfaces.go
@@ -178,11 +178,14 @@ type FS interface {
 	Lls(dir string) (files []os.FileInfo, err error)
 	// LlsFromOpenedDirectory lists all files and directory (equivalent to ls -l)
 	LlsFromOpenedDirectory(dir File) (files []os.FileInfo, err error)
-	// Copy copies files and directory (equivalent to cp -r)
+	// Copy copies files and directory (equivalent to [POSIX cp -r](https://www.unix.com/man-page/posix/1P/cp/) or DOS `copy` or `shutil.copy()`/`shutil.copytree()` in [python](https://docs.python.org/3/library/shutil.html#shutil.copy))
+	// It should be noted that although the behaviour should match `cp -r` in most cases, there may be some corner cases in which the behaviour of Copy may differ slightly.
+	// For instance, if the destination `dest` does not exist and the source is a file, then the destination will be a file unless the destination ends with a path separator and thus, the intention was to consider it as a folder.
 	Copy(src string, dest string) (err error)
-	// CopyWithContext copies files and directory (equivalent to cp -r)
+	// CopyWithContext copies files and directory similar to Copy.
+	// Nonetheless, this function should be preferred over Copy as it is context aware, meaning it is possible to stop the copy if it is taking too long or if context is cancelled.
 	CopyWithContext(ctx context.Context, src string, dest string) (err error)
-	// CopyWithContextAndExclusionPatterns copies files and directory (equivalent to cp -r) but ignores any file matching the exclusion pattern.
+	// CopyWithContextAndExclusionPatterns copies files and directory like CopyWithContext but ignores any file matching the exclusion pattern.
 	CopyWithContextAndExclusionPatterns(ctx context.Context, src string, dest string, exclusionPatterns ...string) (err error)
 	// Move moves a file (equivalent to mv)
 	Move(src string, dest string) (err error)

--- a/utils/filesystem/interfaces.go
+++ b/utils/filesystem/interfaces.go
@@ -178,6 +178,14 @@ type FS interface {
 	Lls(dir string) (files []os.FileInfo, err error)
 	// LlsFromOpenedDirectory lists all files and directory (equivalent to ls -l)
 	LlsFromOpenedDirectory(dir File) (files []os.FileInfo, err error)
+	// CopyToFile copies a file to another file.
+	CopyToFile(srcFile, destFile string) error
+	// CopyToFileWithContext copies a file to another file similarly to CopyToFile.
+	CopyToFileWithContext(ctx context.Context, srcFile, destFile string) error
+	// CopyToDirectory copies a src to a directory  destDirectory which will be created as such if not present.
+	CopyToDirectory(src, destDirectory string) error
+	// CopyToDirectoryWithContext copies a src to a directory similarly to CopyToDirectory.
+	CopyToDirectoryWithContext(ctx context.Context, src, destDirectory string) error
 	// Copy copies files and directory (equivalent to [POSIX cp -r](https://www.unix.com/man-page/posix/1P/cp/) or DOS `copy` or `shutil.copy()`/`shutil.copytree()` in [python](https://docs.python.org/3/library/shutil.html#shutil.copy))
 	// It should be noted that although the behaviour should match `cp -r` in most cases, there may be some corner cases in which the behaviour of Copy may differ slightly.
 	// For instance, if the destination `dest` does not exist and the source is a file, then the destination will be a file unless the destination ends with a path separator and thus, the intention was to consider it as a folder.

--- a/utils/mocks/mock_filesystem.go
+++ b/utils/mocks/mock_filesystem.go
@@ -1095,6 +1095,62 @@ func (mr *MockFSMockRecorder) Copy(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Copy", reflect.TypeOf((*MockFS)(nil).Copy), arg0, arg1)
 }
 
+// CopyToDirectory mocks base method.
+func (m *MockFS) CopyToDirectory(arg0, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CopyToDirectory", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CopyToDirectory indicates an expected call of CopyToDirectory.
+func (mr *MockFSMockRecorder) CopyToDirectory(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyToDirectory", reflect.TypeOf((*MockFS)(nil).CopyToDirectory), arg0, arg1)
+}
+
+// CopyToDirectoryWithContext mocks base method.
+func (m *MockFS) CopyToDirectoryWithContext(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CopyToDirectoryWithContext", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CopyToDirectoryWithContext indicates an expected call of CopyToDirectoryWithContext.
+func (mr *MockFSMockRecorder) CopyToDirectoryWithContext(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyToDirectoryWithContext", reflect.TypeOf((*MockFS)(nil).CopyToDirectoryWithContext), arg0, arg1, arg2)
+}
+
+// CopyToFile mocks base method.
+func (m *MockFS) CopyToFile(arg0, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CopyToFile", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CopyToFile indicates an expected call of CopyToFile.
+func (mr *MockFSMockRecorder) CopyToFile(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyToFile", reflect.TypeOf((*MockFS)(nil).CopyToFile), arg0, arg1)
+}
+
+// CopyToFileWithContext mocks base method.
+func (m *MockFS) CopyToFileWithContext(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CopyToFileWithContext", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CopyToFileWithContext indicates an expected call of CopyToFileWithContext.
+func (mr *MockFSMockRecorder) CopyToFileWithContext(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyToFileWithContext", reflect.TypeOf((*MockFS)(nil).CopyToFileWithContext), arg0, arg1, arg2)
+}
+
 // CopyWithContext mocks base method.
 func (m *MockFS) CopyWithContext(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()

--- a/utils/sharedcache/common.go
+++ b/utils/sharedcache/common.go
@@ -100,13 +100,13 @@ func TransferFiles(ctx context.Context, fs filesystem.FS, dst, src string) (dest
 	}
 
 	// download/upload from/to cache
-	err = fs.Copy(src, destDir)
+	err = fs.CopyWithContext(ctx, src, destDir)
 	if err != nil {
 		return
 	}
 
 	if renameFile {
-		err = fs.Move(filepath.Join(destDir, filepath.Base(src)), destFile)
+		err = fs.MoveWithContext(ctx, filepath.Join(destDir, filepath.Base(src)), destFile)
 		if err != nil {
 			return
 		}

--- a/utils/sharedcache/common_test.go
+++ b/utils/sharedcache/common_test.go
@@ -182,8 +182,8 @@ func TestTransferWithNonExistentDestinationFolders(t *testing.T) {
 			folder2, err := fs.TempDirInTempDir("test-tranfer2")
 			require.NoError(t, err)
 			defer func() { _ = fs.Rm(folder2) }()
-			dest1 := filepath.Join(folder1, "test_dest_tranfer1_dir/")
-			dest2 := filepath.Join(folder2, "test_dest_tranfer2_dir/")
+			dest1 := filepath.Join(folder1, "test_dest_tranfer1_dir") + "/"
+			dest2 := filepath.Join(folder2, "test_dest_tranfer2_dir") + "/"
 
 			testTransfert(t, ctx, fs, folder1, dest1, dest2)
 		})


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

In some cases such as the copy of files to destination which do not exist, the behaviour of `filesystem.Copy()` as changed to better aligned with `cp -r` was not particularly straightforward and potentially misleading

e.g.
filesystem.Copy("source.txt","does-not-exist") and  filesystem.Copy("source.txt",".does-not-exist") had different behaviours since the type of destination was interpreted differently.

The intention of this PR is to clarify the behaviour of Copy in those circumstances and ensure the behaviour is more intuitive.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
