### PR TITLE
:gear: Enforce `misspell` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,6 +23,7 @@ linters:
     - revive
     - gocritic
     - unconvert
+    - misspell
 
 linters-settings:
   goimports:


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
