### PR TITLE
:bug: Make sure that loggers added in NewMultipleLoggers don't fail with 'No Logger Source'

### DIFF
--- a/changes/20240424131658.bugfix
+++ b/changes/20240424131658.bugfix
@@ -1,0 +1,1 @@
+:bug: Make sure that loggers added in NewMultipleLoggers don't fail with 'No Logger Source'

--- a/utils/logs/multiple_logger.go
+++ b/utils/logs/multiple_logger.go
@@ -1,7 +1,6 @@
 package logs
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/go-logr/logr"

--- a/utils/logs/multiple_logger_test.go
+++ b/utils/logs/multiple_logger_test.go
@@ -111,8 +111,6 @@ func TestMultipleLoggers(t *testing.T) {
 	})
 
 	t.Run("Add loggers at start", func(t *testing.T) {
-
-		// Adding a file logger to the mix.
 		file, err := filesystem.TempFileInTempDir("test-multiplelog-filelog-*.log")
 		require.NoError(t, err)
 
@@ -131,10 +129,8 @@ func TestMultipleLoggers(t *testing.T) {
 		nl, err := NewNoopLogger("Test2")
 		require.NoError(t, err)
 
-		// With default logger
 		loggers, err := NewMultipleLoggers("Test Multiple", fl, nl)
 		require.NoError(t, err)
 		testLog(t, loggers)
-
 	})
 }


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Make sure that loggers added in NewMultipleLoggers don't fail with 'No Logger Source'.

NewMultipleLoggers calls Append to add the loggers, this tries to call c.setLoggerSource but at this point the base logger hasn't had it's source set. This change makes sure that the source is set earlier in the process.

It also adds a test that initialises the loggers with NewMultipleLoggers as there wasn't a test which is why this problem was missed.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
