### PR TITLE
:bug: `[pagination]` Fix stream pagination

### DIFF
--- a/changes/20241114171420.bugfix
+++ b/changes/20241114171420.bugfix
@@ -1,0 +1,1 @@
+:bug: `[pagination]` Fix stream pagination

--- a/utils/collection/pagination/interfaces.go
+++ b/utils/collection/pagination/interfaces.go
@@ -22,7 +22,7 @@ type IIterator interface {
 	GetNext() (interface{}, error)
 }
 
-// IStaticPage defines a generic page for a collection.
+// IStaticPage defines a generic page for a collection. A page is marked as static when it cannot retrieve next pages on its own.
 type IStaticPage interface {
 	// HasNext states whether more pages are accessible.
 	HasNext() bool
@@ -78,7 +78,7 @@ type IPaginatorAndPageFetcher interface {
 	FetchNextPage(ctx context.Context, currentPage IStaticPage) (IStaticPage, error)
 }
 
-// IGenericStreamPaginator is an iterator over a stream. A stream is a collection without any know ending.
+// IGenericStreamPaginator is an iterator over a stream. A stream is a collection without any known ending.
 type IGenericStreamPaginator interface {
 	IGenericPaginator
 	// DryUp indicates to the stream that it will soon run out.

--- a/utils/collection/pagination/stream_test.go
+++ b/utils/collection/pagination/stream_test.go
@@ -39,10 +39,8 @@ func TestStreamPaginator(t *testing.T) {
 				})
 				return paginator, err
 			},
-			generateFunc: func() (IStream, int64, error) {
-				return GenerateMockStreamWithEnding()
-			},
-			name: "stream paginator over a stream of static pages with known ending",
+			generateFunc: GenerateMockStreamWithEnding,
+			name:         "stream paginator over a stream of static pages with known ending",
 		},
 		{
 			paginator: func(ctx context.Context, collection IStaticPageStream) (IGenericStreamPaginator, error) {
@@ -51,10 +49,8 @@ func TestStreamPaginator(t *testing.T) {
 				})
 				return paginator, err
 			},
-			generateFunc: func() (IStream, int64, error) {
-				return GenerateMockStreamWithEnding()
-			},
-			name: "stream paginator over a stream of dynamic pages but with a known ending",
+			generateFunc: GenerateMockStreamWithEnding,
+			name:         "stream paginator over a stream of dynamic pages but with a known ending",
 		},
 		{
 			paginator: func(ctx context.Context, collection IStaticPageStream) (IGenericStreamPaginator, error) {
@@ -63,11 +59,9 @@ func TestStreamPaginator(t *testing.T) {
 				})
 				return paginator, err
 			},
-			name: "stream paginator over a running dry stream of dynamic pages",
-			generateFunc: func() (IStream, int64, error) {
-				return GenerateMockStream()
-			},
-			dryOut: true,
+			name:         "stream paginator over a running dry stream of dynamic pages",
+			generateFunc: GenerateMockStream,
+			dryOut:       true,
 		},
 		{
 			paginator: func(ctx context.Context, collection IStaticPageStream) (IGenericStreamPaginator, error) {
@@ -92,11 +86,9 @@ func TestStreamPaginator(t *testing.T) {
 				}
 				return paginator, err
 			},
-			name: "stream paginator over a running dry stream of static pages",
-			generateFunc: func() (IStream, int64, error) {
-				return GenerateMockStream()
-			},
-			dryOut: true,
+			name:         "stream paginator over a running dry stream of static pages",
+			generateFunc: GenerateMockStream,
+			dryOut:       true,
 		},
 	}
 

--- a/utils/collection/pagination/stream_test.go
+++ b/utils/collection/pagination/stream_test.go
@@ -1,0 +1,161 @@
+package pagination
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
+)
+
+func TestStreamPaginator(t *testing.T) {
+	tests := []struct {
+		paginator    func(context.Context, IStaticPageStream) (IGenericStreamPaginator, error)
+		name         string
+		generateFunc func() (firstPage IStream, itemTotal int64, err error)
+		dryOut       bool
+	}{
+		{
+			paginator: func(ctx context.Context, collection IStaticPageStream) (IGenericStreamPaginator, error) {
+				paginator, err := NewStaticPageStreamPaginator(ctx, time.Second, 10*time.Millisecond, func(context.Context) (IStaticPageStream, error) {
+					return collection, nil
+				}, func(fCtx context.Context, current IStaticPage) (IStaticPage, error) {
+					c, err := toDynamicPage(current)
+					if err != nil {
+						return nil, err
+					}
+					return c.GetNext(fCtx)
+				}, func(fCtx context.Context, current IStaticPageStream) (IStaticPageStream, error) {
+					s, err := toDynamicStream(current)
+					if err != nil {
+						return nil, err
+					}
+					return s.GetFuture(fCtx)
+				})
+				return paginator, err
+			},
+			generateFunc: func() (IStream, int64, error) {
+				return GenerateMockStreamWithEnding()
+			},
+			name: "stream paginator over a stream of static pages with known ending",
+		},
+		{
+			paginator: func(ctx context.Context, collection IStaticPageStream) (IGenericStreamPaginator, error) {
+				paginator, err := NewStreamPaginator(ctx, time.Second, 10*time.Millisecond, func(context.Context) (IStream, error) {
+					return toDynamicStream(collection)
+				})
+				return paginator, err
+			},
+			generateFunc: func() (IStream, int64, error) {
+				return GenerateMockStreamWithEnding()
+			},
+			name: "stream paginator over a stream of dynamic pages but with a known ending",
+		},
+		{
+			paginator: func(ctx context.Context, collection IStaticPageStream) (IGenericStreamPaginator, error) {
+				paginator, err := NewStreamPaginator(ctx, time.Second, 10*time.Millisecond, func(context.Context) (IStream, error) {
+					return toDynamicStream(collection)
+				})
+				return paginator, err
+			},
+			name: "stream paginator over a running dry stream of dynamic pages",
+			generateFunc: func() (IStream, int64, error) {
+				return GenerateMockStream()
+			},
+			dryOut: true,
+		},
+		{
+			paginator: func(ctx context.Context, collection IStaticPageStream) (IGenericStreamPaginator, error) {
+				paginator, err := NewStaticPageStreamPaginator(ctx, time.Second, 10*time.Millisecond, func(context.Context) (IStaticPageStream, error) {
+					return collection, nil
+				}, func(fCtx context.Context, current IStaticPage) (IStaticPage, error) {
+					c, err := toDynamicPage(current)
+					if err != nil {
+						return nil, err
+					}
+					return c.GetNext(fCtx)
+				}, func(fCtx context.Context, current IStaticPageStream) (IStaticPageStream, error) {
+					s, err := toDynamicStream(current)
+					if err != nil {
+						return nil, err
+					}
+					return s.GetFuture(fCtx)
+				})
+				if paginator != nil {
+					// Indicate the stream will run out.
+					err = paginator.DryUp()
+				}
+				return paginator, err
+			},
+			name: "stream paginator over a running dry stream of static pages",
+			generateFunc: func() (IStream, int64, error) {
+				return GenerateMockStream()
+			},
+			dryOut: true,
+		},
+	}
+
+	for te := range tests {
+		test := tests[te]
+		for i := 0; i < 10; i++ {
+			mockPages, expectedCount, err := test.generateFunc()
+			require.NoError(t, err)
+			t.Run(fmt.Sprintf("%v-#%v-[%v items]", test.name, i, expectedCount), func(t *testing.T) {
+				paginator, err := test.paginator(context.TODO(), mockPages)
+				require.NoError(t, err)
+				count := int64(0)
+				for {
+					if !paginator.HasNext() {
+						break
+					}
+					count += 1
+					item, err := paginator.GetNext()
+					require.NoError(t, err)
+					require.NotNil(t, item)
+					mockItem, ok := item.(*MockItem)
+					require.True(t, ok)
+					assert.Equal(t, int(count-1), mockItem.Index)
+					if count >= expectedCount%2 {
+						require.NoError(t, paginator.DryUp())
+					}
+				}
+				assert.Equal(t, expectedCount, count)
+			})
+		}
+	}
+}
+
+func TestEmptyStream(t *testing.T) {
+	mockPages, expectedCount, err := GenerateMockEmptyStream()
+	require.NoError(t, err)
+	require.Zero(t, expectedCount)
+	require.NotNil(t, mockPages)
+	paginator, err := NewStreamPaginator(context.Background(), time.Second, 10*time.Millisecond, func(context.Context) (IStream, error) {
+		return toDynamicStream(mockPages)
+	})
+	require.NoError(t, err)
+	assert.False(t, paginator.HasNext())
+	assert.False(t, paginator.IsRunningDry())
+	item, err := paginator.GetNext()
+	errortest.AssertError(t, err, commonerrors.ErrNotFound)
+	assert.Nil(t, item)
+}
+
+func TestDryOutStream(t *testing.T) {
+	mockPages, expectedCount, err := GenerateMockEmptyStream()
+	require.NoError(t, err)
+	require.Zero(t, expectedCount)
+	require.NotNil(t, mockPages)
+	paginator, err := NewStreamPaginator(context.Background(), time.Millisecond, 10*time.Millisecond, func(context.Context) (IStream, error) {
+		return toDynamicStream(mockPages)
+	})
+	require.NoError(t, err)
+	require.NoError(t, paginator.DryUp())
+	assert.False(t, paginator.HasNext())
+	assert.True(t, paginator.IsRunningDry())
+}

--- a/utils/collection/pagination/testing_test.go
+++ b/utils/collection/pagination/testing_test.go
@@ -1,0 +1,124 @@
+package pagination
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-faker/faker/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ARM-software/golang-utils/utils/safecast"
+)
+
+func TestGenerateEmptyPage(t *testing.T) {
+	page := GenerateEmptyPage()
+	require.NotNil(t, page)
+	assert.False(t, page.HasNext())
+	assert.False(t, page.HasFuture())
+	count, err := page.GetItemCount()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestGenerateMockPage(t *testing.T) {
+	r, err := faker.RandomInt(2, 50)
+	require.NoError(t, err)
+	for i := 0; i < r[0]; i++ {
+		page, count, err := GenerateMockPage()
+		require.NoError(t, err)
+		t.Run(fmt.Sprintf("%d_items#%d", i, count), func(t *testing.T) {
+			require.NotNil(t, page)
+			intCount, err := page.GetItemCount()
+			require.NoError(t, err)
+			assert.Equal(t, count, intCount)
+		})
+	}
+}
+
+func TestGenerateMockCollection(t *testing.T) {
+	r, err := faker.RandomInt(2, 50)
+	require.NoError(t, err)
+	for i := 0; i < r[0]; i++ {
+		firstPage, count, err := GenerateMockCollection()
+		require.NoError(t, err)
+		t.Run(fmt.Sprintf("%d_items#%d", i, count), func(t *testing.T) {
+			require.NotNil(t, firstPage)
+			cCount, err := firstPage.GetItemCount()
+			require.NoError(t, err)
+			assert.True(t, cCount <= count)
+			size := safecast.ToInt64(cCount)
+			page := firstPage.(IPage)
+			for {
+				if !page.HasNext() {
+					break
+				}
+				page, err = page.GetNext(context.Background())
+				require.NoError(t, err)
+				cCount, err := page.GetItemCount()
+				require.NoError(t, err)
+				size += cCount
+			}
+			assert.Equal(t, count, size)
+		})
+	}
+}
+
+func TestGenerateMockStream(t *testing.T) {
+	r, err := faker.RandomInt(2, 50)
+	require.NoError(t, err)
+	for i := 0; i < r[0]; i++ {
+		firstPage, count, err := GenerateMockStream()
+		require.NoError(t, err)
+		t.Run(fmt.Sprintf("%d_items#%d", i, count), func(t *testing.T) {
+			require.NotNil(t, firstPage)
+			cCount, err := firstPage.GetItemCount()
+			require.NoError(t, err)
+			assert.True(t, cCount <= count)
+			size := safecast.ToInt64(cCount)
+			page := firstPage.(IStream)
+			for {
+				if !page.HasNext() && !page.HasFuture() {
+					break
+				}
+				if page.HasNext() {
+					nextPage, err := page.GetNext(context.Background())
+					require.NoError(t, err)
+					page = nextPage.(IStream)
+				} else {
+					page, err = page.GetFuture(context.Background())
+					require.NoError(t, err)
+				}
+
+				cCount, err := page.GetItemCount()
+				require.NoError(t, err)
+				size += cCount
+			}
+			assert.Equal(t, count, size)
+		})
+	}
+}
+
+func TestNewMockPageIterator(t *testing.T) {
+	type args struct {
+		page *MockPage
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    IIterator
+		wantErr assert.ErrorAssertionFunc
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewMockPageIterator(tt.args.page)
+			if !tt.wantErr(t, err, fmt.Sprintf("NewMockPageIterator(%v)", tt.args.page)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "NewMockPageIterator(%v)", tt.args.page)
+		})
+	}
+}

--- a/utils/collection/pagination/testing_test.go
+++ b/utils/collection/pagination/testing_test.go
@@ -77,7 +77,7 @@ func TestGenerateMockStream(t *testing.T) {
 			require.NoError(t, err)
 			assert.True(t, cCount <= count)
 			size := safecast.ToInt64(cCount)
-			page := firstPage.(IStream)
+			page := firstPage
 			for {
 				if !page.HasNext() && !page.HasFuture() {
 					break


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description
- Streams implementation had some bugs in that the browsing would stop before reaching the end.
- Added a lot more specific stream tests



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
