### PR TITLE
:sparkles: `[logs]` Add a quiet logger

### DIFF
--- a/changes/20231027081549.feature
+++ b/changes/20231027081549.feature
@@ -1,0 +1,1 @@
+:sparkles: `[logs]` Add a quiet logger

--- a/utils/logs/quiet_logger.go
+++ b/utils/logs/quiet_logger.go
@@ -1,0 +1,38 @@
+package logs
+
+import "github.com/ARM-software/golang-utils/utils/commonerrors"
+
+type quietLogger struct {
+	loggers Loggers
+}
+
+func (l *quietLogger) Close() error {
+	return l.loggers.Close()
+}
+
+func (l *quietLogger) Check() error {
+	return l.loggers.Check()
+}
+
+func (l *quietLogger) SetLogSource(source string) error {
+	return l.loggers.SetLogSource(source)
+}
+
+func (l *quietLogger) SetLoggerSource(source string) error {
+	return l.loggers.SetLoggerSource(source)
+}
+
+func (l *quietLogger) Log(_ ...interface{}) {
+}
+
+func (l *quietLogger) LogError(err ...interface{}) {
+	l.loggers.LogError(err...)
+}
+
+// NewQuietLogger returns a quiet logger which only logs errors.
+func NewQuietLogger(loggers Loggers) (Loggers, error) {
+	if loggers == nil {
+		return nil, commonerrors.ErrNoLogger
+	}
+	return &quietLogger{loggers: loggers}, nil
+}

--- a/utils/logs/quiet_logger_test.go
+++ b/utils/logs/quiet_logger_test.go
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package logs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuietLogger(t *testing.T) {
+	logger, err := NewStdLogger("Test")
+	require.NoError(t, err)
+	loggers, err := NewQuietLogger(logger)
+	require.NoError(t, err)
+	testLog(t, loggers)
+}


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

- Added a logger which only logs errors


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
