### PR TITLE
:sparkles: `[logs]` Add a way to use a `Loggers` as a plain `logr.Logger`

### DIFF
--- a/changes/20240613181738.feature
+++ b/changes/20240613181738.feature
@@ -1,0 +1,1 @@
+:sparkles: `[logs]` Add a way to use a `Loggers` as a plain `logr.Logger`

--- a/utils/logs/logr_logger_test.go
+++ b/utils/logs/logr_logger_test.go
@@ -33,6 +33,15 @@ func TestLogrLoggerConversion(t *testing.T) {
 	require.NoError(t, err)
 	converted := NewLogrLoggerFromLoggers(loggers)
 	converted.WithName(faker.Name()).WithValues(faker.Word(), faker.Name()).Error(commonerrors.ErrUnexpected, faker.Sentence())
+	converted.Info(faker.Sentence(), faker.Word(), faker.Name())
+}
+
+func TestLogrLoggerConversionPlain(t *testing.T) {
+	loggers, err := NewPipeLogger()
+	require.NoError(t, err)
+	converted := NewPlainLogrLoggerFromLoggers(loggers)
+	converted.WithName(faker.Name()).WithValues(faker.Word(), faker.Name()).Error(commonerrors.ErrUnexpected, faker.Sentence())
+	converted.Info(faker.Sentence(), faker.Word(), faker.Name())
 }
 
 func TestGetLogrFromEmptyContext(t *testing.T) {


### PR DESCRIPTION


<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

- added a new logger adaptor


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
