### PR TITLE
:sparkles: `[platform]` Ability to get user information

### DIFF
--- a/changes/20231026104543.feature
+++ b/changes/20231026104543.feature
@@ -1,0 +1,1 @@
+:sparkles: `[platform]` Add `GetUser()` and `GetCurrentUser()`

--- a/utils/environment/current.go
+++ b/utils/environment/current.go
@@ -5,24 +5,16 @@ import (
 	"os/user"
 
 	"github.com/joho/godotenv"
-	"github.com/mitchellh/go-homedir"
 
 	"github.com/ARM-software/golang-utils/utils/filesystem"
+	"github.com/ARM-software/golang-utils/utils/platform"
 )
 
 type currentEnv struct {
 }
 
 func (c *currentEnv) GetCurrentUser() (currentUser *user.User) {
-	currentUser, err := user.Current()
-	if err != nil {
-		return
-	}
-	home, err := homedir.Dir()
-	if err != nil {
-		return
-	}
-	currentUser.HomeDir = home
+	currentUser, _ = platform.GetCurrentUser()
 	return
 }
 

--- a/utils/platform/users.go
+++ b/utils/platform/users.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"os/user"
 
+	"github.com/mitchellh/go-homedir"
+
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/parallelisation"
-	"github.com/mitchellh/go-homedir"
 )
 
 // DefineUser adds a new user to the platform

--- a/utils/platform/users.go
+++ b/utils/platform/users.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/parallelisation"
+	"github.com/mitchellh/go-homedir"
 )
 
 // DefineUser adds a new user to the platform
@@ -70,6 +71,46 @@ func HasUser(username string) (found bool, err error) {
 	if user != nil {
 		found = true
 	}
+	return
+}
+
+// GetUser returns information about a user and expands its home directory.
+func GetUser(username string) (auser *user.User, err error) {
+	auser, err = user.Lookup(username)
+	if err != nil {
+		err = ConvertUserGroupError(err)
+		return
+	}
+	if auser == nil {
+		err = fmt.Errorf("%w: missing user information", commonerrors.ErrUnexpected)
+		return
+	}
+	home, err := homedir.Expand(auser.HomeDir)
+	if err != nil {
+		err = fmt.Errorf("%w: could not expand user [%v]'s home directory: %v", commonerrors.ErrUnexpected, username, err.Error())
+		return
+	}
+	auser.HomeDir = home
+	return
+}
+
+// GetCurrentUser returns information about the current platform's user and expands its home directory.
+func GetCurrentUser() (currentUser *user.User, err error) {
+	currentUser, err = user.Current()
+	if err != nil {
+		err = ConvertUserGroupError(err)
+		return
+	}
+	if currentUser == nil {
+		err = fmt.Errorf("%w: missing user information", commonerrors.ErrUnexpected)
+		return
+	}
+	home, err := homedir.Dir()
+	if err != nil {
+		err = fmt.Errorf("%w: could not retrieve information about current user's home directory: %v", commonerrors.ErrUnexpected, err.Error())
+		return
+	}
+	currentUser.HomeDir = home
 	return
 }
 

--- a/utils/platform/users_test.go
+++ b/utils/platform/users_test.go
@@ -29,6 +29,10 @@ func TestDefineUser(t *testing.T) {
 	// Note: on Windows, it is necessary to run this test with elevated privileges https://github.com/iamacarpet/go-win64api/issues/26
 	if IsWindows() {
 		t.Log("Note: it is necessary to run this test with elevated privileges https://github.com/iamacarpet/go-win64api/issues/26")
+		admin, _ := IsCurrentUserAnAdmin()
+		if !admin {
+			t.Skip("Skipping as running on windows with a non-admin user")
+		}
 	}
 	user := generateTestUser()
 	err := DefineUser(context.TODO(), user, "")
@@ -53,6 +57,19 @@ func TestDefineUser(t *testing.T) {
 	found, err = HasGroup(user.Gid)
 	assert.NoError(t, err)
 	assert.False(t, found)
+}
+
+func TestGetUser(t *testing.T) {
+	currentUser, err := GetCurrentUser()
+	require.NoError(t, err)
+	require.NotEmpty(t, currentUser)
+	assert.NotEmpty(t, currentUser.HomeDir)
+	assert.NotEmpty(t, currentUser.Username)
+	user, err := GetUser(currentUser.Username)
+	require.NoError(t, err)
+	require.NotEmpty(t, user)
+	assert.Equal(t, currentUser.HomeDir, user.HomeDir)
+	assert.Equal(t, currentUser.Username, user.Username)
 }
 
 func TestIsAdmin(t *testing.T) {


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

This is calling the os/user APIs but making sure the homedirectory is expanded.
errors returned are also categorised using the commonerrors


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
