### PR TITLE
:sparkles: Redefine commands depending on user permissions

### DIFF
--- a/changes/20231016164922.feature
+++ b/changes/20231016164922.feature
@@ -1,0 +1,1 @@
+:sparkles: `[collection]` Added `AllNotEmpty` and `AnyEmpty` to check the content of string slices

--- a/changes/20231016173631.feature
+++ b/changes/20231016173631.feature
@@ -1,0 +1,1 @@
+:sparkles: `[collection]` Added `FindInSlice` to extend `Find` search capabilities

--- a/changes/20231016175953.feature
+++ b/changes/20231016175953.feature
@@ -1,0 +1,1 @@
+:sparkles: `[platform]` Added a way to determine if a user has admin rights (i.e. root or superuser on Linux and administrator on Windows) 

--- a/changes/20231016204910.feature
+++ b/changes/20231016204910.feature
@@ -1,0 +1,1 @@
+:sparkles: `[command]` Added a way to prepend commands (using `Prepend()`) to command wrappers in order to chain command wrappers easily

--- a/changes/20231016234712.feature
+++ b/changes/20231016234712.feature
@@ -1,0 +1,1 @@
+:sparkles: `[platform]` Added `WithPrivileges` so that commands are elevated with privileges depending on the permissions of the current user

--- a/utils/collection/search.go
+++ b/utils/collection/search.go
@@ -22,7 +22,7 @@ func FindInSlice(strict bool, slice []string, val ...string) (int, bool) {
 		return -1, false
 	}
 
-	inSlice := make(map[string]int)
+	inSlice := make(map[string]int, len(slice))
 	for i := range slice {
 		item := slice[i]
 		if !strict {

--- a/utils/collection/search.go
+++ b/utils/collection/search.go
@@ -4,29 +4,100 @@
  */
 package collection
 
+import "strings"
+
 // Find looks for an element in a slice. If found it will
 // return its index and true; otherwise it will return -1 and false.
 func Find(slice *[]string, val string) (int, bool) {
-	for i, item := range *slice {
-		if item == val {
-			return i, true
+	if slice == nil {
+		return -1, false
+	}
+	return FindInSlice(true, *slice, val)
+}
+
+// FindInSlice finds if any values val are present in the slice and if so returns the first index.
+// if strict, it check of an exact match; otherwise discard whitespaces and case.
+func FindInSlice(strict bool, slice []string, val ...string) (int, bool) {
+	if len(val) == 0 || len(slice) == 0 {
+		return -1, false
+	}
+	if len(slice) > len(val) {
+		for i := range slice {
+			item := slice[i]
+			if !strict {
+				item = strings.TrimSpace(item)
+			}
+			for j := range val {
+				if !strict && strings.EqualFold(item, val[j]) {
+					return i, true
+				} else if strict && item == val[j] {
+					return i, true
+				}
+			}
+		}
+	} else {
+		for j := range val {
+			for i := range slice {
+				item := slice[i]
+				if !strict {
+					item = strings.TrimSpace(item)
+				}
+				if !strict && strings.EqualFold(item, val[j]) {
+					return i, true
+				} else if strict && item == val[j] {
+					return i, true
+				}
+			}
 		}
 	}
+
 	return -1, false
 }
 
+// Any returns true if there is at least one element of the slice which is true.
 func Any(slice []bool) bool {
-	for _, v := range slice {
-		if v {
+	for i := range slice {
+		if slice[i] {
 			return true
 		}
 	}
 	return false
 }
 
+// AnyEmpty returns whether there is one entry in the slice which is empty.
+// If strict, then whitespaces are considered as empty strings
+func AnyEmpty(strict bool, slice []string) bool {
+	for i := range slice {
+		item := slice[i]
+		if strict {
+			item = strings.TrimSpace(item)
+		}
+		if item == "" {
+			return true
+		}
+	}
+	return false
+}
+
+// All returns true if all items of the slice are true.
 func All(slice []bool) bool {
-	for _, v := range slice {
-		if !v {
+	for i := range slice {
+		if !slice[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// AllNotEmpty returns whether all elements of the slice are not empty.
+// If strict, then whitespaces are considered as empty strings
+func AllNotEmpty(strict bool, slice []string) bool {
+	for i := range slice {
+		item := slice[i]
+		if strict {
+			item = strings.TrimSpace(item)
+		}
+		if item == "" {
 			return false
 		}
 	}

--- a/utils/collection/search.go
+++ b/utils/collection/search.go
@@ -21,33 +21,25 @@ func FindInSlice(strict bool, slice []string, val ...string) (int, bool) {
 	if len(val) == 0 || len(slice) == 0 {
 		return -1, false
 	}
-	if len(slice) > len(val) {
-		for i := range slice {
-			item := slice[i]
-			if !strict {
-				item = strings.TrimSpace(item)
-			}
-			for j := range val {
-				if !strict && strings.EqualFold(item, val[j]) {
-					return i, true
-				} else if strict && item == val[j] {
-					return i, true
-				}
-			}
+
+	inSlice := make(map[string]int)
+	for i := range slice {
+		item := slice[i]
+		if !strict {
+			item = strings.ToLower(strings.TrimSpace(item))
 		}
-	} else {
-		for j := range val {
-			for i := range slice {
-				item := slice[i]
-				if !strict {
-					item = strings.TrimSpace(item)
-				}
-				if !strict && strings.EqualFold(item, val[j]) {
-					return i, true
-				} else if strict && item == val[j] {
-					return i, true
-				}
-			}
+		if _, ok := inSlice[item]; !ok {
+			inSlice[item] = i
+		}
+	}
+
+	for i := range val {
+		item := val[i]
+		if !strict {
+			item = strings.ToLower(strings.TrimSpace(item))
+		}
+		if idx, ok := inSlice[item]; ok {
+			return idx, true
 		}
 	}
 

--- a/utils/collection/search.go
+++ b/utils/collection/search.go
@@ -67,16 +67,8 @@ func Any(slice []bool) bool {
 // AnyEmpty returns whether there is one entry in the slice which is empty.
 // If strict, then whitespaces are considered as empty strings
 func AnyEmpty(strict bool, slice []string) bool {
-	for i := range slice {
-		item := slice[i]
-		if strict {
-			item = strings.TrimSpace(item)
-		}
-		if item == "" {
-			return true
-		}
-	}
-	return false
+	_, found := FindInSlice(!strict, slice, "")
+	return found
 }
 
 // All returns true if all items of the slice are true.
@@ -92,14 +84,6 @@ func All(slice []bool) bool {
 // AllNotEmpty returns whether all elements of the slice are not empty.
 // If strict, then whitespaces are considered as empty strings
 func AllNotEmpty(strict bool, slice []string) bool {
-	for i := range slice {
-		item := slice[i]
-		if strict {
-			item = strings.TrimSpace(item)
-		}
-		if item == "" {
-			return false
-		}
-	}
-	return true
+	_, found := FindInSlice(!strict, slice, "")
+	return !found
 }

--- a/utils/collection/search_test.go
+++ b/utils/collection/search_test.go
@@ -5,9 +5,9 @@
 package collection
 
 import (
-	"github.com/bxcodec/faker/v3"
 	"testing"
 
+	"github.com/bxcodec/faker/v3"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/utils/collection/search_test.go
+++ b/utils/collection/search_test.go
@@ -5,19 +5,56 @@
 package collection
 
 import (
+	"github.com/bxcodec/faker/v3"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestFind(t *testing.T) {
-	index, found := Find(&[]string{"A", "b", "c"}, "D")
+	index, found := Find(nil, "D")
+	assert.False(t, found)
+	assert.Equal(t, -1, index)
+	index, found = Find(&[]string{"A", "b", "c"}, "D")
 	assert.False(t, found)
 	assert.Equal(t, -1, index)
 
 	index, found = Find(&[]string{"A", "B", "b", "c"}, "b")
 	assert.True(t, found)
 	assert.Equal(t, 2, index)
+}
+
+func TestFindInSlice(t *testing.T) {
+	index, found := FindInSlice(true, nil, "D")
+	assert.False(t, found)
+	assert.Equal(t, -1, index)
+	index, found = FindInSlice(true, []string{"A", "b", "c"})
+	assert.False(t, found)
+	assert.Equal(t, -1, index)
+	index, found = FindInSlice(true, []string{"A", "b", "c"}, "D")
+	assert.False(t, found)
+	assert.Equal(t, -1, index)
+	index, found = FindInSlice(true, []string{"A", "b", "c"}, "D", "e", "f", "g", "H")
+	assert.False(t, found)
+	assert.Equal(t, -1, index)
+	index, found = FindInSlice(false, []string{"A", "b", "c"}, "D")
+	assert.False(t, found)
+	assert.Equal(t, -1, index)
+	index, found = FindInSlice(false, []string{"A", "b", "c"}, "D", "e", "f", "g", "H")
+	assert.False(t, found)
+	assert.Equal(t, -1, index)
+	index, found = FindInSlice(true, []string{"A", "B", "b", "c"}, "b")
+	assert.True(t, found)
+	assert.Equal(t, 2, index)
+	index, found = FindInSlice(false, []string{"A", "B", "b", "c"}, "b")
+	assert.True(t, found)
+	assert.Equal(t, 1, index)
+	index, found = FindInSlice(true, []string{"A", "B", "b", "c"}, "b", "D", "e", "f", "g", "H")
+	assert.True(t, found)
+	assert.Equal(t, 2, index)
+	index, found = FindInSlice(false, []string{"A", "B", "b", "c"}, "b", "D", "e", "f", "g", "H")
+	assert.True(t, found)
+	assert.Equal(t, 1, index)
 }
 
 func TestAny(t *testing.T) {
@@ -32,4 +69,24 @@ func TestAll(t *testing.T) {
 	assert.False(t, All([]bool{false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false}))
 	assert.True(t, All([]bool{true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true}))
 	assert.False(t, All([]bool{true, true, true, true, true, true, true, true, true, false, true, true, true, true, true, true, true, true, true, true}))
+}
+
+func TestAnyEmpty(t *testing.T) {
+	assert.True(t, AnyEmpty(false, []string{faker.Username(), faker.Name(), faker.Sentence(), ""}))
+	assert.False(t, AnyEmpty(false, []string{faker.Username(), "         ", faker.Name(), faker.Sentence()}))
+	assert.True(t, AnyEmpty(true, []string{faker.Username(), "         ", faker.Name(), faker.Sentence()}))
+	assert.True(t, AnyEmpty(false, []string{"", faker.Name(), faker.Sentence()}))
+	assert.True(t, AnyEmpty(false, []string{faker.Username(), "", faker.Name(), faker.Sentence()}))
+	assert.True(t, AnyEmpty(false, []string{faker.Username(), "", faker.Name(), "", faker.Sentence()}))
+	assert.False(t, AnyEmpty(false, []string{faker.Username(), faker.Name(), faker.Sentence()}))
+}
+
+func TestAllNotEmpty(t *testing.T) {
+	assert.False(t, AllNotEmpty(false, []string{faker.Username(), faker.Name(), faker.Sentence(), ""}))
+	assert.False(t, AllNotEmpty(false, []string{"", faker.Name(), faker.Sentence()}))
+	assert.False(t, AllNotEmpty(false, []string{faker.Username(), "", faker.Name(), faker.Sentence()}))
+	assert.True(t, AllNotEmpty(false, []string{faker.Username(), "     ", faker.Name(), faker.Sentence()}))
+	assert.False(t, AllNotEmpty(true, []string{faker.Username(), "      ", faker.Name(), faker.Sentence()}))
+	assert.False(t, AllNotEmpty(false, []string{faker.Username(), "", faker.Name(), "", faker.Sentence()}))
+	assert.True(t, AllNotEmpty(false, []string{faker.Username(), faker.Name(), faker.Sentence()}))
 }

--- a/utils/platform/cmd.go
+++ b/utils/platform/cmd.go
@@ -1,0 +1,22 @@
+package platform
+
+import "github.com/ARM-software/golang-utils/utils/subprocess/command"
+
+// WithPrivileges redefines a command so that it is run with elevated privileges.
+// For instance, on Linux, if the current user has enough privileges, the command will be run as is.
+// Otherwise, `sudo` will be used if defined as the sudo  (See `DefineSudoCommand`).
+// Similar scenario will happen on Windows, although the elevated command is defined using `DefineSudoCommand`.
+func WithPrivileges(cmd *command.CommandAsDifferentUser) (cmdWithPrivileges *command.CommandAsDifferentUser) {
+	cmdWithPrivileges = cmd
+	if cmdWithPrivileges == nil {
+		cmdWithPrivileges = command.NewCommandAsDifferentUser()
+	}
+	hasPrivileges, err := IsCurrentUserAnAdmin()
+	if err != nil {
+		return
+	}
+	if !hasPrivileges {
+		cmdWithPrivileges.Prepend(getRunCommandWithPrivileges())
+	}
+	return
+}

--- a/utils/platform/cmd_posix.go
+++ b/utils/platform/cmd_posix.go
@@ -11,15 +11,14 @@ var (
 	sudoCommand = command.Sudo()
 )
 
-// DefineSudoCommand defines the command to run to be `root` or a user with enough privileges to manage accounts.
+// DefineSudoCommand defines the command to run to be `root` or a user with enough privileges (superuser).
 // e.g.
 //   - args="sudo" to run commands as `root`
 //   - args="su", "tom" if `tom` has enough privileges to run the command
-//   - args="gosu", "tom" if `tom` has enough privileges to run the command in a container and `gosu` is installed
 func DefineSudoCommand(args ...string) {
 	sudoCommand = command.NewCommandAsDifferentUser(args...)
 }
 
-func defineCommandWithPrivileges(args ...string) (string, []string) {
-	return sudoCommand.RedefineCommand(args...)
+func getRunCommandWithPrivileges() *command.CommandAsDifferentUser {
+	return sudoCommand
 }

--- a/utils/platform/cmd_test.go
+++ b/utils/platform/cmd_test.go
@@ -1,0 +1,33 @@
+package platform
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/bxcodec/faker/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ARM-software/golang-utils/utils/subprocess/command"
+)
+
+func TestWithPrivileges(t *testing.T) {
+	admin, err := IsCurrentUserAnAdmin()
+	require.NoError(t, err)
+	name := faker.Username()
+	cmd := WithPrivileges(command.Gosu(name)).RedefineInShellForm("test", "1", "2", "3")
+	if admin {
+		assert.Equal(t, fmt.Sprintf("gosu %v test 1 2 3", name), cmd)
+	} else {
+		assert.True(t, strings.Contains(cmd, fmt.Sprintf("gosu %v test 1 2 3", name)))
+		assert.False(t, strings.HasPrefix(cmd, fmt.Sprintf("gosu %v test 1 2 3", name)))
+	}
+	cmd = WithPrivileges(nil).RedefineInShellForm("test", "1", "2", "3")
+	if admin {
+		assert.Equal(t, "test 1 2 3", cmd)
+	} else {
+		assert.True(t, strings.Contains(cmd, "test 1 2 3"))
+		assert.False(t, strings.HasPrefix(cmd, "test 1 2 3"))
+	}
+}

--- a/utils/platform/cmd_windows.go
+++ b/utils/platform/cmd_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+// +build windows
+
+package platform
+
+import "github.com/ARM-software/golang-utils/utils/subprocess/command"
+
+var (
+	// runAsAdmin describes the command to use to run command as Administrator
+	// See https://ss64.com/nt/syntax-elevate.html
+	// see https://lazyadmin.nl/it/runas-command/
+	// see https://www.tenforums.com/general-support/111929-how-use-runas-without-password-prompt.html
+	runAsAdmin = command.RunAs("Administrator")
+)
+
+// DefineRunAsAdmin defines the command to run as Administrator.
+// e.g.
+//   - args="runas", "/user:adrien" to run commands as `adrien`
+func DefineRunAsAdmin(args ...string) {
+	runAsAdmin = command.NewCommandAsDifferentUser(args...)
+}
+
+func getRunCommandWithPrivileges() *command.CommandAsDifferentUser {
+	return runAsAdmin
+}

--- a/utils/platform/users.go
+++ b/utils/platform/users.go
@@ -95,6 +95,7 @@ func IsUserAdmin(user *user.User) (admin bool, err error) {
 		return
 	}
 	admin, err = IsAdmin(user.Username)
+	err = ConvertUserGroupError(err)
 	return
 }
 
@@ -118,6 +119,7 @@ func IsAdmin(username string) (admin bool, err error) {
 		return
 	}
 	admin, err = isCurrentAdmin()
+	err = ConvertUserGroupError(err)
 	return
 }
 

--- a/utils/platform/users_posix.go
+++ b/utils/platform/users_posix.go
@@ -6,9 +6,17 @@ package platform
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"os/user"
 
+	"github.com/ARM-software/golang-utils/utils/collection"
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
+)
+
+const (
+	RootGroup    = "root"
+	SudoersGroup = "sudo"
 )
 
 func addUser(ctx context.Context, username, fullname, password string) (err error) {
@@ -58,7 +66,7 @@ func executeCommand(ctx context.Context, args ...string) error {
 	if len(args) == 0 {
 		return fmt.Errorf("%w: missing command to execute", commonerrors.ErrUndefined)
 	}
-	cmdName, cmdArgs := defineCommandWithPrivileges(args...)
+	cmdName, cmdArgs := WithPrivileges(nil).RedefineCommand(args...)
 	cmd := exec.CommandContext(ctx, cmdName, cmdArgs...)
 	return runCommand(args[0], cmd)
 }
@@ -80,4 +88,36 @@ func runCommand(cmdDescription string, cmd *exec.Cmd) error {
 		newErr = fmt.Errorf("%w: the command `%v` failed: %v (%v)", commonerrors.ErrUnknown, cmdDescription, err.Error(), details)
 		return newErr
 	}
+}
+
+func isAdmin(username string) (admin bool, err error) {
+	if username == "root" {
+		admin = true
+		return
+	}
+	err = fmt.Errorf("%w: could not check whether the user is a superuser or not", commonerrors.ErrNotImplemented)
+	return
+}
+
+func isUserAdmin(user *user.User) (admin bool, err error) {
+	// following method mentioned [here](https://linuxhandbook.com/check-if-user-has-sudo-rights/#method-2-check-if-user-is-part-of-the-sudo-group)
+	gids, subErr := user.GroupIds()
+
+	if subErr == nil {
+		_, admin = collection.FindInSlice(true, gids, RootGroup, SudoersGroup)
+	}
+	admin, err = isAdmin(user.Username)
+	return
+}
+
+func isCurrentAdmin() (admin bool, err error) {
+	// It is not great but following [this way](https://serverfault.com/questions/568627/can-a-program-tell-it-is-being-run-under-sudo)
+	// also mentioned [here](https://stackoverflow.com/questions/29733575/how-to-find-the-user-that-executed-a-program-as-root-using-golang)
+	// and [here](https://stackoverflow.com/questions/10272784/how-do-i-get-the-users-real-uid-if-the-program-is-run-with-sudo)
+	if collection.AllNotEmpty(true, []string{
+		os.Getenv("SUDO_USER"), os.Getenv("SUDO_COMMAND"), os.Getenv("SUDO_UID"), os.Getenv("SUDO_GID"),
+	}) {
+		admin = true
+	}
+	return
 }

--- a/utils/platform/users_posix.go
+++ b/utils/platform/users_posix.go
@@ -105,6 +105,9 @@ func isUserAdmin(user *user.User) (admin bool, err error) {
 
 	if subErr == nil {
 		_, admin = collection.FindInSlice(true, gids, RootGroup, SudoersGroup)
+		if admin {
+			return
+		}
 	}
 	admin, err = isAdmin(user.Username)
 	return

--- a/utils/platform/users_test.go
+++ b/utils/platform/users_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/bxcodec/faker/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
 )
 
 func generateTestUser() (testUser *user.User) {
@@ -50,4 +53,19 @@ func TestDefineUser(t *testing.T) {
 	found, err = HasGroup(user.Gid)
 	assert.NoError(t, err)
 	assert.False(t, found)
+}
+
+func TestIsAdmin(t *testing.T) {
+	testuser := generateTestUser()
+	admin, _ := IsAdmin(testuser.Username)
+	assert.False(t, admin)
+	currentUser, err := user.Current()
+	require.NoError(t, err)
+	admin, _ = IsAdmin(currentUser.Username)
+	assert.False(t, admin)
+	admin, _ = IsUserAdmin(currentUser)
+	assert.False(t, admin)
+	_, err = IsUserAdmin(nil)
+	assert.Error(t, err)
+	errortest.AssertError(t, err, commonerrors.ErrUndefined)
 }

--- a/utils/platform/users_windows.go
+++ b/utils/platform/users_windows.go
@@ -1,0 +1,53 @@
+//go:build windows
+// +build windows
+
+package platform
+
+import (
+	"os"
+	"os/exec"
+	"os/user"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/ARM-software/golang-utils/utils/collection"
+)
+
+const (
+	AdministratorsGroup = "S-1-5-32-544" //https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers
+)
+
+func isUserAdmin(user *user.User) (admin bool, err error) {
+	gids, subErr := user.GroupIds()
+	if subErr == nil {
+		_, admin = collection.FindInSlice(true, gids, AdministratorsGroup)
+		if admin {
+			return
+		}
+	}
+	admin, err = isAdmin(user.Username)
+	return
+}
+
+func isCurrentAdmin() (admin bool, err error) {
+	// In order to avoid, this https://stackoverflow.com/questions/8046097/how-to-check-if-a-process-has-the-administrative-rights
+	// https://gist.github.com/jerblack/d0eb182cc5a1c1d92d92a4c4fcc416c6
+	file, subErr := os.Open("\\\\.\\PHYSICALDRIVE0")
+	defer func() {
+		if file != nil {
+			_ = file.Close()
+		}
+	}()
+	admin = subErr == nil
+	if admin {
+		return
+	}
+	// extra check https://stackoverflow.com/a/28268802
+	subErr = exec.Command("fltmc").Run()
+	admin = subErr == nil
+	if admin {
+		return
+	}
+	admin = windows.GetCurrentProcessToken().IsElevated()
+	return
+}

--- a/utils/platform/users_windows_amd64.go
+++ b/utils/platform/users_windows_amd64.go
@@ -6,7 +6,6 @@ package platform
 import (
 	"context"
 	"fmt"
-
 	wapi "github.com/iamacarpet/go-win64api"
 
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
@@ -111,6 +110,14 @@ func removeGroup(ctx context.Context, groupName string) (err error) {
 	if !success {
 		err = fmt.Errorf("%w: failed removing group", commonerrors.ErrUnknown)
 		return
+	}
+	return
+}
+
+func isAdmin(username string) (admin bool, err error) {
+	admin, err = wapi.IsLocalUserAdmin(username)
+	if err != nil {
+		err = fmt.Errorf("%w: could not determine if user is an admin: %v", commonerrors.ErrUnexpected, err.Error())
 	}
 	return
 }

--- a/utils/platform/users_windows_arm64.go
+++ b/utils/platform/users_windows_arm64.go
@@ -6,7 +6,6 @@ package platform
 import (
 	"context"
 	"fmt"
-
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/parallelisation"
 )
@@ -64,5 +63,10 @@ func removeGroup(ctx context.Context, groupName string) (err error) {
 		return
 	}
 	err = fmt.Errorf("%w: cannot associate user to group", commonerrors.ErrNotImplemented)
+	return
+}
+
+func isAdmin(username string) (admin bool, err error) {
+	err = fmt.Errorf("%w: cannot determine if user is admin", commonerrors.ErrNotImplemented)
 	return
 }

--- a/utils/subprocess/command/cmd.go
+++ b/utils/subprocess/command/cmd.go
@@ -1,35 +1,50 @@
 package command
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
 
 // CommandAsDifferentUser helps redefining commands so that they are run as a different user or with more privileges.
 type CommandAsDifferentUser struct {
+	mu sync.RWMutex
 	// changeUserCmd describes the command to use to execute any command as a different user
 	// e.g. it can be set as "sudo" to run commands as `root` or as "su","tom" or "gosu","jack"
 	changeUserCmd []string
+	prepend       *CommandAsDifferentUser
 }
 
 // Redefine redefines a command so that it will be run as a different user.
 func (c *CommandAsDifferentUser) Redefine(cmd string, args ...string) (cmdName string, cmdArgs []string) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	newArgs := []string{cmd}
 	newArgs = append(newArgs, args...)
-	cmdName, cmdArgs = c.RedefineCommand(newArgs...)
+	cmdName, cmdArgs = c.redefineCommand(newArgs...)
 	return
 }
 
 // RedefineCommand is the same as Redefine but with no separation between the command and its arguments (like the command in Docker)
 func (c *CommandAsDifferentUser) RedefineCommand(args ...string) (cmdName string, cmdArgs []string) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	cmdName, cmdArgs = c.redefineCommand(args...)
+	return
+}
+
+func (c *CommandAsDifferentUser) redefineCommand(args ...string) (cmdName string, cmdArgs []string) {
 	if len(c.changeUserCmd) > 0 {
 		cmdName = c.changeUserCmd[0]
-		for i := 1; i < len(c.changeUserCmd); i++ {
-			cmdArgs = append(cmdArgs, c.changeUserCmd[i])
-		}
+		cmdArgs = append(cmdArgs, c.changeUserCmd[1:]...)
 		cmdArgs = append(cmdArgs, args...)
 	} else {
 		cmdName = args[0]
-		for i := 1; i < len(args); i++ {
-			cmdArgs = append(cmdArgs, args[i])
-		}
+		cmdArgs = append(cmdArgs, args[1:]...)
+	}
+	if c.prepend != nil {
+		cmdName, cmdArgs = c.prepend.Redefine(cmdName, cmdArgs...)
+		return
 	}
 	return
 }
@@ -38,6 +53,16 @@ func (c *CommandAsDifferentUser) RedefineCommand(args ...string) (cmdName string
 func (c *CommandAsDifferentUser) RedefineInShellForm(cmd string, args ...string) string {
 	ncmd, nargs := c.Redefine(cmd, args...)
 	return AsShellForm(ncmd, nargs...)
+}
+
+// Prepend prepends a command translator to this command translator
+// This can be used to run command as a separate user and with higher privileges e.g. `sudo`.
+// It returns this for use in fluent expressions e.g. Gosu(...).Prepend(Sudo()).RedefineInShellForm(...)
+func (c *CommandAsDifferentUser) Prepend(cmd *CommandAsDifferentUser) *CommandAsDifferentUser {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.prepend = cmd
+	return c
 }
 
 // NewCommandAsDifferentUser defines a command wrapper which helps redefining commands so that they are run as a different user.
@@ -49,12 +74,12 @@ func NewCommandAsDifferentUser(switchUserCmd ...string) *CommandAsDifferentUser 
 	return &CommandAsDifferentUser{changeUserCmd: switchUserCmd}
 }
 
-// NewCommandAsRoot will create a command translator which will run command with `sudo`
+// NewCommandAsRoot will create a command translator which will run command with `sudo` (for Unix Only)
 func NewCommandAsRoot() *CommandAsDifferentUser {
 	return NewCommandAsDifferentUser("sudo")
 }
 
-// Sudo will call commands with `sudo`. Similar to NewCommandAsRoot
+// Sudo will call commands with `sudo`. Similar to NewCommandAsRoot (for Unix Only)
 func Sudo() *CommandAsDifferentUser {
 	return NewCommandAsRoot()
 }
@@ -69,7 +94,7 @@ func Gosu(username string) *CommandAsDifferentUser {
 	return NewCommandInContainerAs(username)
 }
 
-// Su will run commands as the user username using [su](https://www.unix.com/man-page/posix/1/su/)
+// Su will run commands as the user username using [su](https://www.unix.com/man-page/posix/1/su/)  (for Unix Only)
 func Su(username string) *CommandAsDifferentUser {
 	return NewCommandAsDifferentUser("su", username)
 }
@@ -77,6 +102,21 @@ func Su(username string) *CommandAsDifferentUser {
 // Me will run the commands without switching user. It is a no operation wrapper.
 func Me() *CommandAsDifferentUser {
 	return NewCommandAsDifferentUser()
+}
+
+// RunAs will run commands as the user username using [runas](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/cc771525%28v=ws.11%29) (For WINDOWS only)
+func RunAs(username string) *CommandAsDifferentUser {
+	return NewCommandAsDifferentUser("runas", fmt.Sprintf("/user:%v", username))
+}
+
+// Elevate will call commands with [elevate](https://learn.microsoft.com/en-us/previous-versions/technet-magazine/cc162321(v=msdn.10)) assuming the tool is installed on the platform. (For WINDOWS only)
+func Elevate() *CommandAsDifferentUser {
+	return NewCommandAsDifferentUser("elevate")
+}
+
+// ShellRunAs will call commands with [shellrunas](https://learn.microsoft.com/en-gb/sysinternals/downloads/shellrunas) assuming [SysInternals](https://docs.microsoft.com/en-gb/sysinternals/downloads/sysinternals-suite) is installed on the platform. (For WINDOWS only)
+func ShellRunAs() *CommandAsDifferentUser {
+	return NewCommandAsDifferentUser("shellrunas", "/quiet")
 }
 
 // AsShellForm returns a command in its shell form.

--- a/utils/subprocess/command/cmd_test.go
+++ b/utils/subprocess/command/cmd_test.go
@@ -14,7 +14,27 @@ func TestCommandAsDifferentUser_Redefine(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("su %v test 1 2 3", name), Su(name).RedefineInShellForm("test", "1", "2", "3"))
 	name = faker.Username()
 	assert.Equal(t, fmt.Sprintf("gosu %v test 1 2 3", name), Gosu(name).RedefineInShellForm("test", "1", "2", "3"))
+	assert.Equal(t, fmt.Sprintf("runas /user:%v test 1 2 3", name), RunAs(name).RedefineInShellForm("test", "1", "2", "3"))
+	assert.Equal(t, "elevate test", Elevate().RedefineInShellForm("test"))
+	assert.Equal(t, "shellrunas /quiet test", ShellRunAs().RedefineInShellForm("test"))
 	assert.Equal(t, "test 1 2 3", NewCommandAsDifferentUser().RedefineInShellForm("test", "1", "2", "3"))
 	assert.Equal(t, "test", Me().RedefineInShellForm("test"))
 	assert.Empty(t, Me().RedefineInShellForm(""))
+	cmd, args := Me().Redefine("test")
+	assert.Equal(t, "test", cmd)
+	assert.Empty(t, args)
+}
+
+func TestCommandAsDifferentUser_Prepend(t *testing.T) {
+	name := faker.Username()
+	assert.Equal(t, fmt.Sprintf("sudo gosu %v test 1 2 3", name), Gosu(name).Prepend(Sudo()).RedefineInShellForm("test", "1", "2", "3"))
+	name = faker.Username()
+	assert.Equal(t, fmt.Sprintf("sudo gosu %v test", name), Gosu(name).Prepend(Sudo()).RedefineInShellForm("test"))
+	cmd, args := Me().Prepend(Sudo()).Redefine("test")
+	assert.Equal(t, "sudo", cmd)
+	assert.Len(t, args, 1)
+	cmd, args = Me().Prepend(NewCommandAsDifferentUser()).Redefine("test")
+	assert.Equal(t, "test", cmd)
+	assert.Empty(t, args)
+
 }


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

- `[platform]` Added `WithPrivileges` so that commands are elevated with privileges depending on the permissions of the current user
this  is so that commands are redefined automatically to run with `sudo` or `runas` depending on current user permissions



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
