### PR TITLE
:sparkles: `[subprocess]` Enable specifying additional environment variables for the subprocess to run with

### DIFF
--- a/changes/20240131182504.feature
+++ b/changes/20240131182504.feature
@@ -1,0 +1,1 @@
+:sparkles: `[subprocess]` Enable specifying additional environment variables for the subprocess to run with

--- a/utils/subprocess/command_wrapper.go
+++ b/utils/subprocess/command_wrapper.go
@@ -101,6 +101,7 @@ func (c *cmdWrapper) Pid() (pid int, err error) {
 type command struct {
 	cmd        string
 	args       []string
+	env        []string
 	as         *commandUtils.CommandAsDifferentUser
 	loggers    logs.Loggers
 	cmdWrapper cmdWrapper
@@ -111,6 +112,8 @@ func (c *command) createCommand(cmdCtx context.Context) *exec.Cmd {
 	cmd := exec.CommandContext(cmdCtx, newCmd, newArgs...) //nolint:gosec
 	cmd.Stdout = newOutStreamer(c.loggers)
 	cmd.Stderr = newErrLogStreamer(c.loggers)
+	cmd.Env = cmd.Environ()
+	cmd.Env = append(cmd.Env, c.env...)
 	return cmd
 }
 
@@ -143,12 +146,13 @@ func (c *command) Check() (err error) {
 	return
 }
 
-func newCommand(loggers logs.Loggers, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (osCmd *command) {
+func newCommand(loggers logs.Loggers, as *commandUtils.CommandAsDifferentUser, env []string, cmd string, args ...string) (osCmd *command) {
 	osCmd = &command{
 		cmd:        cmd,
 		args:       args,
-		loggers:    loggers,
+		env:        env,
 		as:         as,
+		loggers:    loggers,
 		cmdWrapper: cmdWrapper{},
 	}
 	return

--- a/utils/subprocess/command_wrapper_test.go
+++ b/utils/subprocess/command_wrapper_test.go
@@ -81,7 +81,7 @@ func TestCmdRunWithEnv(t *testing.T) {
 		cmdOther   string
 		envVars    []string
 	}{
-		cmdWindows: "set",
+		cmdWindows: "Env",
 		cmdOther:   "env",
 		envVars:    []string{"TEST1=TEST2", "TEST3=TEST4"},
 	}
@@ -92,7 +92,7 @@ func TestCmdRunWithEnv(t *testing.T) {
 		loggers, err := logs.NewLogrLogger(logstest.NewTestLogger(t), "test")
 		require.NoError(t, err)
 		if platform.IsWindows() {
-			cmd = newCommand(loggers, commandUtils.Me(), envTest.envVars, envTest.cmdWindows)
+			cmd = newCommand(loggers, commandUtils.Me(), envTest.envVars, "powershell", "-Command", envTest.cmdWindows)
 		} else {
 			cmd = newCommand(loggers, commandUtils.Me(), envTest.envVars, envTest.cmdOther)
 		}

--- a/utils/subprocess/command_wrapper_test.go
+++ b/utils/subprocess/command_wrapper_test.go
@@ -7,6 +7,7 @@ package subprocess
 import (
 	"context"
 	"os"
+	"regexp"
 	"testing"
 	"time"
 
@@ -72,6 +73,41 @@ func TestCmdRun(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestCmdRunWithEnv(t *testing.T) {
+	envTest := struct {
+		cmdWindows string
+		cmdOther   string
+		envVars    []string
+	}{
+		cmdWindows: "set",
+		cmdOther:   "env",
+		envVars:    []string{"TEST1=TEST2", "TEST3=TEST4"},
+	}
+
+	t.Run("Test command run with env vars", func(t *testing.T) {
+		defer goleak.VerifyNone(t)
+		var cmd *command
+		loggers, err := logs.NewLogrLogger(logstest.NewTestLogger(t), "test")
+		require.NoError(t, err)
+		if platform.IsWindows() {
+			cmd = newCommand(loggers, commandUtils.Me(), envTest.envVars, envTest.cmdWindows)
+		} else {
+			cmd = newCommand(loggers, commandUtils.Me(), envTest.envVars, envTest.cmdOther)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		wrapper := cmd.GetCmd(ctx)
+		wrapper.cmd.Stdout = nil
+		out, err := wrapper.cmd.Output()
+		require.NoError(t, err)
+
+		for i := range envTest.envVars {
+			envVar := envTest.envVars[i]
+			assert.True(t, regexp.MustCompile(envVar).Match(out))
+		}
+	})
 }
 
 func TestCmdStartStop(t *testing.T) {

--- a/utils/subprocess/command_wrapper_test.go
+++ b/utils/subprocess/command_wrapper_test.go
@@ -55,9 +55,9 @@ func TestCmdRun(t *testing.T) {
 			loggers, err := logs.NewLogrLogger(logstest.NewTestLogger(t), "test")
 			require.NoError(t, err)
 			if platform.IsWindows() {
-				cmd = newCommand(loggers, commandUtils.Me(), test.cmdWindows, test.argWindows...)
+				cmd = newCommand(loggers, commandUtils.Me(), nil, test.cmdWindows, test.argWindows...)
 			} else {
-				cmd = newCommand(loggers, commandUtils.Me(), test.cmdOther, test.argOther...)
+				cmd = newCommand(loggers, commandUtils.Me(), nil, test.cmdOther, test.argOther...)
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
@@ -110,9 +110,9 @@ func TestCmdStartStop(t *testing.T) {
 			require.NoError(t, err)
 
 			if platform.IsWindows() {
-				cmd = newCommand(loggers, commandUtils.Me(), test.cmdWindows, test.argWindows...)
+				cmd = newCommand(loggers, commandUtils.Me(), nil, test.cmdWindows, test.argWindows...)
 			} else {
-				cmd = newCommand(loggers, commandUtils.Me(), test.cmdOther, test.argOther...)
+				cmd = newCommand(loggers, commandUtils.Me(), nil, test.cmdOther, test.argOther...)
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()

--- a/utils/subprocess/executor.go
+++ b/utils/subprocess/executor.go
@@ -51,8 +51,8 @@ func newPlainSubProcess(ctx context.Context, loggers logs.Loggers, env []string,
 	return
 }
 
-// Execute executes a command (i.e. spawns a subprocess)
-func Execute(ctx context.Context, loggers logs.Loggers, additionalEnvVars []string, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (err error) {
+// ExecuteWithEnvironment executes a command (i.e. spawns a subprocess). It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
+func ExecuteWithEnvironment(ctx context.Context, loggers logs.Loggers, additionalEnvVars []string, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (err error) {
 	p, err := NewWithEnvironment(ctx, loggers, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, cmd, args...)
 	if err != nil {
 		return
@@ -60,13 +60,9 @@ func Execute(ctx context.Context, loggers logs.Loggers, additionalEnvVars []stri
 	return p.Execute()
 }
 
-// ExecuteWithEnvironment executes a command (i.e. spawns a subprocess). It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
-func ExecuteWithEnvironment(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (err error) {
-	p, err := New(ctx, loggers, messageOnStart, messageOnSuccess, messageOnFailure, cmd, args...)
-	if err != nil {
-		return
-	}
-	return p.Execute()
+// Execute executes a command (i.e. spawns a subprocess).
+func Execute(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) error {
+	return ExecuteWithEnvironment(ctx, loggers, nil, messageOnStart, messageOnSuccess, messageOnFailure, cmd, args...)
 }
 
 // ExecuteAs executes a command (i.e. spawns a subprocess) as a different user.
@@ -90,7 +86,7 @@ func ExecuteWithSudo(ctx context.Context, loggers logs.Loggers, messageOnStart s
 
 // Output executes a command and returns its output (stdOutput and stdErr are merged) as string.
 func Output(ctx context.Context, loggers logs.Loggers, cmd string, args ...string) (string, error) {
-	return OutputAs(ctx, loggers, commandUtils.Me(), cmd, args...)
+	return OutputWithEnvironment(ctx, loggers, nil, cmd, args...)
 }
 
 // OutputWithEnvironment executes a command and returns its output (stdOutput and stdErr are merged) as string. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".

--- a/utils/subprocess/executor.go
+++ b/utils/subprocess/executor.go
@@ -28,26 +28,40 @@ type Subprocess struct {
 }
 
 // New creates a subprocess description.
-func New(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (p *Subprocess, err error) {
-	p, err = newSubProcess(ctx, loggers, messageOnStart, messageOnSuccess, messageOnFailure, commandUtils.Me(), cmd, args...)
+func New(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (*Subprocess, error) {
+	return NewWithEnvironment(ctx, loggers, nil, messageOnStart, messageOnSuccess, messageOnFailure, cmd, args...)
+}
+
+// NewWithEnvironment creates a subprocess description. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
+func NewWithEnvironment(ctx context.Context, loggers logs.Loggers, additionalEnvVars []string, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (p *Subprocess, err error) {
+	p, err = newSubProcess(ctx, loggers, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, commandUtils.Me(), cmd, args...)
 	return
 }
 
 // newSubProcess creates a subprocess description.
-func newSubProcess(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (p *Subprocess, err error) {
+func newSubProcess(ctx context.Context, loggers logs.Loggers, env []string, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (p *Subprocess, err error) {
 	p = new(Subprocess)
-	err = p.SetupAs(ctx, loggers, messageOnStart, messageOnSuccess, messageOnFailure, as, cmd, args...)
+	err = p.SetupAsWithEnvironment(ctx, loggers, env, messageOnStart, messageOnSuccess, messageOnFailure, as, cmd, args...)
 	return
 }
 
-func newPlainSubProcess(ctx context.Context, loggers logs.Loggers, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (p *Subprocess, err error) {
+func newPlainSubProcess(ctx context.Context, loggers logs.Loggers, env []string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (p *Subprocess, err error) {
 	p = new(Subprocess)
-	err = p.setup(ctx, loggers, false, "", "", "", as, cmd, args...)
+	err = p.setup(ctx, loggers, env, false, "", "", "", as, cmd, args...)
 	return
 }
 
 // Execute executes a command (i.e. spawns a subprocess)
-func Execute(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (err error) {
+func Execute(ctx context.Context, loggers logs.Loggers, additionalEnvVars []string, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (err error) {
+	p, err := NewWithEnvironment(ctx, loggers, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, cmd, args...)
+	if err != nil {
+		return
+	}
+	return p.Execute()
+}
+
+// ExecuteWithEnvironment executes a command (i.e. spawns a subprocess). It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
+func ExecuteWithEnvironment(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (err error) {
 	p, err := New(ctx, loggers, messageOnStart, messageOnSuccess, messageOnFailure, cmd, args...)
 	if err != nil {
 		return
@@ -56,8 +70,13 @@ func Execute(ctx context.Context, loggers logs.Loggers, messageOnStart string, m
 }
 
 // ExecuteAs executes a command (i.e. spawns a subprocess) as a different user.
-func ExecuteAs(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (err error) {
-	p, err := newSubProcess(ctx, loggers, messageOnStart, messageOnSuccess, messageOnFailure, as, cmd, args...)
+func ExecuteAs(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) error {
+	return ExecuteAsWithEnvironment(ctx, loggers, nil, messageOnStart, messageOnSuccess, messageOnFailure, as, cmd, args...)
+}
+
+// ExecuteAsWithEnvironment executes a command (i.e. spawns a subprocess) as a different user. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
+func ExecuteAsWithEnvironment(ctx context.Context, loggers logs.Loggers, additionalEnvVars []string, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (err error) {
+	p, err := newSubProcess(ctx, loggers, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, as, cmd, args...)
 	if err != nil {
 		return
 	}
@@ -74,8 +93,18 @@ func Output(ctx context.Context, loggers logs.Loggers, cmd string, args ...strin
 	return OutputAs(ctx, loggers, commandUtils.Me(), cmd, args...)
 }
 
+// OutputWithEnvironment executes a command and returns its output (stdOutput and stdErr are merged) as string. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
+func OutputWithEnvironment(ctx context.Context, loggers logs.Loggers, additionalEnvVars []string, cmd string, args ...string) (string, error) {
+	return OutputAsWithEnvironment(ctx, loggers, additionalEnvVars, commandUtils.Me(), cmd, args...)
+}
+
 // OutputAs executes a command as a different user and returns its output (stdOutput and stdErr are merged) as string.
-func OutputAs(ctx context.Context, loggers logs.Loggers, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (output string, err error) {
+func OutputAs(ctx context.Context, loggers logs.Loggers, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (string, error) {
+	return OutputAsWithEnvironment(ctx, loggers, nil, as, cmd, args...)
+}
+
+// OutputAsWithEnvironment executes a command as a different user and returns its output (stdOutput and stdErr are merged) as string. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
+func OutputAsWithEnvironment(ctx context.Context, loggers logs.Loggers, additionalEnvVars []string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (output string, err error) {
 	if loggers == nil {
 		err = commonerrors.ErrNoLogger
 		return
@@ -89,7 +118,7 @@ func OutputAs(ctx context.Context, loggers logs.Loggers, as *commandUtils.Comman
 	if err != nil {
 		return
 	}
-	p, err := newPlainSubProcess(ctx, mLoggers, as, cmd, args...)
+	p, err := newPlainSubProcess(ctx, mLoggers, additionalEnvVars, as, cmd, args...)
 	if err != nil {
 		return
 	}
@@ -100,16 +129,26 @@ func OutputAs(ctx context.Context, loggers logs.Loggers, as *commandUtils.Comman
 
 // Setup sets up a sub-process i.e. defines the command cmd and the messages on start, success and failure.
 func (s *Subprocess) Setup(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (err error) {
-	return s.setup(ctx, loggers, true, messageOnStart, messageOnSuccess, messageOnFailure, commandUtils.Me(), cmd, args...)
+	return s.SetupWithEnvironment(ctx, loggers, nil, messageOnStart, messageOnSuccess, messageOnFailure, cmd, args...)
+}
+
+// SetupWithEnvironment sets up a sub-process i.e. defines the command cmd and the messages on start, success and failure. Compared to Setup, it allows specifying additional environment variables to be used by the process.
+func (s *Subprocess) SetupWithEnvironment(ctx context.Context, loggers logs.Loggers, additionalEnv []string, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (err error) {
+	return s.setup(ctx, loggers, additionalEnv, true, messageOnStart, messageOnSuccess, messageOnFailure, commandUtils.Me(), cmd, args...)
 }
 
 // SetupAs is similar to Setup but allows the command to be run as a different user.
 func (s *Subprocess) SetupAs(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (err error) {
-	return s.setup(ctx, loggers, true, messageOnStart, messageOnSuccess, messageOnFailure, as, cmd, args...)
+	return s.SetupAsWithEnvironment(ctx, loggers, nil, messageOnStart, messageOnSuccess, messageOnFailure, as, cmd, args...)
+}
+
+// SetupAsWithEnvironment is similar to Setup but allows the command to be run as a different user. Compared to SetupAs, it allows specifying additional environment variables to be used by the process.
+func (s *Subprocess) SetupAsWithEnvironment(ctx context.Context, loggers logs.Loggers, additionalEnv []string, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (err error) {
+	return s.setup(ctx, loggers, additionalEnv, true, messageOnStart, messageOnSuccess, messageOnFailure, as, cmd, args...)
 }
 
 // Setup sets up a sub-process i.e. defines the command cmd and the messages on start, success and failure.
-func (s *Subprocess) setup(ctx context.Context, loggers logs.Loggers, withAdditionalMessages bool, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (err error) {
+func (s *Subprocess) setup(ctx context.Context, loggers logs.Loggers, env []string, withAdditionalMessages bool, messageOnStart, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (err error) {
 	if s.IsOn() {
 		err = s.Stop()
 		if err != nil {
@@ -120,7 +159,7 @@ func (s *Subprocess) setup(ctx context.Context, loggers logs.Loggers, withAdditi
 	defer s.mu.Unlock()
 	s.isRunning.Store(false)
 	s.processMonitoring = newSubprocessMonitoring(ctx)
-	s.command = newCommand(loggers, as, cmd, args...)
+	s.command = newCommand(loggers, as, env, cmd, args...)
 	s.messsaging = newSubprocessMessaging(loggers, withAdditionalMessages, messageOnSuccess, messageOnFailure, messageOnStart, s.command.GetPath())
 	s.reset()
 	return s.check()


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description
- this would mean that the environment of the subprocess can now be set up


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
