### PR TITLE
:sparkles: `[filesystem]` Make file hashing context aware

### DIFF
--- a/changes/20230222130436.feature
+++ b/changes/20230222130436.feature
@@ -1,0 +1,1 @@
+:sparkles: `[filesystem]` Make file hashing operation context aware

--- a/utils/filesystem/files.go
+++ b/utils/filesystem/files.go
@@ -958,12 +958,16 @@ func (fs *VFS) moveFile(ctx context.Context, src string, dest string) (err error
 	return
 }
 
-func (fs *VFS) FileHash(hashAlgo string, path string) (hash string, err error) {
+func (fs *VFS) FileHash(hashAlgo string, path string) (string, error) {
+	return fs.FileHashWithContext(context.Background(), hashAlgo, path)
+}
+
+func (fs *VFS) FileHashWithContext(ctx context.Context, hashAlgo string, path string) (hash string, err error) {
 	hasher, err := NewFileHash(hashAlgo)
 	if err != nil {
 		return
 	}
-	hash, err = hasher.CalculateFile(fs, path)
+	hash, err = hasher.CalculateFileWithContext(ctx, fs, path)
 	return
 }
 

--- a/utils/filesystem/interfaces.go
+++ b/utils/filesystem/interfaces.go
@@ -294,6 +294,8 @@ type FS interface {
 	UnzipWithContextAndLimits(ctx context.Context, source string, destination string, limits ILimits) (fileList []string, err error)
 	// FileHash calculates file hash
 	FileHash(hashAlgo string, path string) (string, error)
+	// FileHashWithContext calculates file hash
+	FileHashWithContext(ctx context.Context, hashAlgo string, path string) (string, error)
 	// IsZip states whether a file is a zip file or not. If the file does not exist, it will state whether the filename has a zip extension or not.
 	IsZip(filepath string) bool
 	// IsZipWithContext states whether a file is a zip file or not. Since the process can take some time (i.e type detection with sniffers such as http.DetectContentType), it is controlled by a context.

--- a/utils/mocks/mock_filesystem.go
+++ b/utils/mocks/mock_filesystem.go
@@ -1294,6 +1294,21 @@ func (mr *MockFSMockRecorder) FileHash(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FileHash", reflect.TypeOf((*MockFS)(nil).FileHash), arg0, arg1)
 }
 
+// FileHashWithContext mocks base method.
+func (m *MockFS) FileHashWithContext(arg0 context.Context, arg1, arg2 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FileHashWithContext", arg0, arg1, arg2)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FileHashWithContext indicates an expected call of FileHashWithContext.
+func (mr *MockFSMockRecorder) FileHashWithContext(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FileHashWithContext", reflect.TypeOf((*MockFS)(nil).FileHashWithContext), arg0, arg1, arg2)
+}
+
 // FindAll mocks base method.
 func (m *MockFS) FindAll(arg0 string, arg1 ...string) ([]string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description
- Added `FileHashWithContext` so that the operation takes into account a context and can be cancelled


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
