### PR TITLE
:sparkles: `encryption` Add support for encrypting content using hybrid RSA/AES encryption

### DIFF
--- a/changes/20250211153712.feature
+++ b/changes/20250211153712.feature
@@ -1,0 +1,1 @@
+:sparkles: `encryption` Add support for encyrpting conent using hybrid RSA/AES encryption

--- a/changes/20250211153712.feature
+++ b/changes/20250211153712.feature
@@ -1,1 +1,1 @@
-:sparkles: `encryption` Add support for encyrpting conent using hybrid RSA/AES encryption
+:sparkles: `encryption` Add support for encrypting content using hybrid RSA/AES encryption

--- a/utils/encryption/aesrsa/encryption.go
+++ b/utils/encryption/aesrsa/encryption.go
@@ -1,0 +1,162 @@
+package aesrsa
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/filesystem"
+)
+
+// ParsePEMBlock will parse the first PEM block found within path
+func ParsePEMBlock(path string) (block *pem.Block, err error) {
+	if path == "" {
+		err = fmt.Errorf("%w: no certificate provided", commonerrors.ErrUndefined)
+		return
+	}
+
+	if !filesystem.Exists(path) {
+		err = fmt.Errorf("%w: could not find certificate at '%v'", commonerrors.ErrNotFound, path)
+		return
+	}
+
+	certBytes, err := filesystem.ReadFile(path)
+	if err != nil {
+		err = fmt.Errorf("%w: failed to read certificate: %v", commonerrors.ErrUnexpected, err.Error())
+		return
+	}
+
+	block, _ = pem.Decode(certBytes)
+	if block == nil {
+		err = fmt.Errorf("%w: failed to decode PEM block from certificate", commonerrors.ErrUnexpected)
+		return
+	}
+
+	return
+}
+
+// DecryptHybridAESRSAEncryptedPayload takes a path to an RSA private key and uses it to decode the AES key in a
+// hybrid encoded payload. This AES key is then used to decode the actual payload contents. Information of the use
+// of hybrid AES RSA encryption can be found here https://www.ijrar.org/papers/IJRAR23B1852.pdf
+func DecryptHybridAESRSAEncryptedPayload(privateKeyPath string, payload *HybridAESRSAEncryptedPayload) (decrypted []byte, err error) {
+	block, err := ParsePEMBlock(privateKeyPath)
+	if err != nil {
+		err = fmt.Errorf("%w: could not parse PEM block from '%v': %v", commonerrors.ErrUnexpected, privateKeyPath, err.Error())
+		return
+	}
+
+	if block == nil {
+		err = fmt.Errorf("%w: block was empty", commonerrors.ErrEmpty)
+		return
+	}
+
+	priv, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		err = fmt.Errorf("%w: could not parse private key at '%v' %v", commonerrors.ErrUnexpected, privateKeyPath, err.Error())
+		return
+	}
+
+	ciphertext, encryptedKey, nonce, err := DecodeHybridAESRSAEncryptedPayload(payload)
+	if err != nil {
+		err = fmt.Errorf("%w: could not decode payload: %v", commonerrors.ErrUnexpected, err.Error())
+		return
+	}
+
+	aesKey, err := rsa.DecryptOAEP(sha256.New(), rand.Reader, priv, encryptedKey, []byte(""))
+	if err != nil {
+		err = fmt.Errorf("%w: could not decrypt private key %v", commonerrors.ErrUnexpected, err.Error())
+		return
+	}
+
+	blockCipher, err := aes.NewCipher(aesKey)
+	if err != nil {
+		err = fmt.Errorf("%w: could not create new cipher %v", commonerrors.ErrUnexpected, err.Error())
+		return
+	}
+
+	aesGCM, err := cipher.NewGCM(blockCipher)
+	if err != nil {
+		err = fmt.Errorf("%w: could not create new GCM %v", commonerrors.ErrUnexpected, err.Error())
+		return
+	}
+
+	decrypted, err = aesGCM.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		err = fmt.Errorf("%w: could not open ciphertext %v", commonerrors.ErrUnexpected, err.Error())
+		return
+	}
+
+	return
+}
+
+// EncryptHybridAESRSAEncryptedPayload takes a path to a valid x509 certificate for key encypherment and uses it to
+// encode a payload using hybrid RSA AES encryption where an AES key is used to encrypt the content in payload and the
+// AES key is encrypted using RSA encryption. AES encryption is used to encode the payload itself as it is faster than
+// RSA for larger payloads. RSA is used to encrypt the relatively small AES key and allows asymmetric encryption
+// whilst also being fast. More information can be found at https://www.ijrar.org/papers/IJRAR23B1852.pdf
+func EncryptHybridAESRSAEncryptedPayload(certPath string, payload []byte) (encrypted *HybridAESRSAEncryptedPayload, err error) {
+	block, err := ParsePEMBlock(certPath)
+	if err != nil {
+		err = fmt.Errorf("%w: could not parse PEM block from '%v': %v", commonerrors.ErrUnexpected, certPath, err.Error())
+		return
+	}
+
+	if block == nil {
+		err = fmt.Errorf("%w: block was empty", commonerrors.ErrEmpty)
+		return
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		err = fmt.Errorf("%w: failed parsing certificate: %v", commonerrors.ErrUnexpected, err.Error())
+		return
+	}
+
+	rsaPub, ok := cert.PublicKey.(*rsa.PublicKey)
+	if !ok {
+		err = fmt.Errorf("%w: public key in certificate is not RSA", commonerrors.ErrInvalid)
+		return
+	}
+
+	aesKey := make([]byte, 32)
+	_, err = rand.Read(aesKey)
+	if err != nil {
+		err = fmt.Errorf("%w: failed generating AES key: %v", commonerrors.ErrUnexpected, err.Error())
+		return
+	}
+
+	blockCipher, err := aes.NewCipher(aesKey)
+	if err != nil {
+		err = fmt.Errorf("%w: failed to create cipher: %v", commonerrors.ErrUnexpected, err.Error())
+		return
+	}
+
+	aesGCM, err := cipher.NewGCM(blockCipher)
+	if err != nil {
+		err = fmt.Errorf("%w: failed creating GCM: %v", commonerrors.ErrUnexpected, err.Error())
+		return
+	}
+
+	nonce := make([]byte, aesGCM.NonceSize())
+	_, err = rand.Read(nonce)
+	if err != nil {
+		err = fmt.Errorf("%w: failed to generate nonce: %v", commonerrors.ErrUnexpected, err.Error())
+		return
+	}
+
+	ciphertext := aesGCM.Seal(nil, nonce, payload, nil)
+	encryptedAESKey, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, rsaPub, aesKey, []byte{})
+	if err != nil {
+		err = fmt.Errorf("%w: could not complete RSA encryption: %v", commonerrors.ErrUnexpected, err.Error())
+		return
+	}
+
+	encrypted = EncodeHybridAESRSAEncryptedPayload(ciphertext, encryptedAESKey, nonce)
+	return
+}

--- a/utils/encryption/aesrsa/encryption_test.go
+++ b/utils/encryption/aesrsa/encryption_test.go
@@ -1,0 +1,111 @@
+package aesrsa
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-faker/faker/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
+	"github.com/ARM-software/golang-utils/utils/encryption/aesrsa/testhelpers"
+	"github.com/ARM-software/golang-utils/utils/filesystem"
+)
+
+func TestEncryption(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		testCertPath, testKeyPath := testhelpers.GenerateTestCerts(t)
+		require.FileExists(t, testCertPath)
+		require.FileExists(t, testKeyPath)
+
+		content := []byte(faker.Sentence())
+
+		encrypted, err := EncryptHybridAESRSAEncryptedPayload(testCertPath, content)
+		require.NoError(t, err)
+		require.NotEmpty(t, encrypted)
+
+		decoded, err := DecryptHybridAESRSAEncryptedPayload(testKeyPath, encrypted)
+		assert.NoError(t, err)
+		assert.Equal(t, content, decoded)
+	})
+
+	t.Run("decrypt: invalid key (missing)", func(t *testing.T) {
+		testCertPath, _ := testhelpers.GenerateTestCerts(t)
+		require.FileExists(t, testCertPath)
+
+		testKeyPath := filepath.Join(strings.Split(faker.Sentence(), " ")...)
+
+		content := []byte(faker.Sentence())
+
+		encrypted, err := EncryptHybridAESRSAEncryptedPayload(testCertPath, content)
+		require.NoError(t, err)
+		require.NotEmpty(t, encrypted)
+
+		decoded, err := DecryptHybridAESRSAEncryptedPayload(testKeyPath, encrypted)
+		errortest.AssertErrorDescription(t, err, "could not find certificate")
+		assert.Empty(t, decoded)
+	})
+
+	t.Run("decrypt: invalid key (wrong key)", func(t *testing.T) {
+		testCertPath, _ := testhelpers.GenerateTestCerts(t)
+		require.FileExists(t, testCertPath)
+
+		_, testKeyPath := testhelpers.GenerateTestCerts(t)
+		require.FileExists(t, testKeyPath)
+
+		content := []byte(faker.Sentence())
+
+		encrypted, err := EncryptHybridAESRSAEncryptedPayload(testCertPath, content)
+		require.NoError(t, err)
+		require.NotEmpty(t, encrypted)
+
+		decoded, err := DecryptHybridAESRSAEncryptedPayload(testKeyPath, encrypted)
+		errortest.AssertErrorDescription(t, err, "decryption error")
+		assert.Empty(t, decoded)
+	})
+
+	t.Run("decrypt: invalid key (invalid file)", func(t *testing.T) {
+		testCertPath, _ := testhelpers.GenerateTestCerts(t)
+		require.FileExists(t, testCertPath)
+
+		testKeyPath := filepath.Join(t.TempDir(), faker.Word())
+		err := filesystem.WriteFile(testKeyPath, []byte(faker.Sentence()), 0644)
+		require.NoError(t, err)
+		require.FileExists(t, testKeyPath)
+
+		content := []byte(faker.Sentence())
+
+		encrypted, err := EncryptHybridAESRSAEncryptedPayload(testCertPath, content)
+		require.NoError(t, err)
+		require.NotEmpty(t, encrypted)
+
+		decoded, err := DecryptHybridAESRSAEncryptedPayload(testKeyPath, encrypted)
+		errortest.AssertErrorDescription(t, err, "failed to decode PEM block from certificate")
+		assert.Empty(t, decoded)
+	})
+
+	t.Run("encrypt: invalid key (missing)", func(t *testing.T) {
+		testCertPath := filepath.Join(strings.Split(faker.Sentence(), " ")...)
+		content := []byte(faker.Sentence())
+		require.NoFileExists(t, testCertPath)
+
+		encrypted, err := EncryptHybridAESRSAEncryptedPayload(testCertPath, content)
+		errortest.AssertErrorDescription(t, err, "could not find certificate")
+		assert.Nil(t, encrypted)
+	})
+
+	t.Run("encrypt: invalid key (invalid file)", func(t *testing.T) {
+		testCertPath := filepath.Join(t.TempDir(), faker.Word())
+		err := filesystem.WriteFile(testCertPath, []byte(faker.Sentence()), 0644)
+		require.NoError(t, err)
+		require.FileExists(t, testCertPath)
+
+		content := []byte(faker.Sentence())
+
+		encrypted, err := EncryptHybridAESRSAEncryptedPayload(testCertPath, content)
+		errortest.AssertErrorDescription(t, err, "failed to decode PEM block from certificate")
+		assert.Nil(t, encrypted)
+	})
+}

--- a/utils/encryption/aesrsa/encryption_test.go
+++ b/utils/encryption/aesrsa/encryption_test.go
@@ -22,11 +22,11 @@ func TestEncryption(t *testing.T) {
 
 		content := []byte(faker.Sentence())
 
-		encrypted, err := EncryptHybridAESRSAEncryptedPayload(testCertPath, content)
+		encrypted, err := EncryptHybridAESRSAEncryptedPayloadFromCertificate(testCertPath, content)
 		require.NoError(t, err)
 		require.NotEmpty(t, encrypted)
 
-		decoded, err := DecryptHybridAESRSAEncryptedPayload(testKeyPath, encrypted)
+		decoded, err := DecryptHybridAESRSAEncryptedPayloadFromPrivateKey(testKeyPath, encrypted)
 		assert.NoError(t, err)
 		assert.Equal(t, content, decoded)
 	})
@@ -39,11 +39,11 @@ func TestEncryption(t *testing.T) {
 
 		content := []byte(faker.Sentence())
 
-		encrypted, err := EncryptHybridAESRSAEncryptedPayload(testCertPath, content)
+		encrypted, err := EncryptHybridAESRSAEncryptedPayloadFromCertificate(testCertPath, content)
 		require.NoError(t, err)
 		require.NotEmpty(t, encrypted)
 
-		decoded, err := DecryptHybridAESRSAEncryptedPayload(testKeyPath, encrypted)
+		decoded, err := DecryptHybridAESRSAEncryptedPayloadFromPrivateKey(testKeyPath, encrypted)
 		errortest.AssertErrorDescription(t, err, "could not find certificate")
 		assert.Empty(t, decoded)
 	})
@@ -57,11 +57,11 @@ func TestEncryption(t *testing.T) {
 
 		content := []byte(faker.Sentence())
 
-		encrypted, err := EncryptHybridAESRSAEncryptedPayload(testCertPath, content)
+		encrypted, err := EncryptHybridAESRSAEncryptedPayloadFromCertificate(testCertPath, content)
 		require.NoError(t, err)
 		require.NotEmpty(t, encrypted)
 
-		decoded, err := DecryptHybridAESRSAEncryptedPayload(testKeyPath, encrypted)
+		decoded, err := DecryptHybridAESRSAEncryptedPayloadFromPrivateKey(testKeyPath, encrypted)
 		errortest.AssertErrorDescription(t, err, "decryption error")
 		assert.Empty(t, decoded)
 	})
@@ -77,11 +77,11 @@ func TestEncryption(t *testing.T) {
 
 		content := []byte(faker.Sentence())
 
-		encrypted, err := EncryptHybridAESRSAEncryptedPayload(testCertPath, content)
+		encrypted, err := EncryptHybridAESRSAEncryptedPayloadFromCertificate(testCertPath, content)
 		require.NoError(t, err)
 		require.NotEmpty(t, encrypted)
 
-		decoded, err := DecryptHybridAESRSAEncryptedPayload(testKeyPath, encrypted)
+		decoded, err := DecryptHybridAESRSAEncryptedPayloadFromPrivateKey(testKeyPath, encrypted)
 		errortest.AssertErrorDescription(t, err, "failed to decode PEM block from certificate")
 		assert.Empty(t, decoded)
 	})
@@ -91,7 +91,7 @@ func TestEncryption(t *testing.T) {
 		content := []byte(faker.Sentence())
 		require.NoFileExists(t, testCertPath)
 
-		encrypted, err := EncryptHybridAESRSAEncryptedPayload(testCertPath, content)
+		encrypted, err := EncryptHybridAESRSAEncryptedPayloadFromCertificate(testCertPath, content)
 		errortest.AssertErrorDescription(t, err, "could not find certificate")
 		assert.Nil(t, encrypted)
 	})
@@ -104,7 +104,7 @@ func TestEncryption(t *testing.T) {
 
 		content := []byte(faker.Sentence())
 
-		encrypted, err := EncryptHybridAESRSAEncryptedPayload(testCertPath, content)
+		encrypted, err := EncryptHybridAESRSAEncryptedPayloadFromCertificate(testCertPath, content)
 		errortest.AssertErrorDescription(t, err, "failed to decode PEM block from certificate")
 		assert.Nil(t, encrypted)
 	})

--- a/utils/encryption/aesrsa/payload.go
+++ b/utils/encryption/aesrsa/payload.go
@@ -1,0 +1,63 @@
+package aesrsa
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/config"
+)
+
+type HybridAESRSAEncryptedPayload struct {
+	// Ciphertext contains the encrypted contents
+	CipherText string `json:"cipher_text" yaml:"cipher_text" mapstructure:"cipher_text"`
+	// EncryptedKey contains the encryped AES key used to encrypt the data
+	EncryptedKey string `json:"encrypted_key" yaml:"encrypted_key" mapstructure:"encrypted_key"`
+	// Nonce used for encryption is required during decryption
+	Nonce string `json:"nonce" yaml:"nonce" mapstructure:"nonce"`
+}
+
+func (p *HybridAESRSAEncryptedPayload) Validate() (err error) {
+	err = config.ValidateEmbedded(p)
+	if err != nil {
+		return err
+	}
+
+	return validation.ValidateStruct(p,
+		validation.Field(&p.CipherText, validation.Required),
+		validation.Field(&p.EncryptedKey, validation.Required),
+		validation.Field(&p.Nonce, validation.Required),
+	)
+}
+
+func DecodeHybridAESRSAEncryptedPayload(p *HybridAESRSAEncryptedPayload) (cipher, key, nonce []byte, err error) {
+	key, err = base64.StdEncoding.DecodeString(p.EncryptedKey)
+	if err != nil {
+		err = fmt.Errorf("%w: could not decode base64 encoded encrypted key %v", commonerrors.ErrUnexpected, err.Error())
+		return
+	}
+
+	nonce, err = base64.StdEncoding.DecodeString(p.Nonce)
+	if err != nil {
+		err = fmt.Errorf("%w: could not decode base64 encoded nonce %v", commonerrors.ErrUnexpected, err.Error())
+		return
+	}
+
+	cipher, err = base64.StdEncoding.DecodeString(p.CipherText)
+	if err != nil {
+		err = fmt.Errorf("%w: could not decode base64 encoded ciphertext %v", commonerrors.ErrUnexpected, err.Error())
+		return
+	}
+
+	return
+}
+
+func EncodeHybridAESRSAEncryptedPayload(cipher, key, nonce []byte) (p *HybridAESRSAEncryptedPayload) {
+	return &HybridAESRSAEncryptedPayload{
+		EncryptedKey: base64.StdEncoding.EncodeToString(key),
+		Nonce:        base64.StdEncoding.EncodeToString(nonce),
+		CipherText:   base64.StdEncoding.EncodeToString(cipher),
+	}
+}

--- a/utils/encryption/aesrsa/testhelpers/helper.go
+++ b/utils/encryption/aesrsa/testhelpers/helper.go
@@ -1,0 +1,62 @@
+package testhelpers
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math"
+	"math/big"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-faker/faker/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ARM-software/golang-utils/utils/filesystem"
+)
+
+func GenerateTestCerts(t *testing.T) (certPath, keyPath string) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	serialNum, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+	require.NoError(t, err)
+
+	certTemplate := &x509.Certificate{
+		SerialNumber:          serialNum,
+		Subject:               pkix.Name{Organization: []string{faker.Name()}}, //nolint:misspell // library is american
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(1 * time.Minute),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	certB, err := x509.CreateCertificate(rand.Reader, certTemplate, certTemplate, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	var certBuf, keyBuf bytes.Buffer
+	err = pem.Encode(&certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: certB})
+	require.NoError(t, err)
+
+	err = pem.Encode(&keyBuf, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	require.NoError(t, err)
+
+	tmpDir := t.TempDir()
+
+	certPath = filepath.Join(tmpDir, "test_cert.pem")
+	err = filesystem.WriteFile(certPath, certBuf.Bytes(), 0644)
+	require.NoError(t, err)
+
+	keyPath = filepath.Join(tmpDir, "test_key.pem")
+	err = filesystem.WriteFile(keyPath, keyBuf.Bytes(), 0644)
+	require.NoError(t, err)
+
+	return
+}


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

This change provides a method of encrypting a payload using hybrid RSA AES encryption. The payload itself is encrypted with the AES key which is fast but symmetric meaning both parties require the key. Therefore the key is encrypted with asymmetric RSA encryption and the encrypted key is included in the payload itself. RSA is not efficient on larger payloads so this method allows for fast encryption whilst also being asymmetric.

Information on hybrid RSA/AES encryption can be found here https://www.ijrar.org/papers/IJRAR23B1852.pdf

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
