### PR TITLE
:sparkles: Improve process termination to avoid orphan subprocesses

### DIFF
--- a/changes/20240403145328.bugfix
+++ b/changes/20240403145328.bugfix
@@ -1,0 +1,1 @@
+:bug: Fix hanging sub processes as described in [(go issue)](https://github.com/golang/go/issues/24050). See https://github.com/go-cmd/cmd/tree/master?tab=readme-ov-file#proper-process-termination for inspiration

--- a/changes/20240403145328.bugfix
+++ b/changes/20240403145328.bugfix
@@ -1,2 +1,1 @@
 :bug: Fix hanging sub processes when deleting folders as described in [(go issue)](https://github.com/golang/go/issues/24050). See https://github.com/go-cmd/cmd/tree/master?tab=readme-ov-file#proper-process-termination for inspiration
-

--- a/changes/20240403145328.bugfix
+++ b/changes/20240403145328.bugfix
@@ -1,1 +1,2 @@
-:bug: Fix hanging sub processes as described in [(go issue)](https://github.com/golang/go/issues/24050). See https://github.com/go-cmd/cmd/tree/master?tab=readme-ov-file#proper-process-termination for inspiration
+:bug: Fix hanging sub processes when deleting folders as described in [(go issue)](https://github.com/golang/go/issues/24050). See https://github.com/go-cmd/cmd/tree/master?tab=readme-ov-file#proper-process-termination for inspiration
+

--- a/changes/20240403150239.feature
+++ b/changes/20240403150239.feature
@@ -1,0 +1,1 @@
+:sparkles: `[proc]` Add a utility to check whether a process is running or not

--- a/utils/proc/process.go
+++ b/utils/proc/process.go
@@ -230,7 +230,7 @@ func isProcessRunning(p *process.Process) (running bool) {
 		running = false
 		return
 	}
-        // On some platforms, such as *nix, a zombie process is reported as a running process by p.IsRunning() but this is not the case. Therefore, a further check is performed on the process status to verify a running process is actually in the expected running state. Nonetheless, status is not cross platform and is not implemented on Windows. For those platform, the status returned by IsRunning is then considered
+	// On some platforms, such as *nix, a zombie process is reported as a running process by p.IsRunning() but this is not the case. Therefore, a further check is performed on the process status to verify a running process is actually in the expected running state. Nonetheless, status is not cross platform and is not implemented on Windows. For those platform, the status returned by IsRunning is then considered
 	status, err := p.Status()
 	if err != nil {
 		return

--- a/utils/proc/process.go
+++ b/utils/proc/process.go
@@ -230,6 +230,7 @@ func isProcessRunning(p *process.Process) (running bool) {
 		running = false
 		return
 	}
+        // On some platforms, such as *nix, a zombie process is reported as a running process by p.IsRunning() but this is not the case. Therefore, a further check is performed on the process status to verify a running process is actually in the expected running state. Nonetheless, status is not cross platform and is not implemented on Windows. For those platform, the status returned by IsRunning is then considered
 	status, err := p.Status()
 	if err != nil {
 		return

--- a/utils/subprocess/executor_test.go
+++ b/utils/subprocess/executor_test.go
@@ -451,7 +451,7 @@ func TestOutputWithEnvironment(t *testing.T) {
 		fmt.Println(output)
 	})
 	t.Run("happy with output", func(t *testing.T) {
-		testString := fmt.Sprintf("This is a test %v!", faker.Sentence())
+		testString := fmt.Sprintf("'This is a test %v!'", faker.Sentence())
 		output, err := OutputWithEnvironment(context.Background(), logger, nil, "echo", testString)
 		require.NoError(t, err)
 		assert.NotEmpty(t, output)

--- a/utils/subprocess/executor_test.go
+++ b/utils/subprocess/executor_test.go
@@ -19,8 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
-	"github.com/ARM-software/golang-utils/utils/commonerrors"
-	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
 	"github.com/ARM-software/golang-utils/utils/logs"
 	"github.com/ARM-software/golang-utils/utils/logs/logstest"
 	"github.com/ARM-software/golang-utils/utils/platform"
@@ -465,14 +463,6 @@ func TestOutputWithEnvironment(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEmpty(t, output)
 		assert.Equal(t, testString, strings.TrimSpace(output))
-	})
-	t.Run("timeout", func(t *testing.T) {
-		timeoutCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		output, err := OutputWithEnvironment(timeoutCtx, logger, nil, "sleep", "5")
-		require.Error(t, err)
-		errortest.AssertError(t, err, commonerrors.ErrTimeout, commonerrors.ErrCancelled)
-		assert.Empty(t, output)
 	})
 	t.Run("environment", func(t *testing.T) {
 		testString := fmt.Sprintf("This is a test %v!", faker.Sentence())


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

- As described in https://github.com/golang/go/issues/24050, processes could be left hanging if not terminated properly. Better process termination was introduced to avoid this phenomenon.
- IsProcessRunning was added to `/proc` to check if a process identified by its pid is currently running.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
