### PR TITLE
:sparkles: `[http]` Added `RetryOnError`

### DIFF
--- a/changes/20230531171611.feature
+++ b/changes/20230531171611.feature
@@ -1,0 +1,1 @@
+:sparkles: `[http]` Added `RetryOnError` togenerically retry a client call on error in a similar way to what `OnError` does in [kubernetes](https://github.com/kubernetes/client-go/blob/cf830e3cb3abbcc32cc1b6bea4feb1a9a1881af3/util/retry/util.go#LL48C6-L48C13)

--- a/utils/go.sum
+++ b/utils/go.sum
@@ -269,8 +269,6 @@ github.com/shoenig/test v0.6.3/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnj
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.2 h1:oxx1eChJGI6Uks2ZC4W1zpLlVgqB8ner4EuQwV4Ik1Y=
 github.com/sirupsen/logrus v1.9.2/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/sirupsen/logrus v1.9.1 h1:Ou41VVR3nMWWmTiEUnj0OlsgOSCUFgsPAOl6jRIcVtQ=
-github.com/sirupsen/logrus v1.9.1/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.1.0 h1:Wvr9V0MxhjRbl3f9nMnKnFfiWTJmtECJ9Njkea3ysW0=
 github.com/skeema/knownhosts v1.1.0/go.mod h1:sKFq3RD6/TKZkSWn8boUbDC7Qkgcv+8XXijpFO6roag=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=

--- a/utils/http/retry.go
+++ b/utils/http/retry.go
@@ -1,0 +1,52 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/avast/retry-go"
+	"github.com/go-logr/logr"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+)
+
+// RetryOnError allows the caller to retry fn when the error returned by fn is retriable
+// as in of the type specified by retriableErr. backoff defines the maximum retries and the wait
+// interval between two retries.
+func RetryOnError(ctx context.Context, logger logr.Logger, retryPolicy *RetryPolicyConfiguration, fn func() error, msgOnRetry string, retriableErr ...error) error {
+	if retryPolicy == nil {
+		return fmt.Errorf("%w: missing retry policy configuration", commonerrors.ErrUndefined)
+	}
+	if !retryPolicy.Enabled {
+		return fn()
+	}
+	var retryType retry.DelayTypeFunc
+	switch {
+	case retryPolicy.LinearBackOffEnabled:
+		retryType = retry.CombineDelay(retry.FixedDelay, retry.RandomDelay)
+	case retryPolicy.BackOffEnabled:
+		retryType = retry.BackOffDelay
+	default:
+		retryType = retry.FixedDelay
+	}
+
+	return commonerrors.ConvertContextError(
+		retry.Do(
+			fn,
+			retry.OnRetry(func(n uint, err error) {
+				logger.Error(err, fmt.Sprintf("%v (attempt #%v)", msgOnRetry, n+1), "attempt", n+1)
+			}),
+			retry.Delay(retryPolicy.RetryWaitMin),
+			retry.MaxDelay(retryPolicy.RetryWaitMax),
+			retry.MaxJitter(25*time.Millisecond),
+			retry.DelayType(retryType),
+			retry.Attempts(uint(retryPolicy.RetryMax)),
+			retry.RetryIf(func(err error) bool {
+				return commonerrors.Any(err, retriableErr...)
+			}),
+			retry.LastErrorOnly(true),
+			retry.Context(ctx),
+		),
+	)
+}

--- a/utils/http/retry_test.go
+++ b/utils/http/retry_test.go
@@ -1,0 +1,94 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
+	"github.com/ARM-software/golang-utils/utils/logs/logstest"
+)
+
+func TestRetryOnError(t *testing.T) {
+	tests := []struct {
+		policy *RetryPolicyConfiguration
+	}{
+		{
+			policy: DefaultBasicRetryPolicyConfiguration(),
+		},
+		{
+			policy: DefaultNoRetryPolicyConfiguration(),
+		},
+		{
+			policy: DefaultLinearBackoffRetryPolicyConfiguration(),
+		},
+		{
+			policy: DefaultExponentialBackoffRetryPolicyConfiguration(),
+		},
+	}
+	attemptCount := atomic.NewInt32(0)
+	fn := func() error {
+		attemptCount.Inc()
+		return commonerrors.ErrUnknown
+	}
+
+	for i := range tests {
+		test := tests[i]
+		attemptCount.Store(0)
+		t.Run(fmt.Sprintf("retry %T policy", test.policy), func(t *testing.T) {
+			err := RetryOnError(context.Background(), logstest.NewTestLogger(t), test.policy, fn, "failed fn()", commonerrors.ErrUndefined, commonerrors.ErrUnknown)
+			assert.Error(t, err)
+			errortest.AssertError(t, err, commonerrors.ErrUnknown)
+			if test.policy.RetryMax == 0 {
+				assert.Equal(t, 1, int(attemptCount.Load()))
+			} else {
+				assert.Equal(t, test.policy.RetryMax, int(attemptCount.Load()))
+			}
+		})
+		attemptCount.Store(0)
+		t.Run(fmt.Sprintf("no retry when unlisted error (%T policy)", test.policy), func(t *testing.T) {
+			err := RetryOnError(context.Background(), logstest.NewTestLogger(t), test.policy, fn, "failed fn()")
+			assert.Error(t, err)
+			errortest.AssertError(t, err, commonerrors.ErrUnknown)
+			assert.Equal(t, 1, int(attemptCount.Load()))
+		})
+		attemptCount.Store(0)
+		t.Run(fmt.Sprintf("no retry when unlisted error (%T policy)", test.policy), func(t *testing.T) {
+			err := RetryOnError(context.Background(), logstest.NewTestLogger(t), test.policy, fn, "failed fn()", commonerrors.ErrMarshalling)
+			assert.Error(t, err)
+			errortest.AssertError(t, err, commonerrors.ErrUnknown)
+			assert.Equal(t, 1, int(attemptCount.Load()))
+		})
+	}
+	t.Run("check context cancellation", func(t *testing.T) {
+		attemptCount.Store(0)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := RetryOnError(ctx, logstest.NewTestLogger(t), DefaultLinearBackoffRetryPolicyConfiguration(), fn, "failed fn()", commonerrors.ErrUndefined, commonerrors.ErrUnknown)
+		assert.Error(t, err)
+		errortest.AssertError(t, err, commonerrors.ErrCancelled)
+		assert.Zero(t, int(attemptCount.Load()))
+	})
+	t.Run("requires a retry policy", func(t *testing.T) {
+		attemptCount.Store(0)
+		err := RetryOnError(context.Background(), logstest.NewTestLogger(t), nil, fn, "failed fn()", commonerrors.ErrUnknown)
+		assert.Error(t, err)
+		errortest.AssertError(t, err, commonerrors.ErrUndefined)
+		assert.Zero(t, int(attemptCount.Load()))
+	})
+	t.Run("no retry if passing", func(t *testing.T) {
+		attemptCount.Store(0)
+		successFn := func() error {
+			attemptCount.Inc()
+			return nil
+		}
+		err := RetryOnError(context.Background(), logstest.NewTestLogger(t), DefaultLinearBackoffRetryPolicyConfiguration(), successFn, "failed fn()", commonerrors.ErrUndefined, commonerrors.ErrUnknown)
+		require.NoError(t, err)
+		assert.Equal(t, 1, int(attemptCount.Load()))
+	})
+}


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

- Added `RetryOnError` in the `http` module to generically retry client calls on particular errors



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
