### PR TITLE
:sparkles: `logs`Add GetLogrLoggerFromContext

### DIFF
--- a/changes/20230607112032.feature
+++ b/changes/20230607112032.feature
@@ -1,0 +1,1 @@
+:sparkles: `logs` Add GetLogrLoggerFromContext to fetch a logr.logger from a context

--- a/utils/logs/logr_logger.go
+++ b/utils/logs/logr_logger.go
@@ -5,6 +5,7 @@
 package logs
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -83,4 +84,17 @@ func NewLogrLoggerWithClose(logrImpl logr.Logger, loggerSource string, closeFunc
 // NewLogrLoggerFromLoggers converts loggers into a logr.Logger
 func NewLogrLoggerFromLoggers(loggers Loggers) logr.Logger {
 	return stdr.New(newGolangStdLoggerFromLoggers(loggers))
+}
+
+// GetLogrLoggerFromContext gets a logger from a context, unless it does not exist then it returns an ErrNoLogger
+func GetLogrLoggerFromContext(ctx context.Context) (logger logr.Logger, err error) {
+	logger, err = logr.FromContext(ctx)
+	if err != nil {
+		err = fmt.Errorf("%w: %v", commonerrors.ErrNoLogger, err.Error())
+		return
+	}
+	if logger.IsZero() {
+		err = commonerrors.ErrNoLogger
+	}
+	return
 }

--- a/utils/logs/logr_logger_test.go
+++ b/utils/logs/logr_logger_test.go
@@ -5,12 +5,16 @@
 package logs
 
 import (
+	"context"
 	"testing"
 
 	"github.com/bxcodec/faker/v3"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
 	"github.com/ARM-software/golang-utils/utils/logs/logstest"
 )
 
@@ -29,4 +33,23 @@ func TestLogrLoggerConversion(t *testing.T) {
 	require.NoError(t, err)
 	converted := NewLogrLoggerFromLoggers(loggers)
 	converted.WithName(faker.Name()).WithValues(faker.Word(), faker.Name()).Error(commonerrors.ErrUnexpected, faker.Sentence())
+}
+
+func TestGetLogrFromEmptyContext(t *testing.T) {
+	ctx := context.Background()
+	logger, err := GetLogrLoggerFromContext(ctx)
+
+	assert.Equal(t, logr.Logger{}, logger)
+	errortest.AssertError(t, err, commonerrors.ErrNoLogger)
+}
+
+func TestGetLogrFromContext(t *testing.T) {
+	ctx := context.Background()
+	logger := logstest.NewTestLogger(t)
+	ctx = logr.NewContext(ctx, logger)
+
+	newLogger, err := GetLogrLoggerFromContext(ctx)
+	assert.NoError(t, err)
+
+	assert.Equal(t, logger, newLogger)
 }


### PR DESCRIPTION


<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

-  `logs`Add GetLogrLoggerFromContext to fetch a logr.logger  from a context (#271)

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ] Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ] Additional tests are not required for this change (e.g. documentation update).

---------

<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
