### PR TITLE
:sparkles: `http` Add support for extracting underlying go-retryable client from retryable client

### DIFF
--- a/changes/20240603130700.feature
+++ b/changes/20240603130700.feature
@@ -1,0 +1,1 @@
+:sparkles: `http` Add support for extracting underlying go-retryable client from retryable client

--- a/utils/http/client_test.go
+++ b/utils/http/client_test.go
@@ -39,7 +39,9 @@ func TestClientHappy(t *testing.T) {
 		},
 		{
 			clientName: "default retryable client",
-			client:     NewRetryableClient,
+			client: func() IClient {
+				return NewRetryableClient()
+			},
 		},
 		{
 			clientName: "client with no retry",
@@ -182,7 +184,9 @@ func TestClientWithDifferentBodies(t *testing.T) {
 		},
 		{
 			clientName: "default retryable client",
-			client:     NewRetryableClient,
+			client: func() IClient {
+				return NewRetryableClient()
+			},
 		},
 		{
 			clientName: "client with no retry",

--- a/utils/http/interfaces.go
+++ b/utils/http/interfaces.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
 )
 
 //go:generate mockgen -destination=../mocks/mock_$GOPACKAGE.go -package=mocks github.com/ARM-software/golang-utils/utils/$GOPACKAGE IClient,IRetryWaitPolicy
@@ -56,4 +58,10 @@ type IRetryWaitPolicy interface {
 	// Apply determines the amount of time to wait before the next retry attempt.
 	// the time will be comprised between the `min` and `max` value unless other information are retrieved from the server response e.g. `Retry-After` header.
 	Apply(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration
+}
+
+// IRetryableClient is a retryable client. It is a normal client with the additional method of extracting the underlying go-retryablehttp client so it can be used in libraries that use it
+type IRetryableClient interface {
+	IClient
+	UnderlyingClient() *retryablehttp.Client
 }


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Add support for extracting underlying go-retryable client from retryable client. This will allow us to use this retryable client in libraries that want the hashicorp one.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
