### PR TITLE
:sparkles: Add pipe logger for logging output without adding anything to the output

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,16 +8,13 @@ run:
 linters:
   disable-all: true # Disable defaults, then enable the ones we want
   enable:
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
     - bodyclose
     - stylecheck
     - gosec

--- a/changes/20240508124107.feature
+++ b/changes/20240508124107.feature
@@ -1,0 +1,1 @@
+:sparkles: Add pipe logger for logging output without adding anything to the output

--- a/utils/logs/pipe_logger.go
+++ b/utils/logs/pipe_logger.go
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2020-2024 Arm Limited or its affiliates and Contributors. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package logs
+
+import (
+	"log"
+	"os"
+)
+
+// NewPipeLogger will log messages without appending any prefix. Can be used when re-logging some other log output to prevent duplication of the log source etc.
+func NewPipeLogger() (loggers Loggers, err error) {
+	loggers = &GenericLoggers{
+		Output: log.New(os.Stdout, "", 0),
+		Error:  log.New(os.Stderr, "", 0),
+	}
+	return
+}

--- a/utils/logs/pipe_logger_test.go
+++ b/utils/logs/pipe_logger_test.go
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package logs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPipeLogger(t *testing.T) {
+	loggers, err := NewPipeLogger()
+	require.NoError(t, err)
+	testLog(t, loggers)
+}


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Add pipe logger for logging output without adding anything to the output

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
