### PR TITLE
:bug: `[logs]` resolve problem with the logger source being set for a `logr.Logger`

### DIFF
--- a/changes/20240627132421.bugfix
+++ b/changes/20240627132421.bugfix
@@ -1,0 +1,1 @@
+:bug: `[logs]` resolve problem with the logger source being set for a logr.Logger


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description
- avoid infinite logger creation loop



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
