### PR TITLE
:sparkles: `[config]` Enable `time.Time` as valid configuration value

### DIFF
--- a/changes/20230626173820.feature
+++ b/changes/20230626173820.feature
@@ -1,0 +1,1 @@
+:sparkles: `[config]` Enable the ability to specify `time.Time` as configuration values

--- a/utils/config/fixtures/config-test.json
+++ b/utils/config/fixtures/config-test.json
@@ -2,6 +2,7 @@
   "dummy_string": "test string",
   "dummy_int": 1,
   "dummy_time": "54s",
+  "dummy_date": "2023-06-22T15:40:05Z",
   "dummyconfig": {
     "dummy_host": "host1",
     "port": 20,


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

- `viper` does not allow configuration fields to be `time.Time`. This PR is to enable this.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
