### PR TITLE
:sparkles: `[filesystem]` Add utilities to work with `io/fs FS`

### DIFF
--- a/changes/20230705185305.feature
+++ b/changes/20230705185305.feature
@@ -1,0 +1,1 @@
+:sparkles: `[filesystem]` Add utilities to work with `io/fs FS`

--- a/utils/filesystem/filesystem.go
+++ b/utils/filesystem/filesystem.go
@@ -20,6 +20,7 @@ const (
 	StandardFS FilesystemType = iota
 	InMemoryFS
 	Embed
+	Custom
 )
 
 var (

--- a/utils/filesystem/iofs.go
+++ b/utils/filesystem/iofs.go
@@ -1,0 +1,34 @@
+package filesystem
+
+import (
+	"fmt"
+	"io/fs"
+
+	"github.com/spf13/afero"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+)
+
+type wrappedFS struct {
+	filesystem FS
+}
+
+func (w *wrappedFS) Open(name string) (fs.File, error) {
+	return w.filesystem.GenericOpen(name)
+}
+
+// ConvertToIOFilesystem converts a filesystem FS to a io/fs FS
+func ConvertToIOFilesystem(filesystem FS) (fs.FS, error) {
+	if filesystem == nil {
+		return nil, fmt.Errorf("%w: missing filesystem", commonerrors.ErrUndefined)
+	}
+	return &wrappedFS{filesystem: filesystem}, nil
+}
+
+// ConvertFromIOFilesystem converts an io/fs FS into a FS
+func ConvertFromIOFilesystem(filesystem fs.FS) (FS, error) {
+	if filesystem == nil {
+		return nil, fmt.Errorf("%w: missing filesystem", commonerrors.ErrUndefined)
+	}
+	return NewVirtualFileSystem(afero.FromIOFS{FS: filesystem}, Custom, IdentityPathConverterFunc), nil
+}

--- a/utils/filesystem/iofs_test.go
+++ b/utils/filesystem/iofs_test.go
@@ -1,0 +1,25 @@
+package filesystem
+
+import (
+	"testing"
+
+	"github.com/bxcodec/faker/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_IoFS_Exists(t *testing.T) {
+	ifs, err := NewEmbedFileSystem(&testContent)
+	require.NoError(t, err)
+
+	ioFs, err := ConvertToIOFilesystem(ifs)
+	require.NoError(t, err)
+
+	fs, err := ConvertFromIOFilesystem(ioFs)
+	require.NoError(t, err)
+
+	assert.False(t, fs.Exists(faker.DomainName()))
+	assert.True(t, fs.Exists("testdata"))
+	assert.True(t, fs.Exists("testdata/embed"))
+	assert.True(t, fs.Exists("testdata/embed/level1/test.txt"))
+}

--- a/utils/mocks/mock_filesystem.go
+++ b/utils/mocks/mock_filesystem.go
@@ -1775,6 +1775,21 @@ func (mr *MockFSMockRecorder) ReadFile(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockFS)(nil).ReadFile), arg0)
 }
 
+// ReadFileContent mocks base method.
+func (m *MockFS) ReadFileContent(arg0 context.Context, arg1 filesystem.File, arg2 filesystem.ILimits) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadFileContent", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadFileContent indicates an expected call of ReadFileContent.
+func (mr *MockFSMockRecorder) ReadFileContent(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFileContent", reflect.TypeOf((*MockFS)(nil).ReadFileContent), arg0, arg1, arg2)
+}
+
 // ReadFileWithContext mocks base method.
 func (m *MockFS) ReadFileWithContext(arg0 context.Context, arg1 string) ([]byte, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description
-  `[filesystem]` Add utilities to work with `io/fs FS`


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
