### PR TITLE
:sparkles: `[filesystem]` Created Adapter to `embed.FS` 

### DIFF
--- a/changes/20230609154852.feature
+++ b/changes/20230609154852.feature
@@ -1,0 +1,1 @@
+:sparkles: `[filesystem]` Created Adapter to `embed.FS` for use of common utilities

--- a/changes/20230609154935.feature
+++ b/changes/20230609154935.feature
@@ -1,0 +1,1 @@
+:sparkles: `[filesystem]` Added `ReadFileContent` in order to read from a File object

--- a/utils/filesystem/embedfs.go
+++ b/utils/filesystem/embedfs.go
@@ -1,0 +1,33 @@
+package filesystem
+
+import (
+	"embed"
+	"fmt"
+	"os"
+
+	"github.com/spf13/afero"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+)
+
+type embedFsAdapter struct {
+	afero.Fs
+}
+
+func (e *embedFsAdapter) OpenFile(name string, flag int, _ os.FileMode) (afero.File, error) {
+	if flag != os.O_RDONLY {
+		return nil, fmt.Errorf("%w: embed.FS is readonly", commonerrors.ErrUnsupported)
+	}
+	return e.Open(name)
+}
+
+func newEmbedFSAdapter(fs *embed.FS) (afero.Fs, error) {
+	if fs == nil {
+		return nil, fmt.Errorf("%w: missing filesystem", commonerrors.ErrUndefined)
+	}
+	return &embedFsAdapter{
+		Fs: afero.FromIOFS{
+			FS: *fs,
+		},
+	}, nil
+}

--- a/utils/filesystem/embedfs_test.go
+++ b/utils/filesystem/embedfs_test.go
@@ -1,0 +1,154 @@
+package filesystem
+
+import (
+	"embed"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/bxcodec/faker/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
+)
+
+//go:embed *
+var testContent embed.FS
+
+const testFile1Content = "this is a text file with some content\n"
+
+func Test_embedFS_Exists(t *testing.T) {
+	fs, err := NewEmbedFileSystem(&testContent)
+	require.NoError(t, err)
+	assert.False(t, fs.Exists(faker.DomainName()))
+	assert.True(t, fs.Exists("testdata"))
+	assert.True(t, fs.Exists("testdata/embed"))
+	assert.True(t, fs.Exists("testdata/embed/level1/test.txt"))
+}
+
+func Test_embedFS_Browsing(t *testing.T) {
+	fs, err := NewEmbedFileSystem(&testContent)
+	require.NoError(t, err)
+	empty, err := fs.IsEmpty(faker.DomainName())
+	require.NoError(t, err)
+	assert.True(t, empty)
+	empty, err = fs.IsEmpty("testdata")
+	require.NoError(t, err)
+	assert.False(t, empty)
+	empty, err = fs.IsEmpty("testdata/embed")
+	require.NoError(t, err)
+	assert.False(t, empty)
+	empty, err = fs.IsEmpty("testdata/embed/level1")
+	require.NoError(t, err)
+	assert.False(t, empty)
+}
+
+func Test_embedFS_Browsing2(t *testing.T) {
+	efs, err := NewEmbedFileSystem(&testContent)
+	require.NoError(t, err)
+	var wFunc = func(path string, info fs.FileInfo, err error) error {
+		fmt.Println(path)
+		return nil
+	}
+	require.NoError(t, efs.Walk("testdata/embed", wFunc))
+}
+
+func Test_embedFS_LS(t *testing.T) {
+	efs, err := NewEmbedFileSystem(&testContent)
+	require.NoError(t, err)
+
+	files, err := efs.Ls("testdata")
+	require.NoError(t, err)
+	assert.NotZero(t, files)
+	assert.Contains(t, files, "embed")
+
+	files, err = efs.Ls("testdata/embed")
+	require.NoError(t, err)
+	assert.NotZero(t, files)
+	assert.Contains(t, files, "level1")
+	assert.Contains(t, files, "test.txt")
+}
+
+func Test_embedFS_itemType(t *testing.T) {
+	efs, err := NewEmbedFileSystem(&testContent)
+	require.NoError(t, err)
+	isFile, err := efs.IsFile("testdata")
+	require.NoError(t, err)
+	assert.False(t, isFile)
+	isDir, err := efs.IsDir("testdata")
+	require.NoError(t, err)
+	assert.True(t, isDir)
+	isFile, err = efs.IsFile("testdata/embed/level1/test.txt")
+	require.NoError(t, err)
+	assert.True(t, isFile)
+	isDir, err = efs.IsDir("testdata/embed/level1/test.txt")
+	require.NoError(t, err)
+	assert.False(t, isDir)
+}
+
+func Test_embedFS_Read(t *testing.T) {
+	efs, err := NewEmbedFileSystem(&testContent)
+	require.NoError(t, err)
+
+	t.Run("embed read", func(t *testing.T) {
+		c, err := testContent.ReadFile("testdata/embed/test.txt")
+		require.NoError(t, err)
+		assert.Equal(t, testFile1Content, string(c))
+	})
+
+	t.Run("using file opening", func(t *testing.T) {
+		f, err := efs.GenericOpen("testdata/embed/test.txt")
+		require.NoError(t, err)
+		defer func() { _ = f.Close() }()
+		c, err := io.ReadAll(f)
+		require.NoError(t, err)
+		assert.Equal(t, testFile1Content, string(c))
+		require.NoError(t, f.Close())
+	})
+
+	t.Run("using file opening 2", func(t *testing.T) {
+		f, err := efs.OpenFile("testdata/embed/test.txt", os.O_RDONLY, os.FileMode(0600))
+		require.NoError(t, err)
+		defer func() { _ = f.Close() }()
+		c, err := io.ReadAll(f)
+		require.NoError(t, err)
+		assert.Equal(t, testFile1Content, string(c))
+		require.NoError(t, f.Close())
+	})
+
+	t.Run("using file read", func(t *testing.T) {
+		c, err := efs.ReadFile("testdata/embed/test.txt")
+		require.NoError(t, err)
+		assert.Equal(t, testFile1Content, string(c))
+	})
+
+}
+
+func Test_embed_not_supported(t *testing.T) {
+	efs, err := NewEmbedFileSystem(nil)
+	errortest.RequireError(t, err, commonerrors.ErrUndefined)
+
+	efs, err = NewEmbedFileSystem(&testContent)
+	require.NoError(t, err)
+
+	_, err = efs.TempDir("testdata", "aaaa")
+	assert.True(t, commonerrors.CorrespondTo(err, "permission denied"))
+
+	f, err := efs.OpenFile("testdata/embed/test.txt", os.O_RDWR, os.FileMode(0600))
+	defer func() {
+		if f != nil {
+			_ = f.Close()
+		}
+	}()
+	require.Error(t, err)
+	errortest.AssertError(t, err, commonerrors.ErrUnsupported)
+
+	err = efs.Chmod("testdata/embed/test.txt", os.FileMode(0600))
+	require.Error(t, err)
+	assert.True(t, commonerrors.CorrespondTo(err, "permission denied"))
+
+}

--- a/utils/filesystem/embedfs_test.go
+++ b/utils/filesystem/embedfs_test.go
@@ -131,6 +131,7 @@ func Test_embedFS_Read(t *testing.T) {
 func Test_embed_not_supported(t *testing.T) {
 	efs, err := NewEmbedFileSystem(nil)
 	errortest.RequireError(t, err, commonerrors.ErrUndefined)
+	assert.Nil(t, efs)
 
 	efs, err = NewEmbedFileSystem(&testContent)
 	require.NoError(t, err)

--- a/utils/filesystem/filesystem.go
+++ b/utils/filesystem/filesystem.go
@@ -2,10 +2,11 @@
  * Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package filesystem
 
 import (
-	"errors"
+	"embed"
 	"os"
 
 	"github.com/spf13/afero"
@@ -18,6 +19,7 @@ type FilesystemType int
 const (
 	StandardFS FilesystemType = iota
 	InMemoryFS
+	Embed
 )
 
 var (
@@ -32,6 +34,14 @@ func NewStandardFileSystem() FS {
 	return NewVirtualFileSystem(NewExtendedOsFs(), StandardFS, IdentityPathConverterFunc)
 }
 
+func NewEmbedFileSystem(fs *embed.FS) (FS, error) {
+	wrapped, err := newEmbedFSAdapter(fs)
+	if err != nil {
+		return nil, err
+	}
+	return NewVirtualFileSystem(wrapped, Embed, IdentityPathConverterFunc), nil
+}
+
 func NewFs(fsType FilesystemType) FS {
 	switch fsType {
 	case StandardFS:
@@ -42,12 +52,12 @@ func NewFs(fsType FilesystemType) FS {
 	return NewStandardFileSystem()
 }
 
-// Converts file system error into common errors
-func ConvertFileSytemError(err error) error {
+// ConvertFileSystemError converts file system error into common errors
+func ConvertFileSystemError(err error) error {
 	if err == nil {
 		return nil
 	}
-	if commonerrors.Any(err, os.ErrExist, errors.New("file exists"), errors.New("file already exists")) {
+	if commonerrors.Any(err, os.ErrExist) || commonerrors.CorrespondTo(err, "file exists", "file already exists") {
 		return commonerrors.ErrExists
 	}
 	return err

--- a/utils/filesystem/interfaces.go
+++ b/utils/filesystem/interfaces.go
@@ -219,6 +219,8 @@ type FS interface {
 	ReadFileWithLimits(filename string, limits ILimits) ([]byte, error)
 	// ReadFileWithContextAndLimits reads a file and returns its content. Limits and context are taken into account during the reading process.
 	ReadFileWithContextAndLimits(ctx context.Context, filename string, limits ILimits) ([]byte, error)
+	// ReadFileContent reads a file and returns its content. Limits and context are taken into account during the reading process.
+	ReadFileContent(ctx context.Context, file File, limits ILimits) ([]byte, error)
 	// WriteFile writes data to a file named by filename.
 	// If the file does not exist, WriteFile creates it with permissions perm;
 	// otherwise WriteFile truncates it before writing.

--- a/utils/filesystem/lockfile.go
+++ b/utils/filesystem/lockfile.go
@@ -135,7 +135,7 @@ func (l *RemoteLockFile) TryLock(ctx context.Context) (err error) {
 	lockPath := l.lockPath()
 	// create directory as lock
 	err = l.fs.vfs.Mkdir(lockPath, 0755)
-	if commonerrors.Any(ConvertFileSytemError(err), commonerrors.ErrExists) {
+	if commonerrors.Any(ConvertFileSystemError(err), commonerrors.ErrExists) {
 		if l.IsStale() {
 			if l.overrideStaleLock {
 				_ = l.ReleaseIfStale(ctx)

--- a/utils/filesystem/testdata/embed/test.txt
+++ b/utils/filesystem/testdata/embed/test.txt
@@ -1,0 +1,1 @@
+this is a text file with some content


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description
- `[filesystem]` Created Adapter to `embed.FS` for use of common utilities"
- `[filesystem]` Ability to read the content of an `afero.File`


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
