### PR TITLE
:bug: Make sure that configuration defaults are not over-ridden with blank values when reading in a config file that doesn't specify fields

### DIFF
--- a/changes/20240918112214.bugfix
+++ b/changes/20240918112214.bugfix
@@ -1,0 +1,1 @@
+:bug: Make sure that configuration defaults are not over-ridden with blank values when reading in a config file that doesn't specify fields

--- a/utils/config/service_configuration.go
+++ b/utils/config/service_configuration.go
@@ -103,7 +103,7 @@ func LoadFromConfigurationFile(viperSession *viper.Viper, configFile string) (er
 		return
 	}
 	viperSession.SetConfigFile(configFile)
-	err = convertViperError(viperSession.ReadInConfig())
+	err = convertViperError(viperSession.MergeInConfig())
 	return
 }
 

--- a/utils/config/service_configuration_test.go
+++ b/utils/config/service_configuration_test.go
@@ -564,6 +564,30 @@ func TestServiceConfigurationLoadFromFile(t *testing.T) {
 	assert.Equal(t, "test string", value)
 }
 
+type testCfg struct {
+	Field1 string `mapstructure:"f1"`
+	Field2 string `mapstructure:"dummy_string"`
+}
+
+func (cfg *testCfg) Validate() error {
+	return validation.ValidateStruct(cfg,
+		validation.Field(&cfg.Field1, validation.Required),
+	)
+}
+
+func TestServiceConfigurationLoadFromFileWithDefaults(t *testing.T) {
+	os.Clearenv()
+	session := viper.New()
+	test := testCfg{}
+	err := LoadFromEnvironment(session, "", &test, &testCfg{
+		Field1: "test",
+	}, filepath.Join(".", "fixtures", "config-test.json"))
+	require.NoError(t, err)
+	assert.NotEmpty(t, test.Field1)
+	assert.Equal(t, "test", test.Field1)
+	assert.Equal(t, "test string", test.Field2)
+}
+
 func TestServiceConfigurationLoadFromEnvironment(t *testing.T) {
 	os.Clearenv()
 	session := viper.New()

--- a/utils/config/service_configuration_test.go
+++ b/utils/config/service_configuration_test.go
@@ -585,6 +585,7 @@ func TestServiceConfigurationLoadFromFileWithDefaults(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, test.Field1)
 	assert.Equal(t, "test", test.Field1)
+	assert.NotEmpty(t, test.Field2)
 	assert.Equal(t, "test string", test.Field2)
 }
 

--- a/utils/field/fields_test.go
+++ b/utils/field/fields_test.go
@@ -37,7 +37,7 @@ func TestOptionalField(t *testing.T) {
 		},
 		{
 			fieldType:    "UInt",
-			value:        uint(time.Now().Second()),
+			value:        uint(time.Now().Second()), //nolint:gosec // time is positive and uint has more bits than int so no overflow
 			defaultValue: uint(76),
 			setFunction: func(a any) any {
 				return ToOptionalUint(a.(uint))
@@ -97,7 +97,7 @@ func TestOptionalField(t *testing.T) {
 		},
 		{
 			fieldType:    "UInt64",
-			value:        uint64(time.Now().Unix()),
+			value:        uint64(time.Now().Unix()), //nolint:gosec // time is positive and uint64 has more bits than int64 so no overflow
 			defaultValue: uint64(97894),
 			setFunction: func(a any) any {
 				return ToOptionalUint64(a.(uint64))

--- a/utils/filesystem/zip.go
+++ b/utils/filesystem/zip.go
@@ -356,10 +356,10 @@ func (fs *VFS) unzip(ctx context.Context, source string, destination string, lim
 					fileCounter.Inc()
 					fileList = append(fileList, filePath)
 				}
-				totalSizeOnDisk.Add(uint64(fileSizeOnDisk))
+				totalSizeOnDisk.Add(uint64(fileSizeOnDisk)) //nolint:gosec // file size is positive and uint64 has more bits than int64 so no overflow
 			}
 		} else {
-			totalSizeOnDisk.Add(uint64(fileSizeOnDisk))
+			totalSizeOnDisk.Add(uint64(fileSizeOnDisk)) //nolint:gosec // file size is positive and uint64 has more bits than int64 so no overflow
 		}
 
 		if limits.Apply() && totalSizeOnDisk.Load() > limits.GetMaxTotalSize() {

--- a/utils/retry/retry.go
+++ b/utils/retry/retry.go
@@ -39,7 +39,7 @@ func RetryIf(ctx context.Context, logger logr.Logger, retryPolicy *RetryPolicyCo
 			retry.MaxDelay(retryPolicy.RetryWaitMax),
 			retry.MaxJitter(25*time.Millisecond),
 			retry.DelayType(retryType),
-			retry.Attempts(uint(retryPolicy.RetryMax)),
+			retry.Attempts(uint(retryPolicy.RetryMax)), //nolint:gosec // in normal use this will have had Validate() called which enforces that the minimum number of RetryMax is 0 so it won't overflow
 			retry.RetryIf(retryConditionFn),
 			retry.LastErrorOnly(true),
 			retry.Context(ctx),


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

If using a config file then it was overriding the default values that had already been added to the session. This is fine except if you don't specify a value in the config because it is replaced with an empty value and the defaults are not kept.

With the newly added test, if you do it the old way the test fails.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
