### PR TITLE
:sparkles: `http` Add support for overriding the default client used by the oath retryable clients

### DIFF
--- a/changes/20240619131209.feature
+++ b/changes/20240619131209.feature
@@ -1,0 +1,1 @@
+:sparkles: `http` Add support for overriding the default client used by the oath retryable clients

--- a/utils/http/client_test.go
+++ b/utils/http/client_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
@@ -65,6 +66,18 @@ func TestClientHappy(t *testing.T) {
 			clientName: "client with linear backoff",
 			client: func() IClient {
 				return NewConfigurableRetryableClient(DefaultRobustHTTPClientConfigurationWithLinearBackOff())
+			},
+		},
+		{
+			clientName: "custom oauth client with retry after but no backoff using oauth2.Token (using custom client function with client == nil)",
+			client: func() IClient {
+				return NewConfigurableRetryableOauthClientWithLoggerAndCustomClient(DefaultRobustHTTPClientConfigurationWithRetryAfter(), nil, logr.Discard(), "test-token")
+			},
+		},
+		{
+			clientName: "custom oauth client with retry after but no backoff using oauth2.Token (using custom client function with client == NewPlainHTTPClient())",
+			client: func() IClient {
+				return NewConfigurableRetryableOauthClientWithLoggerAndCustomClient(DefaultRobustHTTPClientConfigurationWithRetryAfter(), NewPlainHTTPClient().StandardClient(), logr.Discard(), "test-token")
 			},
 		},
 	}
@@ -210,6 +223,18 @@ func TestClientWithDifferentBodies(t *testing.T) {
 			clientName: "client with linear backoff",
 			client: func() IClient {
 				return NewConfigurableRetryableClient(DefaultRobustHTTPClientConfigurationWithLinearBackOff())
+			},
+		},
+		{
+			clientName: "custom oauth client with retry after but no backoff using oauth2.Token (using custom client function with client == nil)",
+			client: func() IClient {
+				return NewConfigurableRetryableOauthClientWithLoggerAndCustomClient(DefaultRobustHTTPClientConfigurationWithRetryAfter(), nil, logr.Discard(), "test-token")
+			},
+		},
+		{
+			clientName: "custom oauth client with retry after but no backoff using oauth2.Token (using custom client function with client == NewPlainHTTPClient())",
+			client: func() IClient {
+				return NewConfigurableRetryableOauthClientWithLoggerAndCustomClient(DefaultRobustHTTPClientConfigurationWithRetryAfter(), NewPlainHTTPClient().StandardClient(), logr.Discard(), "test-token")
 			},
 		},
 	}

--- a/utils/http/retryable_client.go
+++ b/utils/http/retryable_client.go
@@ -60,10 +60,23 @@ func NewConfigurableRetryableOauthClient(cfg *HTTPClientConfiguration, token str
 // NewConfigurableRetryableOauthClientWithLogger creates a new http client which will retry failed requests according to the retry configuration (e.g. no retry, basic retry policy, exponential backoff) with the authorisation header set to token
 // It is also possible to supply a logger for debug purposes
 func NewConfigurableRetryableOauthClientWithLogger(cfg *HTTPClientConfiguration, logger logr.Logger, token string) IRetryableClient {
+	return NewConfigurableRetryableOauthClientWithLoggerAndCustomClient(cfg, nil, logger, token)
+}
+
+// NewConfigurableRetryableOauthClientWithLogger creates a new http client which will retry failed requests according to the retry configuration (e.g. no retry, basic retry policy, exponential backoff) with the authorisation header set to token
+// The underlying client used by the oauth client can be optionally supplied via client
+// It is also possible to supply a logger for debug purposes
+func NewConfigurableRetryableOauthClientWithLoggerAndCustomClient(cfg *HTTPClientConfiguration, client *http.Client, logger logr.Logger, token string) IRetryableClient {
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},
 	)
-	tc := oauth2.NewClient(context.Background(), ts)
+
+	oauthClientCtx := context.Background()
+	if client != nil {
+		oauthClientCtx = context.WithValue(oauthClientCtx, oauth2.HTTPClient, client)
+	}
+
+	tc := oauth2.NewClient(oauthClientCtx, ts)
 
 	return NewConfigurableRetryableClientWithLoggerFromClient(cfg, logger, tc)
 }

--- a/utils/http/retryable_client.go
+++ b/utils/http/retryable_client.go
@@ -71,11 +71,11 @@ func NewConfigurableRetryableOauthClientWithLoggerAndCustomClient(cfg *HTTPClien
 		&oauth2.Token{AccessToken: token},
 	)
 
-	oauthClientCtx := context.Background()
-	if client != nil {
-		oauthClientCtx = context.WithValue(oauthClientCtx, oauth2.HTTPClient, client)
+	if client == nil {
+		client = cleanhttp.DefaultPooledClient()
 	}
 
+	oauthClientCtx := context.WithValue(context.Background(), oauth2.HTTPClient, client)
 	tc := oauth2.NewClient(oauthClientCtx, ts)
 
 	return NewConfigurableRetryableClientWithLoggerFromClient(cfg, logger, tc)

--- a/utils/http/retryable_client_test.go
+++ b/utils/http/retryable_client_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/go-http-utils/headers"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
@@ -87,6 +88,14 @@ func TestClient_Delete_Backoff(t *testing.T) {
 			token:           field.ToOptionalString("test-token"),
 			retryableClient: NewConfigurableRetryableOauthClientWithToken(DefaultRobustHTTPClientConfigurationWithRetryAfter(), &oauth2.Token{AccessToken: "test-token"}),
 			clientName:      "custom oauth client with retry after but no backoff using oauth2.Token",
+		},
+		{
+			retryableClient: NewConfigurableRetryableOauthClientWithLoggerAndCustomClient(DefaultRobustHTTPClientConfigurationWithRetryAfter(), nil, logr.Discard(), "test-token"),
+			clientName:      "custom oauth client with retry after but no backoff using oauth2.Token (using custom client function with client == nil)",
+		},
+		{
+			retryableClient: NewConfigurableRetryableOauthClientWithLoggerAndCustomClient(DefaultRobustHTTPClientConfigurationWithRetryAfter(), NewPlainHTTPClient().StandardClient(), logr.Discard(), "test-token"),
+			clientName:      "custom oauth client with retry after but no backoff using oauth2.Token (using custom client function with client == NewPlainHTTPClient())",
 		},
 	}
 	for i := range tests {
@@ -189,6 +198,14 @@ func TestClient_Get_Fail_Timeout(t *testing.T) {
 			retryableClient: NewConfigurableRetryableOauthClientWithToken(DefaultRobustHTTPClientConfigurationWithRetryAfter(), &oauth2.Token{AccessToken: "test-token"}),
 			clientName:      "custom oauth client with retry after but no backoff using oauth2.Token",
 		},
+		{
+			retryableClient: NewConfigurableRetryableOauthClientWithLoggerAndCustomClient(DefaultRobustHTTPClientConfigurationWithRetryAfter(), nil, logr.Discard(), "test-token"),
+			clientName:      "custom oauth client with retry after but no backoff using oauth2.Token (using custom client function with client == nil)",
+		},
+		{
+			retryableClient: NewConfigurableRetryableOauthClientWithLoggerAndCustomClient(DefaultRobustHTTPClientConfigurationWithRetryAfter(), NewPlainHTTPClient().StandardClient(), logr.Discard(), "test-token"),
+			clientName:      "custom oauth client with retry after but no backoff using oauth2.Token (using custom client function with client == NewPlainHTTPClient())",
+		},
 	}
 	for i := range tests {
 		test := tests[i]
@@ -279,6 +296,14 @@ func TestUnderlyingClient(t *testing.T) {
 		{
 			retryableClient: NewConfigurableRetryableOauthClientWithToken(DefaultRobustHTTPClientConfigurationWithRetryAfter(), &oauth2.Token{AccessToken: "test-token"}),
 			clientName:      "custom oauth client with retry after but no backoff using oauth2.Token",
+		},
+		{
+			retryableClient: NewConfigurableRetryableOauthClientWithLoggerAndCustomClient(DefaultRobustHTTPClientConfigurationWithRetryAfter(), nil, logr.Discard(), "test-token"),
+			clientName:      "custom oauth client with retry after but no backoff using oauth2.Token (using custom client function with client == nil)",
+		},
+		{
+			retryableClient: NewConfigurableRetryableOauthClientWithLoggerAndCustomClient(DefaultRobustHTTPClientConfigurationWithRetryAfter(), NewPlainHTTPClient().StandardClient(), logr.Discard(), "test-token"),
+			clientName:      "custom oauth client with retry after but no backoff using oauth2.Token (using custom client function with client == NewPlainHTTPClient())",
 		},
 	}
 


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Add support for overriding the default client used by the oath retryable clients

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
