### PR TITLE
:sparkles: `[logs]` hclogs wrapper

### DIFF
--- a/changes/20230606144452.feature
+++ b/changes/20230606144452.feature
@@ -1,0 +1,1 @@
+:sparkles: `[logs]` created a [hclog](https://github.com/hashicorp/go-hclog)'s wrapper over logs.Loggers

--- a/utils/logs/hclog_logger.go
+++ b/utils/logs/hclog_logger.go
@@ -13,11 +13,46 @@ import (
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 )
 
-// NewHclogLogger returns a logger which uses hclog logger (https://github.com/hashicorp/go-hclog
+// NewHclogLogger returns a logger which uses hclog logger (https://github.com/hashicorp/go-hclog)
 func NewHclogLogger(hclogL hclog.Logger, loggerSource string) (loggers Loggers, err error) {
 	if hclogL == nil {
 		err = commonerrors.ErrNoLogger
 		return
 	}
 	return NewLogrLogger(hclogr.Wrap(hclogL), loggerSource)
+}
+
+// NewHclogWrapper returns an hclog logger from a Loggers logger
+func NewHclogWrapper(loggers Loggers) (hclogL hclog.Logger, err error) {
+	if loggers == nil {
+		err = commonerrors.ErrNoLogger
+		return
+	}
+	intercept := hclog.NewInterceptLogger(nil)
+
+	info, err := NewInfoWriterFromLoggers(loggers)
+	if err != nil {
+		return
+	}
+	errL, err := NewErrorWriterFromLoggers(loggers)
+	if err != nil {
+		return
+	}
+
+	sinkErr := hclog.NewSinkAdapter(&hclog.LoggerOptions{
+		Level:       hclog.Warn,
+		Output:      errL,
+		DisableTime: true,
+	})
+	sinkInfo := hclog.NewSinkAdapter(&hclog.LoggerOptions{
+		Level:       hclog.Info,
+		Output:      info,
+		DisableTime: true,
+	})
+
+	intercept.RegisterSink(sinkErr)
+	intercept.RegisterSink(sinkInfo)
+
+	hclogL = intercept
+	return
 }

--- a/utils/logs/hclog_logger_test.go
+++ b/utils/logs/hclog_logger_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ARM-software/golang-utils/utils/logs/logstest"
 )
 
 func TestHclogLogger(t *testing.T) {
@@ -16,4 +18,14 @@ func TestHclogLogger(t *testing.T) {
 	loggers, err := NewHclogLogger(logger, "Test")
 	require.NoError(t, err)
 	testLog(t, loggers)
+}
+
+func TestHclogWrapper(t *testing.T) {
+	loggers, err := NewLogrLogger(logstest.NewTestLogger(t), "test")
+	require.NoError(t, err)
+	hcLogger, err := NewHclogWrapper(loggers)
+	require.NoError(t, err)
+	loggerTest, err := NewHclogLogger(hcLogger, "Test")
+	require.NoError(t, err)
+	testLog(t, loggerTest)
 }

--- a/utils/logs/writer.go
+++ b/utils/logs/writer.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/diode"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
 )
 
 type MultipleWritersWithSource struct {
@@ -113,4 +115,56 @@ func NewDiodeWriterForSlowWriter(slowWriter WriterWithSource, ringBufferSize int
 	}),
 		slowWriter: slowWriter,
 	}
+}
+
+type infoWriter struct {
+	loggers Loggers
+}
+
+func (w *infoWriter) Write(p []byte) (n int, err error) {
+	if w.loggers == nil {
+		err = commonerrors.ErrNoLogger
+		return
+	}
+	n = len(p)
+	w.loggers.Log(string(p))
+	return
+}
+
+// NewInfoWriterFromLoggers returns a io.Writer from a Loggers by only returning INFO messages
+func NewInfoWriterFromLoggers(l Loggers) (w io.Writer, err error) {
+	if l == nil {
+		err = commonerrors.ErrNoLogger
+		return
+	}
+	w = &infoWriter{
+		loggers: l,
+	}
+	return
+}
+
+type errWriter struct {
+	loggers Loggers
+}
+
+func (w *errWriter) Write(p []byte) (n int, err error) {
+	if w.loggers == nil {
+		err = commonerrors.ErrNoLogger
+		return
+	}
+	n = len(p)
+	w.loggers.LogError(string(p))
+	return
+}
+
+// NewErrorWriterFromLoggers returns a io.Writer from a Loggers by only returning ERROR messages
+func NewErrorWriterFromLoggers(l Loggers) (w io.Writer, err error) {
+	if l == nil {
+		err = commonerrors.ErrNoLogger
+		return
+	}
+	w = &errWriter{
+		loggers: l,
+	}
+	return
 }


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

- `[logs]` created a [hclog](https://github.com/hashicorp/go-hclog)'s wrapper over logs.Loggers



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
