### PR TITLE
:sparkles: `commonerrors` Add support for determining commonerror from a string

### DIFF
--- a/changes/20240604150742.feature
+++ b/changes/20240604150742.feature
@@ -1,0 +1,1 @@
+:sparkles: `commonerrors` Add support for determining commonerror from a string

--- a/utils/commonerrors/errors.go
+++ b/utils/commonerrors/errors.go
@@ -101,6 +101,19 @@ func CorrespondTo(target error, description ...string) bool {
 	return false
 }
 
+// ErrorDescriptionIs determines whether a srting matches a commonerror that is being represented as a
+// string. For example through fmt.Sprint(err) or err.Error().
+//
+// This assumes that the common convention we follow where we put the common error at the beginning of the error holds.
+func ErrorDescriptionIs(target string, errors ...error) bool {
+	for i := range errors {
+		if strings.HasPrefix(target, errors[i].Error()) {
+			return true
+		}
+	}
+	return false
+}
+
 // deserialiseCommonError returns the common error corresponding to its string value
 func deserialiseCommonError(errStr string) (bool, error) {
 	errStr = strings.TrimSpace(errStr)

--- a/utils/commonerrors/errors.go
+++ b/utils/commonerrors/errors.go
@@ -101,11 +101,9 @@ func CorrespondTo(target error, description ...string) bool {
 	return false
 }
 
-// ErrorDescriptionIs determines whether a srting matches a commonerror that is being represented as a
-// string. For example through fmt.Sprint(err) or err.Error().
-//
-// This assumes that the common convention we follow where we put the common error at the beginning of the error holds.
-func ErrorDescriptionIs(target string, errors ...error) bool {
+// RelatesTo determines whether an error description string could relate to a particular set of common errors
+// This assumes that the error description follows the convention of placing the type of errors at the start of the string.
+func RelatesTo(target string, errors ...error) bool {
 	for i := range errors {
 		if strings.HasPrefix(target, errors[i].Error()) {
 			return true

--- a/utils/commonerrors/errors_test.go
+++ b/utils/commonerrors/errors_test.go
@@ -186,3 +186,18 @@ func TestIgnore(t *testing.T) {
 	assert.Equal(t, nil, Ignore(fmt.Errorf("an error %w", ErrNotImplemented), ErrInvalid, ErrNotImplemented, ErrUnknown))
 	assert.Equal(t, fmt.Errorf("an error %w", ErrNotImplemented), Ignore(fmt.Errorf("an error %w", ErrNotImplemented), ErrInvalid, ErrUnknown))
 }
+
+func TestErrDescriptionIs(t *testing.T) {
+	assert.True(t, ErrorDescriptionIs(fmt.Errorf("%w: %v", ErrInvalid, faker.Sentence()).Error(), ErrInvalid))
+	assert.True(t, ErrorDescriptionIs(fmt.Errorf("%w: %v", ErrInvalid, faker.Sentence()).Error(), ErrInvalid, ErrCondition))
+	assert.False(t, ErrorDescriptionIs(fmt.Errorf("%w: %v", ErrUnauthorised, faker.Sentence()).Error(), ErrInvalid))
+	assert.False(t, ErrorDescriptionIs(fmt.Errorf("%w: %v", ErrUnauthorised, faker.Sentence()).Error(), ErrInvalid, ErrCondition))
+	assert.True(t, ErrorDescriptionIs(fmt.Sprint(fmt.Errorf("%w: %v", ErrInvalid, faker.Sentence())), ErrInvalid))
+	assert.True(t, ErrorDescriptionIs(fmt.Sprint(fmt.Errorf("%w: %v", ErrInvalid, faker.Sentence())), ErrInvalid, ErrCondition))
+	assert.False(t, ErrorDescriptionIs(fmt.Sprint(fmt.Errorf("%w: %v", ErrUnauthorised, faker.Sentence())), ErrInvalid))
+	assert.False(t, ErrorDescriptionIs(fmt.Sprint(fmt.Errorf("%w: %v", ErrUnauthorised, faker.Sentence())), ErrInvalid, ErrCondition))
+	assert.True(t, ErrorDescriptionIs(fmt.Sprintf("%v: %v", ErrInvalid.Error(), faker.Sentence()), ErrInvalid))
+	assert.True(t, ErrorDescriptionIs(fmt.Sprintf("%v: %v", ErrInvalid.Error(), faker.Sentence()), ErrInvalid, ErrCondition))
+	assert.False(t, ErrorDescriptionIs(fmt.Sprintf("%v: %v", ErrUnauthorised.Error(), faker.Sentence()), ErrInvalid))
+	assert.False(t, ErrorDescriptionIs(fmt.Sprintf("%v: %v", ErrUnauthorised.Error(), faker.Sentence()), ErrInvalid, ErrCondition))
+}

--- a/utils/commonerrors/errors_test.go
+++ b/utils/commonerrors/errors_test.go
@@ -187,17 +187,17 @@ func TestIgnore(t *testing.T) {
 	assert.Equal(t, fmt.Errorf("an error %w", ErrNotImplemented), Ignore(fmt.Errorf("an error %w", ErrNotImplemented), ErrInvalid, ErrUnknown))
 }
 
-func TestErrDescriptionIs(t *testing.T) {
-	assert.True(t, ErrorDescriptionIs(fmt.Errorf("%w: %v", ErrInvalid, faker.Sentence()).Error(), ErrInvalid))
-	assert.True(t, ErrorDescriptionIs(fmt.Errorf("%w: %v", ErrInvalid, faker.Sentence()).Error(), ErrInvalid, ErrCondition))
-	assert.False(t, ErrorDescriptionIs(fmt.Errorf("%w: %v", ErrUnauthorised, faker.Sentence()).Error(), ErrInvalid))
-	assert.False(t, ErrorDescriptionIs(fmt.Errorf("%w: %v", ErrUnauthorised, faker.Sentence()).Error(), ErrInvalid, ErrCondition))
-	assert.True(t, ErrorDescriptionIs(fmt.Sprint(fmt.Errorf("%w: %v", ErrInvalid, faker.Sentence())), ErrInvalid))
-	assert.True(t, ErrorDescriptionIs(fmt.Sprint(fmt.Errorf("%w: %v", ErrInvalid, faker.Sentence())), ErrInvalid, ErrCondition))
-	assert.False(t, ErrorDescriptionIs(fmt.Sprint(fmt.Errorf("%w: %v", ErrUnauthorised, faker.Sentence())), ErrInvalid))
-	assert.False(t, ErrorDescriptionIs(fmt.Sprint(fmt.Errorf("%w: %v", ErrUnauthorised, faker.Sentence())), ErrInvalid, ErrCondition))
-	assert.True(t, ErrorDescriptionIs(fmt.Sprintf("%v: %v", ErrInvalid.Error(), faker.Sentence()), ErrInvalid))
-	assert.True(t, ErrorDescriptionIs(fmt.Sprintf("%v: %v", ErrInvalid.Error(), faker.Sentence()), ErrInvalid, ErrCondition))
-	assert.False(t, ErrorDescriptionIs(fmt.Sprintf("%v: %v", ErrUnauthorised.Error(), faker.Sentence()), ErrInvalid))
-	assert.False(t, ErrorDescriptionIs(fmt.Sprintf("%v: %v", ErrUnauthorised.Error(), faker.Sentence()), ErrInvalid, ErrCondition))
+func TestErrorRelatesTo(t *testing.T) {
+	assert.True(t, RelatesTo(fmt.Errorf("%w: %v", ErrInvalid, faker.Sentence()).Error(), ErrInvalid))
+	assert.True(t, RelatesTo(fmt.Errorf("%w: %v", ErrInvalid, faker.Sentence()).Error(), ErrInvalid, ErrCondition))
+	assert.False(t, RelatesTo(fmt.Errorf("%w: %v", ErrUnauthorised, faker.Sentence()).Error(), ErrInvalid))
+	assert.False(t, RelatesTo(fmt.Errorf("%w: %v", ErrUnauthorised, faker.Sentence()).Error(), ErrInvalid, ErrCondition))
+	assert.True(t, RelatesTo(fmt.Sprint(fmt.Errorf("%w: %v", ErrInvalid, faker.Sentence())), ErrInvalid))
+	assert.True(t, RelatesTo(fmt.Sprint(fmt.Errorf("%w: %v", ErrInvalid, faker.Sentence())), ErrInvalid, ErrCondition))
+	assert.False(t, RelatesTo(fmt.Sprint(fmt.Errorf("%w: %v", ErrUnauthorised, faker.Sentence())), ErrInvalid))
+	assert.False(t, RelatesTo(fmt.Sprint(fmt.Errorf("%w: %v", ErrUnauthorised, faker.Sentence())), ErrInvalid, ErrCondition))
+	assert.True(t, RelatesTo(fmt.Sprintf("%v: %v", ErrInvalid.Error(), faker.Sentence()), ErrInvalid))
+	assert.True(t, RelatesTo(fmt.Sprintf("%v: %v", ErrInvalid.Error(), faker.Sentence()), ErrInvalid, ErrCondition))
+	assert.False(t, RelatesTo(fmt.Sprintf("%v: %v", ErrUnauthorised.Error(), faker.Sentence()), ErrInvalid))
+	assert.False(t, RelatesTo(fmt.Sprintf("%v: %v", ErrUnauthorised.Error(), faker.Sentence()), ErrInvalid, ErrCondition))
 }


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Add support for determining commonerror from a string

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
