### PR TITLE
:sparkles: `[filesystem]` File ownership utilities

### DIFF
--- a/changes/20230906170005.feature
+++ b/changes/20230906170005.feature
@@ -1,0 +1,1 @@
+:sparkles: `[filesystem]` Add utilities to Fetch and Change file ownership using `user.User`

--- a/utils/filesystem/files_windows.go
+++ b/utils/filesystem/files_windows.go
@@ -5,7 +5,7 @@ import (
 	"syscall"
 )
 
-func determineFileOwners(os.FileInfo) (uid, gid int, err error) {
+func determineFileOwners(_ os.FileInfo) (uid, gid int, err error) {
 	uid = syscall.Getuid()
 	gid = syscall.Getgid()
 

--- a/utils/filesystem/interfaces.go
+++ b/utils/filesystem/interfaces.go
@@ -1,13 +1,11 @@
-/*
- * Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
+// Package filesystem defines utilities with regards to filesystem access./*
 package filesystem
 
 import (
 	"context"
 	"io"
 	"os"
+	"os/user"
 	"path/filepath"
 	"time"
 
@@ -243,8 +241,12 @@ type FS interface {
 	Chtimes(name string, atime time.Time, mtime time.Time) error
 	// Chown changes the numeric uid and gid of the named file.
 	Chown(name string, uid, gid int) error
+	// ChangeOwnership changes the ownership of the named file.
+	ChangeOwnership(name string, owner *user.User) error
 	// FetchOwners returns the numeric uid and gid of the named file
 	FetchOwners(name string) (uid, gid int, err error)
+	// FetchFileOwner returns the owner of the named file.
+	FetchFileOwner(name string) (owner *user.User, err error)
 	// Link creates newname as a hard link to the oldname file
 	Link(oldname, newname string) error
 	// Readlink returns the destination of the named symbolic link.

--- a/utils/mocks/mock_filesystem.go
+++ b/utils/mocks/mock_filesystem.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	io "io"
 	fs "io/fs"
+	user "os/user"
 	filepath "path/filepath"
 	reflect "reflect"
 	time "time"
@@ -937,6 +938,20 @@ func (m *MockFS) EXPECT() *MockFSMockRecorder {
 	return m.recorder
 }
 
+// ChangeOwnership mocks base method.
+func (m *MockFS) ChangeOwnership(arg0 string, arg1 *user.User) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ChangeOwnership", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ChangeOwnership indicates an expected call of ChangeOwnership.
+func (mr *MockFSMockRecorder) ChangeOwnership(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeOwnership", reflect.TypeOf((*MockFS)(nil).ChangeOwnership), arg0, arg1)
+}
+
 // Chmod mocks base method.
 func (m *MockFS) Chmod(arg0 string, arg1 fs.FileMode) error {
 	m.ctrl.T.Helper()
@@ -1260,6 +1275,21 @@ func (m *MockFS) Exists(arg0 string) bool {
 func (mr *MockFSMockRecorder) Exists(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockFS)(nil).Exists), arg0)
+}
+
+// FetchFileOwner mocks base method.
+func (m *MockFS) FetchFileOwner(arg0 string) (*user.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchFileOwner", arg0)
+	ret0, _ := ret[0].(*user.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchFileOwner indicates an expected call of FetchFileOwner.
+func (mr *MockFSMockRecorder) FetchFileOwner(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchFileOwner", reflect.TypeOf((*MockFS)(nil).FetchFileOwner), arg0)
 }
 
 // FetchOwners mocks base method.
@@ -2283,6 +2313,20 @@ func (m *MockICloseableFS) EXPECT() *MockICloseableFSMockRecorder {
 	return m.recorder
 }
 
+// ChangeOwnership mocks base method.
+func (m *MockICloseableFS) ChangeOwnership(arg0 string, arg1 *user.User) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ChangeOwnership", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ChangeOwnership indicates an expected call of ChangeOwnership.
+func (mr *MockICloseableFSMockRecorder) ChangeOwnership(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeOwnership", reflect.TypeOf((*MockICloseableFS)(nil).ChangeOwnership), arg0, arg1)
+}
+
 // Chmod mocks base method.
 func (m *MockICloseableFS) Chmod(arg0 string, arg1 fs.FileMode) error {
 	m.ctrl.T.Helper()
@@ -2620,6 +2664,21 @@ func (m *MockICloseableFS) Exists(arg0 string) bool {
 func (mr *MockICloseableFSMockRecorder) Exists(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockICloseableFS)(nil).Exists), arg0)
+}
+
+// FetchFileOwner mocks base method.
+func (m *MockICloseableFS) FetchFileOwner(arg0 string) (*user.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchFileOwner", arg0)
+	ret0, _ := ret[0].(*user.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchFileOwner indicates an expected call of FetchFileOwner.
+func (mr *MockICloseableFSMockRecorder) FetchFileOwner(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchFileOwner", reflect.TypeOf((*MockICloseableFS)(nil).FetchFileOwner), arg0)
 }
 
 // FetchOwners mocks base method.


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description
- This PR adds some more utilities to the `filesystem` module to deal with file ownership

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
