### PR TITLE
:sparkles: Added error testing utilities

### DIFF
--- a/changes/202305241743.feature
+++ b/changes/202305241743.feature
@@ -1,0 +1,1 @@
+:sparkles: Added testing utilities with regards to error assertions

--- a/utils/commonerrors/errortest/testing.go
+++ b/utils/commonerrors/errortest/testing.go
@@ -1,0 +1,29 @@
+package errortest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+)
+
+// AssertError asserts that the error is matching one of the `expectedErrors`
+// This is a wrapper for commonerrors.Any.
+func AssertError(t *testing.T, err error, expectedErrors ...error) bool {
+	if commonerrors.Any(err, expectedErrors...) {
+		return true
+	}
+	return assert.Fail(t, fmt.Sprintf("Failed error assertion:\n actual: %v\n expected: %+v", err, expectedErrors))
+}
+
+// RequireError requires that the error is matching one of the `expectedErrors`
+// This is a wrapper for commonerrors.Any.
+func RequireError(t *testing.T, err error, expectedErrors ...error) {
+	t.Helper()
+	if commonerrors.Any(err, expectedErrors...) {
+		return
+	}
+	t.FailNow()
+}

--- a/utils/commonerrors/errortest/testing_test.go
+++ b/utils/commonerrors/errortest/testing_test.go
@@ -1,0 +1,15 @@
+package errortest
+
+import (
+	"testing"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+)
+
+func TestAssertError(t *testing.T) {
+	AssertError(t, commonerrors.ErrUndefined, commonerrors.ErrNotFound, commonerrors.ErrMarshalling, commonerrors.ErrUndefined)
+}
+
+func TestRequireError(t *testing.T) {
+	RequireError(t, commonerrors.ErrUndefined, commonerrors.ErrNotFound, commonerrors.ErrMarshalling, commonerrors.ErrUndefined)
+}


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

-Added error testing utilities
### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
