### PR TITLE
:sparkles: Add support for parsing a comma separated string list as a map of key-value pairs

### DIFF
--- a/changes/20240827111953.feature
+++ b/changes/20240827111953.feature
@@ -1,0 +1,1 @@
+:sparkles: Add support for parsing a comma separated string list as a map of key-value pairs

--- a/utils/collection/parseLists.go
+++ b/utils/collection/parseLists.go
@@ -5,8 +5,11 @@
 package collection
 
 import (
+	"fmt"
 	"strings"
 	"unicode"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
 )
 
 func lineIsOnlyWhitespace(line string) bool {
@@ -51,4 +54,23 @@ func ParseListWithCleanupKeepBlankLines(input string, sep string) (newS []string
 // ParseCommaSeparatedList returns the list of string separated by a comma
 func ParseCommaSeparatedList(input string) []string {
 	return ParseListWithCleanup(input, ",")
+}
+
+// ParseCommaSeparatedListToMap returns a map of key value pairs from a string containing a comma separated list
+func ParseCommaSeparatedListToMap(input string) (pairs map[string]string, err error) {
+	inputSplit := ParseCommaSeparatedList(input)
+	numElements := len(inputSplit)
+
+	if numElements%2 != 0 {
+		err = fmt.Errorf("%w: could not parse comma separated list '%v' into map as it did not have an even number of elements", commonerrors.ErrInvalid, input)
+		return
+	}
+
+	pairs = make(map[string]string, numElements/2)
+
+	for i := 0; i < numElements; i += 2 {
+		pairs[inputSplit[i]] = inputSplit[i+1]
+	}
+
+	return
 }

--- a/utils/collection/parseLists.go
+++ b/utils/collection/parseLists.go
@@ -67,7 +67,7 @@ func ParseCommaSeparatedListToMap(input string) (pairs map[string]string, err er
 	}
 
 	pairs = make(map[string]string, numElements/2)
-// TODO use slices.Chunk introduced in go 23 when library is upgraded
+	// TODO use slices.Chunk introduced in go 23 when library is upgraded
 	for i := 0; i < numElements; i += 2 {
 		pairs[inputSplit[i]] = inputSplit[i+1]
 	}

--- a/utils/collection/parseLists.go
+++ b/utils/collection/parseLists.go
@@ -67,7 +67,7 @@ func ParseCommaSeparatedListToMap(input string) (pairs map[string]string, err er
 	}
 
 	pairs = make(map[string]string, numElements/2)
-
+// TODO use slices.Chunk introduced in go 23 when library is upgraded
 	for i := 0; i < numElements; i += 2 {
 		pairs[inputSplit[i]] = inputSplit[i+1]
 	}

--- a/utils/collection/parseLists_test.go
+++ b/utils/collection/parseLists_test.go
@@ -9,12 +9,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ARM-software/golang-utils/utils/commonerrors"
-	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
 	"github.com/go-faker/faker/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
 )
 
 var (


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Add support for parsing a comma separated string list as a map of key-value pairs

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
