### PR TITLE
:sparkles: `commonerrors` Add support for warnings in commonerrors

### DIFF
--- a/changes/20240530162101.feature
+++ b/changes/20240530162101.feature
@@ -1,0 +1,1 @@
+:sparkles: `commonerrors` Add support for warnings in commonerrors

--- a/utils/commonerrors/errors.go
+++ b/utils/commonerrors/errors.go
@@ -54,6 +54,7 @@ const warningStr = "warning"
 
 var warningStrPrepend = fmt.Sprintf("%v: ", warningStr)
 
+// IsCommonError returns whether an error is a commonerror
 func IsCommonError(target error) bool {
 	return Any(target, ErrNotImplemented, ErrNoExtension, ErrNoLogger, ErrNoLoggerSource, ErrNoLogSource, ErrUndefined, ErrInvalidDestination, ErrTimeout, ErrLocked, ErrStaleLock, ErrExists, ErrNotFound, ErrUnsupported, ErrUnavailable, ErrWrongUser, ErrUnauthorised, ErrUnknown, ErrInvalid, ErrConflict, ErrMarshalling, ErrCancelled, ErrEmpty, ErrUnexpected, ErrTooLarge, ErrForbidden, ErrCondition, ErrEOF, ErrMalicious, ErrWarning)
 }


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Add support for warnings in commonerrors

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
