### PR TITLE
:sparkles: [fields] Extends utilities with regards to optional fields

### DIFF
--- a/changes/20241216151002.feature
+++ b/changes/20241216151002.feature
@@ -1,0 +1,1 @@
+:sparkles: [fields] Extends utilities with regards to optional fields

--- a/utils/field/fields.go
+++ b/utils/field/fields.go
@@ -9,172 +9,166 @@ package field
 import "time"
 
 // ToOptionalInt returns a pointer to an int
-func ToOptionalInt(i int) *int {
-	return &i
+func ToOptionalInt(f int) *int {
+	return ToOptional(f)
 }
 
 // OptionalInt returns the value of an optional field or else
 // returns defaultValue.
 func OptionalInt(ptr *int, defaultValue int) int {
-	if ptr != nil {
-		return *ptr
-	}
-	return defaultValue
+	return Optional(ptr, defaultValue)
 }
 
 // ToOptionalInt32 returns a pointer to an int32.
-func ToOptionalInt32(i int32) *int32 {
-	return &i
+func ToOptionalInt32(f int32) *int32 {
+	return ToOptional(f)
 }
 
 // OptionalInt32 returns the value of an optional field or else
 // returns defaultValue.
 func OptionalInt32(ptr *int32, defaultValue int32) int32 {
-	if ptr != nil {
-		return *ptr
-	}
-	return defaultValue
+	return Optional(ptr, defaultValue)
 }
 
 // ToOptionalUint returns a pointer to an uint
-func ToOptionalUint(i uint) *uint {
-	return &i
+func ToOptionalUint(f uint) *uint {
+	return ToOptional(f)
 }
 
 // OptionalUint returns the value of an optional field or else returns defaultValue.
 func OptionalUint(ptr *uint, defaultValue uint) uint {
-	if ptr != nil {
-		return *ptr
-	}
-	return defaultValue
+	return Optional(ptr, defaultValue)
 }
 
 // ToOptionalUint32 returns a pointer to an uint32.
-func ToOptionalUint32(i uint32) *uint32 {
-	return &i
+func ToOptionalUint32(f uint32) *uint32 {
+	return ToOptional(f)
 }
 
 // OptionalUint32 returns the value of an optional field or else returns defaultValue.
 func OptionalUint32(ptr *uint32, defaultValue uint32) uint32 {
-	if ptr != nil {
-		return *ptr
-	}
-	return defaultValue
+	return Optional(ptr, defaultValue)
 }
 
 // ToOptionalInt64 returns a pointer to an int64.
-func ToOptionalInt64(i int64) *int64 {
-	return &i
+func ToOptionalInt64(f int64) *int64 {
+	return ToOptional(f)
 }
 
 // OptionalInt64 returns the value of an optional field or else returns defaultValue.
 func OptionalInt64(ptr *int64, defaultValue int64) int64 {
-	if ptr != nil {
-		return *ptr
-	}
-	return defaultValue
+	return Optional(ptr, defaultValue)
 }
 
 // ToOptionalUint64 returns a pointer to an uint64.
-func ToOptionalUint64(i uint64) *uint64 {
-	return &i
+func ToOptionalUint64(f uint64) *uint64 {
+	return ToOptional(f)
 }
 
 // OptionalUint64 returns the value of an optional field or else returns defaultValue.
 func OptionalUint64(ptr *uint64, defaultValue uint64) uint64 {
-	if ptr != nil {
-		return *ptr
-	}
-	return defaultValue
+	return Optional(ptr, defaultValue)
 }
 
 // ToOptionalBool returns a pointer to a bool.
 func ToOptionalBool(b bool) *bool {
-	return &b
+	return ToOptional(b)
 }
 
 // OptionalBool returns the value of an optional field or else returns defaultValue.
 func OptionalBool(ptr *bool, defaultValue bool) bool {
-	if ptr != nil {
-		return *ptr
-	}
-	return defaultValue
+	return Optional(ptr, defaultValue)
 }
 
 // ToOptionalString returns a pointer to a string.
 func ToOptionalString(s string) *string {
-	return &s
+	return ToOptional(s)
 }
 
 // OptionalString returns the value of an optional field or else returns defaultValue.
 func OptionalString(ptr *string, defaultValue string) string {
-	if ptr != nil {
-		return *ptr
-	}
-	return defaultValue
+	return Optional(ptr, defaultValue)
 }
 
 // ToOptionalAny returns a pointer to a object.
 func ToOptionalAny(a any) *any {
-	return &a
+	return ToOptional(a)
 }
 
 // OptionalAny returns the value of an optional field or else returns defaultValue.
 func OptionalAny(ptr *any, defaultValue any) any {
-	if ptr != nil {
-		return *ptr
-	}
-	return defaultValue
+	return Optional(ptr, defaultValue)
 }
 
 // ToOptionalFloat32 returns a pointer to a float32.
-func ToOptionalFloat32(i float32) *float32 {
-	return &i
+func ToOptionalFloat32(f float32) *float32 {
+	return ToOptional(f)
 }
 
 // OptionalFloat32 returns the value of an optional field or else returns defaultValue.
 func OptionalFloat32(ptr *float32, defaultValue float32) float32 {
-	if ptr != nil {
-		return *ptr
-	}
-	return defaultValue
+	return Optional(ptr, defaultValue)
 }
 
 // ToOptionalFloat64 returns a pointer to a float64.
-func ToOptionalFloat64(i float64) *float64 {
-	return &i
+func ToOptionalFloat64(f float64) *float64 {
+	return ToOptional(f)
 }
 
 // OptionalFloat64 returns the value of an optional field or else returns defaultValue.
 func OptionalFloat64(ptr *float64, defaultValue float64) float64 {
-	if ptr != nil {
-		return *ptr
-	}
-	return defaultValue
+	return Optional(ptr, defaultValue)
 }
 
 // ToOptionalDuration returns a pointer to a Duration.
-func ToOptionalDuration(i time.Duration) *time.Duration {
-	return &i
+func ToOptionalDuration(f time.Duration) *time.Duration {
+	return ToOptional(f)
 }
 
 // OptionalDuration returns the value of an optional field or else returns defaultValue.
 func OptionalDuration(ptr *time.Duration, defaultValue time.Duration) time.Duration {
-	if ptr != nil {
-		return *ptr
-	}
-	return defaultValue
+	return Optional(ptr, defaultValue)
 }
 
 // ToOptionalTime returns a pointer to a Time.
-func ToOptionalTime(i time.Time) *time.Time {
-	return &i
+func ToOptionalTime(f time.Time) *time.Time {
+	return ToOptional(f)
 }
 
 // OptionalTime returns the value of an optional field or else returns defaultValue.
 func OptionalTime(ptr *time.Time, defaultValue time.Time) time.Time {
+	return Optional(ptr, defaultValue)
+}
+
+// ToOptional returns a pointer to the given field value.
+func ToOptional[T any](v T) *T {
+	return &v
+}
+
+// Optional  returns the value of an optional field or else returns defaultValue.
+func Optional[T any](ptr *T, defaultValue T) T {
 	if ptr != nil {
 		return *ptr
 	}
 	return defaultValue
+}
+
+// Equal returns true if both arguments are nil or both arguments
+// dereference to the same value.
+func Equal[T comparable](a, b *T) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return EqualValue(a, *b)
+}
+
+// EqualValue returns true if optional field dereferences to the value.
+func EqualValue[T comparable](field *T, value T) bool {
+	if field == nil {
+		return false
+	}
+	return *field == value
 }

--- a/utils/field/fields_test.go
+++ b/utils/field/fields_test.go
@@ -228,3 +228,24 @@ func TestOptionalField(t *testing.T) {
 		})
 	}
 }
+
+func TestEqual(t *testing.T) {
+	type T int
+	assert.True(t, Equal[T](nil, nil))
+	assert.False(t, Equal(ToOptionalInt(1), nil))
+	assert.False(t, Equal(nil, ToOptionalInt(1)))
+	assert.True(t, Equal(ToOptionalInt(1), ToOptionalInt(1)))
+	str := faker.Sentence()
+	assert.True(t, Equal(ToOptionalString(str), ToOptionalString(str)))
+	assert.False(t, Equal(ToOptionalString(str), ToOptionalString("")))
+}
+
+func TestEqualValue(t *testing.T) {
+	type T any
+	assert.False(t, EqualValue[T](nil, nil))
+	assert.False(t, EqualValue(nil, 1))
+	assert.True(t, EqualValue(ToOptionalInt(1), 1))
+	str := faker.Sentence()
+	assert.True(t, EqualValue(ToOptionalString(str), str))
+	assert.False(t, EqualValue(ToOptionalString(str), ""))
+}


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

extend `[field]` utilities to use generics



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
