### PR TITLE
:bug: `subprocess` subprocess.Output results in data race if output prints to both stderr and stdout

### DIFF
--- a/changes/20240131145019.bugfix
+++ b/changes/20240131145019.bugfix
@@ -1,1 +1,1 @@
-:bug: `subprocess` subprocess.Output results in data race if output prints to both stderr and stdout
+:bug: `subprocess` Fix issue where subprocess.Output results in data race if the output prints to both stderr and stdout

--- a/changes/20240131145019.bugfix
+++ b/changes/20240131145019.bugfix
@@ -1,0 +1,1 @@
+:bug: `subprocess` subprocess.Output results in data race if output prints to both stderr and stdout

--- a/changes/20240131151659.bugfix
+++ b/changes/20240131151659.bugfix
@@ -1,0 +1,1 @@
+:bug: `logs` Fix mutex lock in multipleLoggers as it was using a read only lock in situation where loggers can actually be accessing the same underlying resource

--- a/utils/logs/multiple_logger.go
+++ b/utils/logs/multiple_logger.go
@@ -63,16 +63,16 @@ func (c *MultipleLogger) setLoggerSource(source string) error {
 }
 
 func (c *MultipleLogger) Log(output ...interface{}) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	for i := range c.loggers {
 		c.loggers[i].Log(output...)
 	}
 }
 
 func (c *MultipleLogger) LogError(err ...interface{}) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	for i := range c.loggers {
 		c.loggers[i].LogError(err...)
 	}

--- a/utils/subprocess/executor_test.go
+++ b/utils/subprocess/executor_test.go
@@ -236,6 +236,7 @@ func TestOutput(t *testing.T) {
 		cmdOther     string
 		argOther     []string
 		expectOutput bool
+		runCount     int
 	}{
 		{
 			name:         "ShortProcess",
@@ -244,6 +245,7 @@ func TestOutput(t *testing.T) {
 			cmdOther:     "ls",
 			argOther:     []string{"-l", currentDir},
 			expectOutput: true,
+			runCount:     1,
 		},
 		{
 			name:       "LongProcess",
@@ -251,12 +253,14 @@ func TestOutput(t *testing.T) {
 			argWindows: []string{"SLEEP 1"},
 			cmdOther:   "sleep",
 			argOther:   []string{"1"},
+			runCount:   1,
 		},
 		{
 			name:         "BothStdOutandStdErr",
 			cmdOther:     "./testdata/echo_stdout_and_stderr.sh",
 			argOther:     []string{"foo"},
 			expectOutput: true,
+			runCount:     5,
 		},
 	}
 
@@ -267,14 +271,16 @@ func TestOutput(t *testing.T) {
 			loggers, err := logs.NewLogrLogger(logstest.NewTestLogger(t), "testOutput")
 			require.NoError(t, err)
 			var output string
-			if platform.IsWindows() && test.cmdWindows != "" {
-				output, err = Output(context.Background(), loggers, test.cmdWindows, test.argWindows...)
-			} else {
-				output, err = Output(context.Background(), loggers, test.cmdOther, test.argOther...)
-			}
-			require.NoError(t, err)
-			if test.expectOutput {
-				assert.NotEmpty(t, output)
+			for i := 0; i < test.runCount; i++ {
+				if platform.IsWindows() && test.cmdWindows != "" {
+					output, err = Output(context.Background(), loggers, test.cmdWindows, test.argWindows...)
+				} else {
+					output, err = Output(context.Background(), loggers, test.cmdOther, test.argOther...)
+				}
+				require.NoError(t, err)
+				if test.expectOutput {
+					assert.NotEmpty(t, output)
+				}
 			}
 		})
 	}

--- a/utils/subprocess/executor_test.go
+++ b/utils/subprocess/executor_test.go
@@ -252,6 +252,12 @@ func TestOutput(t *testing.T) {
 			cmdOther:   "sleep",
 			argOther:   []string{"1"},
 		},
+		{
+			name:         "BothStdOutandStdErr",
+			cmdOther:     "./testdata/echo_stdout_and_stderr.sh",
+			argOther:     []string{"foo"},
+			expectOutput: true,
+		},
 	}
 
 	for i := range tests {
@@ -261,7 +267,7 @@ func TestOutput(t *testing.T) {
 			loggers, err := logs.NewLogrLogger(logstest.NewTestLogger(t), "testOutput")
 			require.NoError(t, err)
 			var output string
-			if platform.IsWindows() {
+			if platform.IsWindows() && test.cmdWindows != "" {
 				output, err = Output(context.Background(), loggers, test.cmdWindows, test.argWindows...)
 			} else {
 				output, err = Output(context.Background(), loggers, test.cmdOther, test.argOther...)

--- a/utils/subprocess/testdata/echo_stdout_and_stderr.sh
+++ b/utils/subprocess/testdata/echo_stdout_and_stderr.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "$1" | tee /dev/stderr


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

subprocess.Output results in data race if output prints to both stderr and stdout

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
