### PR TITLE
:bug: `[platform]` differentiate between the different Windows architectures support

### DIFF
--- a/changes/20230919122752.bugfix
+++ b/changes/20230919122752.bugfix
@@ -1,0 +1,1 @@
+:bug: `[platform]` differentiate between the different architectures running Windows as `arm` is not fully supported

--- a/utils/platform/users.go
+++ b/utils/platform/users.go
@@ -127,8 +127,8 @@ func AssociateUserToGroup(ctx context.Context, username, groupName string) error
 	return ConvertUserGroupError(associateUserToGroup(ctx, username, groupName))
 }
 
-// DissociateUserToGroup removes a user from a group.
-func DissociateUserToGroup(ctx context.Context, username, groupName string) error {
+// DissociateUserFromGroup removes a user from a group.
+func DissociateUserFromGroup(ctx context.Context, username, groupName string) error {
 	err := parallelisation.DetermineContextError(ctx)
 	if err != nil {
 		return err
@@ -141,7 +141,7 @@ func DissociateUserToGroup(ctx context.Context, username, groupName string) erro
 	if !found && err == nil {
 		return nil
 	}
-	return ConvertUserGroupError(dissociateUserToGroup(ctx, username, groupName))
+	return ConvertUserGroupError(dissociateUserFromGroup(ctx, username, groupName))
 }
 
 // ConvertUserGroupError converts errors related to users in common errors.

--- a/utils/platform/users_posix.go
+++ b/utils/platform/users_posix.go
@@ -60,7 +60,7 @@ func associateUserToGroup(ctx context.Context, username, groupName string) (err 
 	return
 }
 
-func dissociateUserToGroup(ctx context.Context, username, groupName string) (err error) {
+func dissociateUserFromGroup(ctx context.Context, username, groupName string) (err error) {
 	err = executeCommand(ctx, "gpasswd", "-d", username, groupName)
 	return
 }

--- a/utils/platform/users_test.go
+++ b/utils/platform/users_test.go
@@ -41,7 +41,7 @@ func TestDefineUser(t *testing.T) {
 	assert.True(t, found)
 	defer func() { _ = RemoveGroup(context.Background(), user.Gid) }()
 	require.NoError(t, AssociateUserToGroup(context.TODO(), user.Username, user.Gid))
-	require.NoError(t, DissociateUserToGroup(context.TODO(), user.Username, user.Gid))
+	require.NoError(t, DissociateUserFromGroup(context.TODO(), user.Username, user.Gid))
 	require.NoError(t, DeleteUser(context.TODO(), user))
 	found, err = HasUser(user.Username)
 	assert.NoError(t, err)

--- a/utils/platform/users_windows_amd64.go
+++ b/utils/platform/users_windows_amd64.go
@@ -81,7 +81,7 @@ func associateUserToGroup(ctx context.Context, username, groupName string) (err 
 	return
 }
 
-func dissociateUserToGroup(ctx context.Context, username, groupName string) (err error) {
+func dissociateUserFromGroup(ctx context.Context, username, groupName string) (err error) {
 	err = parallelisation.DetermineContextError(ctx)
 	if err != nil {
 		return

--- a/utils/platform/users_windows_arm64.go
+++ b/utils/platform/users_windows_arm64.go
@@ -1,0 +1,68 @@
+//go:build windows
+// +build windows
+
+package platform
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/parallelisation"
+)
+
+// Note : there is no implementation for the arm architecture until support is provided by the following library https://github.com/iamacarpet/go-win64api/issues/62
+
+func addUser(ctx context.Context, username, fullname, password string) (err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+	err = fmt.Errorf("%w: cannot add user", commonerrors.ErrNotImplemented)
+	return
+}
+
+func removeUser(ctx context.Context, username string) (err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+	err = fmt.Errorf("%w: cannot remove user", commonerrors.ErrNotImplemented)
+	return
+}
+
+func addGroup(ctx context.Context, groupName string) (err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+	err = fmt.Errorf("%w: cannot add group", commonerrors.ErrNotImplemented)
+	return
+}
+
+func associateUserToGroup(ctx context.Context, username, groupName string) (err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+	err = fmt.Errorf("%w: cannot associate user to group", commonerrors.ErrNotImplemented)
+	return
+}
+
+func dissociateUserFromGroup(ctx context.Context, username, groupName string) (err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+	err = fmt.Errorf("%w: cannot dissociate user from group", commonerrors.ErrNotImplemented)
+	return
+}
+
+func removeGroup(ctx context.Context, groupName string) (err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+	err = fmt.Errorf("%w: cannot associate user to group", commonerrors.ErrNotImplemented)
+	return
+}


### PR DESCRIPTION

<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

- Windows on Arm is not supported by dependency and so must be differentiated from Intel Windows

### Test Coverage
- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
