### PR TITLE
:sparkles: [platform] Variable expansion

### DIFF
--- a/changes/20231027143154.feature
+++ b/changes/20231027143154.feature
@@ -1,0 +1,1 @@
+:sparkles: [`platform`] portable variable expansion

--- a/utils/environment/envvar.go
+++ b/utils/environment/envvar.go
@@ -2,7 +2,6 @@ package environment
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 
@@ -148,6 +147,5 @@ func FindEnvironmentVariable(envvar string, envvars ...IEnvironmentVariable) (IE
 			return envvars[i], nil
 		}
 	}
-	os.Expand()
 	return nil, fmt.Errorf("%w: environment variable '%v' not set", commonerrors.ErrNotFound, envvar)
 }

--- a/utils/environment/envvar.go
+++ b/utils/environment/envvar.go
@@ -2,6 +2,7 @@ package environment
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 
@@ -147,5 +148,6 @@ func FindEnvironmentVariable(envvar string, envvars ...IEnvironmentVariable) (IE
 			return envvars[i], nil
 		}
 	}
+	os.Expand()
 	return nil, fmt.Errorf("%w: environment variable '%v' not set", commonerrors.ErrNotFound, envvar)
 }

--- a/utils/platform/os.go
+++ b/utils/platform/os.go
@@ -8,7 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/shirou/gopsutil/v3/host"
@@ -19,6 +21,9 @@ import (
 
 var (
 	errNotSupportedByWindows = errors.New("not supported by windows")
+	// https://learn.microsoft.com/en-us/previous-versions/troubleshoot/winautomation/product-documentation/best-practices/variables/percentage-character-usage-in-notations
+	// https://ss64.com/nt/syntax-replace.html
+	windowsVariableExpansionRegexStr = `%(?P<variable>[^:=]*)(:(?P<StrToFind>.*)=(?P<NewString>.*))?%`
 )
 
 // ConvertError converts a platform error into a commonerrors
@@ -172,4 +177,124 @@ func GetRAM() (ram RAM, err error) {
 		Free:        vm.Free,
 	}
 	return
+}
+
+// ExpandParameter expands a variable expressed in a string `s` with its value returned by the mapping function.
+// If the mapping function returns a string with variables, it will expand them too if recursive is set to true.
+func ExpandParameter(s string, mappingFunc func(string) (string, bool), recursive bool) string {
+	if IsWindows() {
+		return ExpandWindowsParameter(s, mappingFunc, recursive)
+	}
+	return ExpandUnixParameter(s, mappingFunc, recursive)
+}
+
+func newMappingFunc(recursive bool, mappingFunc func(string) (string, bool), expansionFunc func(s string, mappingFunc func(string) (string, bool)) string) func(string) (string, bool) {
+	if recursive {
+		return recursiveMapping(mappingFunc, expansionFunc)
+	}
+	return mappingFunc
+}
+
+func recursiveMapping(mappingFunc func(string) (string, bool), expansionFunc func(s string, mappingFunc func(string) (string, bool)) string) func(string) (string, bool) {
+	newMappingFunc := func(entry string) (string, bool) {
+		mappedEntry, found := mappingFunc(entry)
+		if !found {
+			return mappedEntry, found
+		}
+		newExpanded := expansionFunc(mappedEntry, mappingFunc)
+		if mappedEntry == newExpanded {
+			return newExpanded, true
+		}
+		return expansionFunc(newExpanded, mappingFunc), true
+	}
+	return newMappingFunc
+}
+
+// ExpandUnixParameter expands a ${param} or $param in `s` based on the mapping function
+// See https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html
+// TODO if os.Expand is not good enough, consider using other libraries such as https://github.com/ganbarodigital/go_shellexpand or https://github.com/mvdan/sh
+func ExpandUnixParameter(s string, mappingFunc func(string) (string, bool), recursive bool) string {
+	mapping := newMappingFunc(recursive, mappingFunc, expandUnixParameter)
+	return expandUnixParameter(s, mapping)
+}
+
+func expandUnixParameter(s string, mappingFunc func(string) (string, bool)) string {
+	return os.Expand(s, func(variable string) string {
+		mapped, _ := mappingFunc(variable)
+		return mapped
+	})
+}
+
+// ExpandWindowsParameter expands a %param% in `s` based on the mapping function
+// See https://learn.microsoft.com/en-us/previous-versions/troubleshoot/winautomation/product-documentation/best-practices/variables/percentage-character-usage-in-notations
+// https://devblogs.microsoft.com/oldnewthing/20060823-00/?p=29993
+// https://github.com/golang/go/issues/24848
+func ExpandWindowsParameter(s string, mappingFunc func(string) (string, bool), recursive bool) string {
+	mapping := newMappingFunc(recursive, mappingFunc, expandWindowsParameter)
+	return expandWindowsParameter(s, mapping)
+}
+
+func expandWindowsParameter(s string, mappingFunc func(string) (string, bool)) string {
+	variableRegex := regexp.MustCompile(windowsVariableExpansionRegexStr)
+	if !variableRegex.MatchString(s) {
+		return s
+	}
+	allMatches := variableRegex.FindAllStringSubmatch(s, -1)
+	expandedString := s
+	for i := range allMatches {
+		old, newStr := expandedVariableWithEdit(allMatches[i], mappingFunc)
+		expandedString = strings.ReplaceAll(expandedString, old, newStr)
+	}
+	return expandedString
+}
+
+func expandedVariableWithoutEdit(match []string, mappingFunc func(string) (string, bool)) (string, string, bool) {
+	if len(match) < 1 {
+		return "", "", false
+	}
+	if len(match) < 2 {
+		return match[0], "", false
+	}
+	variable := match[1]
+	if len(strings.TrimSpace(variable)) == 0 {
+		return match[0], match[0], false
+	}
+	expandedVariable, found := mappingFunc(variable)
+	if found {
+		return match[0], expandedVariable, true
+	}
+	return match[0], match[0], false
+}
+func expandedVariableWithEdit(match []string, mappingFunc func(string) (string, bool)) (string, string) {
+	if len(match) != 5 {
+		s, expandedVariable, _ := expandedVariableWithoutEdit(match, mappingFunc)
+		return s, expandedVariable
+	}
+	strToFind := match[3]
+	newString := match[4]
+	s, expandedVariable, expanded := expandedVariableWithoutEdit(match, mappingFunc)
+	if !expanded {
+		return s, expandedVariable
+	}
+	return s, strings.ReplaceAll(expandedVariable, strToFind, newString)
+}
+
+// ExpandFromEnvironment expands a string containing variables with values from the environment.
+// On unix, it is equivalent to os.ExpandEnv but differs on Windows due to the following issues:
+// - https://learn.microsoft.com/en-gb/windows/win32/api/processenv/nf-processenv-expandenvironmentstringsa?redirectedfrom=MSDN
+// - https://github.com/golang/go/issues/43763
+// - https://github.com/golang/go/issues/24848
+func ExpandFromEnvironment(s string, recursive bool) string {
+	if IsWindows() {
+		expanded := expandFromEnvironment(s)
+		if recursive {
+			newExpanded := expandFromEnvironment(expanded)
+			if expanded == newExpanded {
+				return expanded
+			}
+			return ExpandFromEnvironment(newExpanded, recursive)
+		}
+		return expanded
+	}
+	return ExpandUnixParameter(s, os.LookupEnv, recursive)
 }

--- a/utils/platform/os_posix.go
+++ b/utils/platform/os_posix.go
@@ -1,0 +1,9 @@
+//go:build linux || unix || (js && wasm) || darwin || aix || dragonfly || freebsd || nacl || netbsd || openbsd || solaris
+// +build linux unix js,wasm darwin aix dragonfly freebsd nacl netbsd openbsd solaris
+
+package platform
+
+func expandFromEnvironment(s string) string {
+	// nothing to do on unix system as it should be covered by os.ExpandEnv
+	return s
+}

--- a/utils/platform/os_test.go
+++ b/utils/platform/os_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/bxcodec/faker/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -54,4 +55,206 @@ func TestMemoryInformation(t *testing.T) {
 	require.Nil(t, err)
 	assert.NotZero(t, ram)
 	fmt.Println(ram)
+}
+
+func TestExpandParameter(t *testing.T) {
+	complexVar := faker.Username()
+	complexVar2 := faker.Name()
+	random := faker.Sentence()
+	mapping := map[string]string{complexVar: "a test", "a": "b", complexVar2: "another test", "var1": "last test"}
+	mappingFunc := func(entry string) (string, bool) {
+		if entry == "" {
+			return "", true
+		}
+		mapped, found := mapping[entry]
+		return mapped, found
+	}
+	tests := []struct {
+		expression                string
+		expandedExpressionUnix    string
+		expandedExpressionWindows string
+	}{
+		{
+			expression:                "",
+			expandedExpressionUnix:    "",
+			expandedExpressionWindows: "",
+		},
+		{
+			expression:                "   ${}   ",
+			expandedExpressionUnix:    "      ",
+			expandedExpressionWindows: "   ${}   ",
+		},
+		{
+			expression:                fmt.Sprintf("  ${%v}  ", random),
+			expandedExpressionUnix:    "    ",
+			expandedExpressionWindows: fmt.Sprintf("  ${%v}  ", random),
+		},
+		{
+			expression:                "   $   ",
+			expandedExpressionUnix:    "   $   ",
+			expandedExpressionWindows: "   $   ",
+		},
+		{
+			expression:                "   %%   ",
+			expandedExpressionUnix:    "   %%   ",
+			expandedExpressionWindows: "   %%   ",
+		},
+		{
+			expression:                "   %  %   ",
+			expandedExpressionUnix:    "   %  %   ",
+			expandedExpressionWindows: "   %  %   ",
+		},
+		{
+			expression:                "   %  %   ",
+			expandedExpressionUnix:    "   %  %   ",
+			expandedExpressionWindows: "   %  %   ",
+		},
+		{
+			expression:                "   %:=  %   ",
+			expandedExpressionUnix:    "   %:=  %   ",
+			expandedExpressionWindows: "   %:=  %   ",
+		},
+		{
+			expression:                "   %  :=  %   ",
+			expandedExpressionUnix:    "   %  :=  %   ",
+			expandedExpressionWindows: "   %  :=  %   ",
+		},
+		{
+			expression:                "   %" + random + "%   ",
+			expandedExpressionUnix:    "   %" + random + "%   ",
+			expandedExpressionWindows: "   %" + random + "%   ",
+		},
+		{
+			expression:                fmt.Sprintf("${%v}", complexVar),
+			expandedExpressionUnix:    "a test",
+			expandedExpressionWindows: fmt.Sprintf("${%v}", complexVar),
+		},
+		{
+			expression:                fmt.Sprintf("  ${%v}   ", complexVar),
+			expandedExpressionUnix:    "  a test   ",
+			expandedExpressionWindows: fmt.Sprintf("  ${%v}   ", complexVar),
+		},
+		{
+			expression:                `%` + fmt.Sprintf("${%v}", complexVar2) + `%`,
+			expandedExpressionUnix:    "%another test%",
+			expandedExpressionWindows: `%` + fmt.Sprintf("${%v}", complexVar2) + `%`,
+		},
+		{
+			expression:                fmt.Sprintf("a1234556() ${%v}a1234556() .", complexVar2),
+			expandedExpressionUnix:    "a1234556() another testa1234556() .",
+			expandedExpressionWindows: fmt.Sprintf("a1234556() ${%v}a1234556() .", complexVar2),
+		},
+		{
+			expression:                `%` + complexVar + `%`,
+			expandedExpressionUnix:    `%` + complexVar + `%`,
+			expandedExpressionWindows: "a test",
+		},
+		{
+			expression:                `  %` + complexVar + `%  `,
+			expandedExpressionUnix:    `  %` + complexVar + `%  `,
+			expandedExpressionWindows: "  a test  ",
+		},
+		{
+			expression:                `a1234556()${} %` + complexVar2 + `%  a1234556()${} .$`,
+			expandedExpressionUnix:    `a1234556() %` + complexVar2 + `%  a1234556() .$`,
+			expandedExpressionWindows: "a1234556()${} another test  a1234556()${} .$",
+		},
+	}
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.expression, func(t *testing.T) {
+			assert.Equal(t, test.expandedExpressionUnix, ExpandUnixParameter(test.expression, mappingFunc, false))
+			assert.Equal(t, test.expandedExpressionWindows, ExpandWindowsParameter(test.expression, mappingFunc, false))
+			if IsWindows() {
+				assert.Equal(t, test.expandedExpressionWindows, ExpandParameter(test.expression, mappingFunc, false))
+			} else {
+				assert.Equal(t, test.expandedExpressionUnix, ExpandParameter(test.expression, mappingFunc, false))
+			}
+		})
+	}
+}
+
+func TestRecursiveExpandParameter(t *testing.T) {
+	complexVar := faker.Username()
+	complexVar2 := faker.Name()
+	random := faker.Sentence()
+	windowsMapping := map[string]string{complexVar: "123456 %" + complexVar2 + "% .123-_", "a": "b", complexVar2: random, "var1": "last test"}
+	linuxMapping := map[string]string{complexVar: "123456 ${" + complexVar2 + "} .123-_", "a": "b", complexVar2: random, "var1": "last test"}
+	mappingFunc := func(windows bool) func(entry string) (string, bool) {
+		return func(entry string) (string, bool) {
+			if entry == "" {
+				return "", true
+			}
+			var mapping map[string]string
+			if windows {
+				mapping = windowsMapping
+			} else {
+				mapping = linuxMapping
+			}
+			mapped, found := mapping[entry]
+			return mapped, found
+
+		}
+	}
+	tests := []struct {
+		expression                string
+		expandedExpressionUnix    string
+		expandedExpressionWindows string
+	}{
+		{
+			expression:                "",
+			expandedExpressionUnix:    "",
+			expandedExpressionWindows: "",
+		},
+		{
+			expression:                "",
+			expandedExpressionUnix:    "",
+			expandedExpressionWindows: "",
+		},
+		{
+			expression:                fmt.Sprintf("12345${%v} 123456", complexVar),
+			expandedExpressionUnix:    fmt.Sprintf("12345123456 %v .123-_ 123456", random),
+			expandedExpressionWindows: fmt.Sprintf("12345${%v} 123456", complexVar),
+		},
+		{
+			expression:                `12345%` + complexVar + `% 123456`,
+			expandedExpressionUnix:    `12345%` + complexVar + `% 123456`,
+			expandedExpressionWindows: fmt.Sprintf("12345123456 %v .123-_ 123456", random),
+		},
+	}
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.expression, func(t *testing.T) {
+			assert.Equal(t, test.expandedExpressionUnix, ExpandUnixParameter(test.expression, mappingFunc(false), true))
+			assert.Equal(t, test.expandedExpressionWindows, ExpandWindowsParameter(test.expression, mappingFunc(true), true))
+			if IsWindows() {
+				assert.Equal(t, test.expandedExpressionWindows, ExpandParameter(test.expression, mappingFunc(true), true))
+			} else {
+				assert.Equal(t, test.expandedExpressionUnix, ExpandParameter(test.expression, mappingFunc(false), true))
+			}
+		})
+	}
+}
+
+func TestExpandFromEnvironment(t *testing.T) {
+	if IsWindows() {
+		t.Run("on windows", func(t *testing.T) {
+			assert.NotEmpty(t, ExpandFromEnvironment("%WINDIR%", false))
+			assert.NotEqual(t, "%WINDIR%", ExpandFromEnvironment("%WINDIR%", false))
+			assert.Equal(t, "%%", ExpandFromEnvironment("%%", false))
+			assert.Equal(t, "${}", ExpandFromEnvironment("${}", false))
+		})
+	} else {
+		t.Run("on linux", func(t *testing.T) {
+			assert.NotEmpty(t, ExpandFromEnvironment("$HOME", false))
+			assert.NotEmpty(t, ExpandFromEnvironment("${HOME}", false))
+			assert.NotEqual(t, "$HOME", ExpandFromEnvironment("$HOME", false))
+			assert.NotEqual(t, "${HOME}", ExpandFromEnvironment("${HOME}", false))
+			assert.Empty(t, ExpandFromEnvironment("${}", false))
+		})
+	}
+	random := faker.Sentence()
+	assert.Equal(t, "%"+random+"%", ExpandFromEnvironment("%"+random+"%", false))
+	assert.Equal(t, random, ExpandFromEnvironment(random, false))
+	assert.Equal(t, "%%", ExpandFromEnvironment("%%", false))
 }

--- a/utils/platform/os_windows.go
+++ b/utils/platform/os_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+// +build windows
+
+package platform
+
+import "golang.org/x/sys/windows/registry"
+
+func expandFromEnvironment(s string) string {
+	expanded, err := registry.ExpandString(s)
+	if err == nil {
+		return expanded
+	}
+	return s
+}


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

- `os.Expand` is not portable and is not recursive
- Introducing utilities to allow variable expansion on any platform


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
