### PR TITLE
:sparkles: `[filesystem]` Add a way to convert `filesystem.File` to `*os.File`

### DIFF
--- a/changes/20240118145043.feature
+++ b/changes/20240118145043.feature
@@ -1,0 +1,1 @@
+:sparkles: `[filesystem]` Add a way to convert `filesystem.File` to `*os.File` for legacy functions which have not moved to using `fs.File`

--- a/utils/filesystem/files.go
+++ b/utils/filesystem/files.go
@@ -1887,3 +1887,12 @@ func convertToExtendedFile(file afero.File, onCloseCallBack func() error) (File,
 		onCloseCallBack: onCloseCallBack,
 	}, nil
 }
+
+// ConvertToOSFile converts a file to a `os` implementation of a file for certain use-cases where functions have not moved to using `fs.File`.
+func ConvertToOSFile(f File) (osFile *os.File) {
+	if f == nil {
+		return
+	}
+	osFile = os.NewFile(f.Fd(), f.Name())
+	return
+}

--- a/utils/filesystem/files_test.go
+++ b/utils/filesystem/files_test.go
@@ -2025,6 +2025,7 @@ func TestConvertToOSFile(t *testing.T) {
 	osFile = ConvertToOSFile(rFile)
 	defer func() { _ = osFile.Close() }()
 	content, err := io.ReadAll(osFile)
+	require.NoError(t, err)
 	assert.Equal(t, text, string(content))
 	require.NoError(t, osFile.Close())
 	require.Error(t, rFile.Close(), "file must already be closed")

--- a/utils/filesystem/files_test.go
+++ b/utils/filesystem/files_test.go
@@ -5,9 +5,11 @@
 package filesystem
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -2003,4 +2005,27 @@ func testFileMode(t *testing.T, fs FS, filePath string, mode int) {
 	} else {
 		assert.Equal(t, mode, int(fi.Mode().Perm()))
 	}
+}
+
+func TestConvertToOSFile(t *testing.T) {
+	temp := t.TempDir()
+	file, err := TempFile(temp, "test-file-convert-.test")
+	require.NoError(t, err)
+	defer func() { _ = file.Close() }()
+	osFile := ConvertToOSFile(file)
+	require.NotNil(t, osFile)
+	text := fmt.Sprintf("test some file data; %v", faker.Paragraph())
+	_, err = safeio.CopyDataWithContext(context.TODO(), bytes.NewReader([]byte(text)), osFile)
+	require.NoError(t, err)
+	require.NoError(t, osFile.Close())
+	require.Error(t, file.Close(), "file must already be closed")
+	rFile, err := GenericOpen(file.Name())
+	require.NoError(t, err)
+	defer func() { _ = rFile.Close() }()
+	osFile = ConvertToOSFile(rFile)
+	defer func() { _ = osFile.Close() }()
+	content, err := io.ReadAll(osFile)
+	assert.Equal(t, text, string(content))
+	require.NoError(t, osFile.Close())
+	require.Error(t, rFile.Close(), "file must already be closed")
 }

--- a/utils/git/git_test.go
+++ b/utils/git/git_test.go
@@ -142,7 +142,7 @@ func getValidBlobHash(tree *object.Tree) (blobHash plumbing.Hash, err error) {
 			return
 		}
 	}
-	err = commonerrors.ErrNotFound
+	blobHash = tree.Hash
 	return
 }
 


### PR DESCRIPTION

<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

Conversion method for some usecases where legacy functions require `*os.File` instead of interfaces when working with files

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
