### PR TITLE
:sparkles: `[commonerrors]` Provide utilities to wrap or format errors

### DIFF
--- a/changes/20250227155909.feature
+++ b/changes/20250227155909.feature
@@ -1,0 +1,1 @@
+:sparkles: [commonerrors] Provide utilities to wrap or format errors following the convention errorType: reason

--- a/utils/charset/charset.go
+++ b/utils/charset/charset.go
@@ -6,7 +6,6 @@ package charset
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"unicode/utf8"
 
@@ -27,7 +26,7 @@ func DetectTextEncoding(content []byte) (encoding.Encoding, string, error) {
 
 	result, err := chardet.NewTextDetector().DetectBest(content)
 	if err != nil {
-		return nil, "", fmt.Errorf("%w: %v", commonerrors.ErrNotFound, err)
+		return nil, "", commonerrors.WrapError(commonerrors.ErrNotFound, err, "")
 	}
 
 	return LookupCharset(result.Charset)
@@ -49,9 +48,9 @@ func LookupCharset(charsetLabel string) (charsetEnc encoding.Encoding, charsetNa
 	charsetEnc, err = findCharsetEncoding(charsetLabel)
 	if err != nil {
 		if commonerrors.Any(err, commonerrors.ErrUnsupported) {
-			err = fmt.Errorf("%w: charset [%v] is not supported by go: %v", commonerrors.ErrUnsupported, charsetLabel, err.Error())
+			err = commonerrors.WrapErrorf(commonerrors.ErrUnsupported, err, "charset [%v] is not supported by go", charsetLabel)
 		} else {
-			err = fmt.Errorf("%w: charset [%v] is invalid: %v", commonerrors.ErrInvalid, charsetLabel, err.Error())
+			err = commonerrors.WrapErrorf(commonerrors.ErrInvalid, err, "charset [%v] is invalid", charsetLabel)
 		}
 		return
 	}
@@ -97,7 +96,7 @@ func checkEncodingSupport(charsetEnc encoding.Encoding, err error) (encoding.Enc
 	newErr := err
 	if err == nil {
 		if charsetEnc == nil {
-			newErr = fmt.Errorf("%w charset encoding", commonerrors.ErrUnsupported)
+			newErr = commonerrors.New(commonerrors.ErrUnsupported, "unsupported charset encoding")
 		}
 	}
 	return charsetEnc, newErr

--- a/utils/charset/mapping.go
+++ b/utils/charset/mapping.go
@@ -5,7 +5,6 @@
 package charset
 
 import (
-	"fmt"
 	"strings"
 	"sync"
 
@@ -28,7 +27,7 @@ type charsetEncodingMapping struct {
 func (m *charsetEncodingMapping) GetCanonicalName(alias string) (name string, err error) {
 	name, found := m.mapping[strings.ToLower(strings.TrimSpace(alias))]
 	if !found {
-		err = fmt.Errorf("%w: charset alias [%v] was not found in the list of supported Charsets", commonerrors.ErrNotFound, alias)
+		err = commonerrors.Newf(commonerrors.ErrNotFound, "charset alias [%v] was not found in the list of supported Charsets", alias)
 	}
 	return
 }

--- a/utils/charset/unsupportedcharset_index.go
+++ b/utils/charset/unsupportedcharset_index.go
@@ -5,7 +5,6 @@
 package charset
 
 import (
-	"fmt"
 	"strings"
 
 	"golang.org/x/text/encoding"
@@ -24,5 +23,5 @@ func GetUnsupported(name string) (encoding.Encoding, error) {
 			return nil, nil
 		}
 	}
-	return nil, fmt.Errorf("%w encoding name", commonerrors.ErrInvalid)
+	return nil, commonerrors.New(commonerrors.ErrInvalid, "invalid encoding name")
 }

--- a/utils/collection/conditions.go
+++ b/utils/collection/conditions.go
@@ -1,8 +1,6 @@
 package collection
 
 import (
-	"fmt"
-
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 )
 
@@ -32,7 +30,7 @@ func (c *Conditions) Add(conditions ...bool) Conditions {
 // ForEach will execute function each() on every condition unless an error is returned and will end add this point.
 func (c *Conditions) ForEach(each func(bool) error) error {
 	if c == nil || len(*c) == 0 {
-		return fmt.Errorf("%w: the collection of conditions is empty", commonerrors.ErrUndefined)
+		return commonerrors.New(commonerrors.ErrUndefined, "the collection of conditions is empty")
 	}
 	for i := range *c {
 		subErr := each((*c)[i])

--- a/utils/collection/pagination/pagination.go
+++ b/utils/collection/pagination/pagination.go
@@ -7,8 +7,6 @@ package pagination
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/parallelisation"
 )
@@ -77,7 +75,7 @@ func (a *AbstractPaginator) GetNext() (item interface{}, err error) {
 		return
 	}
 	if !a.HasNext() {
-		err = fmt.Errorf("%w: there is not any next item", commonerrors.ErrNotFound)
+		err = commonerrors.New(commonerrors.ErrNotFound, "there is not any next item")
 		return
 	}
 	currentIt, err := a.FetchCurrentPageIterator()
@@ -103,7 +101,7 @@ func (a *AbstractPaginator) setCurrentPage(page IStaticPage) (err error) {
 
 func (a *AbstractPaginator) SetCurrentPage(page IStaticPage) (err error) {
 	if page == nil {
-		err = fmt.Errorf("%w: missing page", commonerrors.ErrUndefined)
+		err = commonerrors.New(commonerrors.ErrUndefined, "missing page")
 		return
 	}
 	err = a.setCurrentPage(page)
@@ -113,7 +111,7 @@ func (a *AbstractPaginator) SetCurrentPage(page IStaticPage) (err error) {
 func (a *AbstractPaginator) FetchCurrentPage() (page IStaticPage, err error) {
 	page = a.currentPage
 	if page == nil {
-		err = fmt.Errorf("%w: missing page", commonerrors.ErrUndefined)
+		err = commonerrors.New(commonerrors.ErrUndefined, "missing page")
 	}
 	return
 }
@@ -121,7 +119,7 @@ func (a *AbstractPaginator) FetchCurrentPage() (page IStaticPage, err error) {
 func (a *AbstractPaginator) FetchCurrentPageIterator() (it IIterator, err error) {
 	it = a.currentPageIterator
 	if it == nil {
-		err = fmt.Errorf("%w: missing page iterator", commonerrors.ErrUndefined)
+		err = commonerrors.New(commonerrors.ErrUndefined, "missing page iterator")
 	}
 	return
 }
@@ -164,7 +162,7 @@ func toDynamicPage(page IStaticPage) (dynamicPage IPage, err error) {
 	}
 	dynamicPage, ok := page.(IPage)
 	if !ok {
-		err = fmt.Errorf("%w: current page is not dynamic i.e. it is not possible to fetch next pages from it", commonerrors.ErrInvalid)
+		err = commonerrors.New(commonerrors.ErrInvalid, "current page is not dynamic i.e. it is not possible to fetch next pages from it")
 	}
 	return
 }

--- a/utils/collection/pagination/pagination.go
+++ b/utils/collection/pagination/pagination.go
@@ -7,6 +7,7 @@ package pagination
 
 import (
 	"context"
+
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/parallelisation"
 )

--- a/utils/collection/pagination/stream.go
+++ b/utils/collection/pagination/stream.go
@@ -7,7 +7,6 @@ package pagination
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"go.uber.org/atomic"
@@ -78,7 +77,7 @@ func (s *AbstractStreamPaginator) GetNext() (interface{}, error) {
 		}
 
 		if !s.HasNext() {
-			err = fmt.Errorf("%w: there is not any next item", commonerrors.ErrNotFound)
+			err = commonerrors.New(commonerrors.ErrNotFound, "there is not any next item")
 			return nil, err
 		}
 		parallelisation.SleepWithContext(s.GetContext(), s.backoff)
@@ -127,7 +126,7 @@ func toDynamicStream(stream IStaticPageStream) (dynamicStream IStream, err error
 	}
 	dynamicStream, ok := stream.(IStream)
 	if !ok {
-		err = fmt.Errorf("%w: current stream is not dynamic i.e. it is not possible to fetch next pages from it", commonerrors.ErrInvalid)
+		err = commonerrors.New(commonerrors.ErrInvalid, "current stream is not dynamic i.e. it is not possible to fetch next pages from it")
 	}
 	return
 }

--- a/utils/collection/parseLists.go
+++ b/utils/collection/parseLists.go
@@ -5,7 +5,6 @@
 package collection
 
 import (
-	"fmt"
 	"strings"
 	"unicode"
 
@@ -62,7 +61,7 @@ func ParseCommaSeparatedListToMap(input string) (pairs map[string]string, err er
 	numElements := len(inputSplit)
 
 	if numElements%2 != 0 {
-		err = fmt.Errorf("%w: could not parse comma separated list '%v' into map as it did not have an even number of elements", commonerrors.ErrInvalid, input)
+		err = commonerrors.Newf(commonerrors.ErrInvalid, "could not parse comma separated list '%v' into map as it did not have an even number of elements", input)
 		return
 	}
 

--- a/utils/commonerrors/errors.go
+++ b/utils/commonerrors/errors.go
@@ -266,3 +266,53 @@ func IsEmpty(err error) bool {
 	}
 	return false
 }
+
+// Errorf is similar to fmt.Errorf although it will try to follow the error convention we use i.e. `errortype: message` but differs in that the wrapped error will be the targetErr
+func Errorf(targetErr error, format string, args ...any) error {
+	tErr := ConvertContextError(targetErr)
+	if tErr == nil {
+		tErr = ErrUnknown
+	}
+	msg := format
+	if len(args) > 0 {
+		msg = fmt.Sprintf(format, args...)
+	}
+	return fmt.Errorf("%w%v %v", tErr, string(TypeReasonErrorSeparator), msg)
+}
+
+// WrapError wraps an error into a particular targetError. However, if the original error has to do with a contextual error (i.e. ErrCancelled or ErrTimeout), it will be passed through without having is type changed.
+// This method should be used to safely wrap errors without losing information about context control information.
+// If the target error is not set, the wrapped error will be of type ErrUnknown.
+func WrapError(targetError, originalError error, msg string) error {
+	tErr := targetError
+	if tErr == nil {
+		tErr = ErrUnknown
+	}
+	origErr := ConvertContextError(originalError)
+	if Any(origErr, ErrTimeout, ErrCancelled) {
+		tErr = origErr
+	}
+	if originalError == nil {
+		return New(tErr, msg)
+	} else {
+		return Errorf(tErr, "%v%v %v", msg, string(TypeReasonErrorSeparator), originalError.Error())
+	}
+}
+
+// WrapErrorf is similar to WrapError but uses a format for the message
+func WrapErrorf(targetError, originalError error, msgFormat string, args ...any) error {
+	if len(args) == 0 {
+		return WrapError(targetError, originalError, msgFormat)
+	}
+	return WrapError(targetError, originalError, fmt.Sprintf(msgFormat, args...))
+}
+
+// New is similar to errors.New or fmt.Errorf but creates an error of type targetError
+func New(targetError error, msg string) error {
+	return Errorf(targetError, msg)
+}
+
+// Newf is similar to New but allows to format the message
+func Newf(targetError error, msgFormat string, args ...any) error {
+	return WrapErrorf(targetError, nil, msgFormat, args...)
+}

--- a/utils/commonerrors/errors_test.go
+++ b/utils/commonerrors/errors_test.go
@@ -202,3 +202,17 @@ func TestErrorRelatesTo(t *testing.T) {
 	assert.False(t, RelatesTo(fmt.Sprintf("%v: %v", ErrUnauthorised.Error(), faker.Sentence()), ErrInvalid))
 	assert.False(t, RelatesTo(fmt.Sprintf("%v: %v", ErrUnauthorised.Error(), faker.Sentence()), ErrInvalid, ErrCondition))
 }
+
+func TestWrapError(t *testing.T) {
+	assert.True(t, Any(WrapError(ErrUndefined, nil, faker.Sentence()), ErrUndefined))
+	assert.True(t, Any(WrapError(ErrUndefined, ErrNotFound, faker.Sentence()), ErrUndefined))
+	assert.True(t, Any(WrapError(nil, ErrNotFound, faker.Sentence()), ErrUnknown))
+	assert.True(t, Any(WrapError(ErrUndefined, context.DeadlineExceeded, faker.Sentence()), ErrTimeout))
+	assert.True(t, Any(WrapError(ErrUndefined, context.Canceled, faker.Sentence()), ErrCancelled))
+	assert.True(t, Any(WrapError(ErrUndefined, ErrTimeout, faker.Sentence()), ErrTimeout))
+	assert.True(t, Any(WrapError(ErrUndefined, ErrCancelled, faker.Sentence()), ErrCancelled))
+	assert.True(t, Any(WrapErrorf(context.DeadlineExceeded, nil, faker.Sentence()), ErrTimeout))
+	assert.True(t, Any(WrapError(context.Canceled, ErrConflict, faker.Sentence()), ErrCancelled))
+	assert.True(t, Any(WrapErrorf(context.DeadlineExceeded, nil, "%v this is a test %v", faker.Name(), faker.Word()), ErrTimeout))
+	assert.True(t, Any(Newf(context.DeadlineExceeded, "%v this is a test %v", faker.Name(), faker.Word()), ErrTimeout))
+}

--- a/utils/commonerrors/serialisation.go
+++ b/utils/commonerrors/serialisation.go
@@ -62,7 +62,7 @@ func (e *marshallingError) ConvertToError() error {
 	if e.Reason == "" {
 		return e.ErrorType
 	}
-	return fmt.Errorf("%w%v %v", e.ErrorType, string(TypeReasonErrorSeparator), e.Reason)
+	return New(e.ErrorType, e.Reason)
 }
 
 func (e *marshallingError) SetWrappedError(err error) {
@@ -77,7 +77,7 @@ func (m *multiplemarshallingError) MarshalText() (text []byte, err error) {
 	for i := range m.subErrs {
 		subtext, suberr := m.subErrs[i].MarshalText()
 		if suberr != nil {
-			err = fmt.Errorf("%w%v an error item could not be marshalled%v %v", ErrMarshalling, string(TypeReasonErrorSeparator), string(TypeReasonErrorSeparator), suberr.Error())
+			err = WrapError(ErrMarshalling, suberr, "an error item could not be marshalled")
 			return
 		}
 		text = append(text, subtext...)
@@ -162,7 +162,7 @@ func processError(err error) (mErr iMarshallingError) {
 	mErr = processErrorStr(err.Error())
 	if IsEmpty(mErr) {
 		mErr = &marshallingError{
-			ErrorType: fmt.Errorf("%w%v error `%T` with no description returned", ErrUnknown, string(TypeReasonErrorSeparator), err),
+			ErrorType: Newf(ErrUnknown, "error `%T` with no description returned", err),
 		}
 		return
 	}

--- a/utils/idgen/uuid.go
+++ b/utils/idgen/uuid.go
@@ -5,8 +5,6 @@
 package idgen
 
 import (
-	"fmt"
-
 	"github.com/gofrs/uuid/v5"
 
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
@@ -16,7 +14,7 @@ import (
 func GenerateUUID4() (string, error) {
 	uuid, err := uuid.NewV4()
 	if err != nil {
-		return "", fmt.Errorf("%w: failed generating uuid: %v", commonerrors.ErrUnexpected, err.Error())
+		return "", commonerrors.WrapError(commonerrors.ErrUnexpected, err, "failed generating uuid")
 	}
 	return uuid.String(), nil
 }

--- a/utils/proc/process.go
+++ b/utils/proc/process.go
@@ -7,8 +7,6 @@ package proc
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/shirou/gopsutil/v4/process"
 
 	"github.com/ARM-software/golang-utils/utils/collection"
@@ -50,7 +48,7 @@ func FindProcess(ctx context.Context, pid int) (p IProcess, err error) {
 	if commonerrors.Any(err, nil, commonerrors.ErrTimeout, commonerrors.ErrCancelled) {
 		return
 	}
-	err = fmt.Errorf("%w: process (#%v) could not be found: %v", commonerrors.ErrNotFound, pid, err.Error())
+	err = commonerrors.WrapErrorf(commonerrors.ErrNotFound, err, "process (#%v) could not be found", pid)
 	return
 }
 

--- a/utils/proc/process.go
+++ b/utils/proc/process.go
@@ -7,6 +7,7 @@ package proc
 
 import (
 	"context"
+
 	"github.com/shirou/gopsutil/v4/process"
 
 	"github.com/ARM-software/golang-utils/utils/collection"

--- a/utils/retry/retry.go
+++ b/utils/retry/retry.go
@@ -15,7 +15,7 @@ import (
 // RetryIf will retry fn when the value returned from retryConditionFn is true
 func RetryIf(ctx context.Context, logger logr.Logger, retryPolicy *RetryPolicyConfiguration, fn func() error, msgOnRetry string, retryConditionFn func(err error) bool) error {
 	if retryPolicy == nil {
-		return fmt.Errorf("%w: missing retry policy configuration", commonerrors.ErrUndefined)
+		return commonerrors.New(commonerrors.ErrUndefined, "missing retry policy configuration")
 	}
 	if !retryPolicy.Enabled {
 		return fn()

--- a/utils/safeio/error.go
+++ b/utils/safeio/error.go
@@ -1,7 +1,6 @@
 package safeio
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
@@ -16,7 +15,7 @@ func ConvertIOError(err error) (newErr error) {
 	switch {
 	case commonerrors.Any(newErr, commonerrors.ErrEOF):
 	case commonerrors.Any(newErr, io.EOF, io.ErrUnexpectedEOF):
-		newErr = fmt.Errorf("%w: %v", commonerrors.ErrEOF, newErr.Error())
+		newErr = commonerrors.WrapError(commonerrors.ErrEOF, newErr, "")
 	}
 	return
 }

--- a/utils/safeio/read.go
+++ b/utils/safeio/read.go
@@ -3,7 +3,6 @@ package safeio
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 
 	"github.com/dolmen-go/contextio"
@@ -42,7 +41,7 @@ func ReadAtMost(ctx context.Context, src io.Reader, max int64, bufferCapacity in
 			return
 		}
 		if panicErr, ok := e.(error); ok && (panicErr == bytes.ErrTooLarge || commonerrors.Any(panicErr, commonerrors.ErrTooLarge, bytes.ErrTooLarge)) {
-			err = fmt.Errorf("%w: %v", commonerrors.ErrTooLarge, panicErr.Error())
+			err = commonerrors.WrapError(commonerrors.ErrTooLarge, panicErr, "")
 		} else {
 			panic(e)
 		}
@@ -60,7 +59,7 @@ func ReadAtMost(ctx context.Context, src io.Reader, max int64, bufferCapacity in
 		return
 	}
 	if read == int64(0) {
-		err = fmt.Errorf("%w: no bytes were read", commonerrors.ErrEmpty)
+		err = commonerrors.New(commonerrors.ErrEmpty, "no bytes were read")
 	}
 	content = buf.Bytes()
 	return

--- a/utils/semver/semver.go
+++ b/utils/semver/semver.go
@@ -15,7 +15,7 @@ import (
 func CanonicalWithGoPrefix(v string) (canonical string, err error) {
 	v = strings.TrimSpace(v)
 	if v == "" {
-		err = fmt.Errorf("%w: no version was supplied", commonerrors.ErrUndefined)
+		err = commonerrors.New(commonerrors.ErrUndefined, "no version was supplied")
 		return
 	}
 
@@ -25,7 +25,7 @@ func CanonicalWithGoPrefix(v string) (canonical string, err error) {
 
 	canonical = semver.Canonical(v)
 	if canonical == "" {
-		err = fmt.Errorf("%w: could not parse '%v' as a semantic version", commonerrors.ErrInvalid, v)
+		err = commonerrors.Newf(commonerrors.ErrInvalid, "could not parse '%v' as a semantic version", v)
 	}
 
 	return

--- a/utils/signing/signing.go
+++ b/utils/signing/signing.go
@@ -38,17 +38,17 @@ func (k *Ed25519Signer) GetPrivateKey() string {
 
 func (k *Ed25519Signer) Sign(message []byte) (signature []byte, err error) {
 	if len(k.private) == 0 {
-		err = fmt.Errorf("%w: missing private key", commonerrors.ErrUndefined)
+		err = commonerrors.New(commonerrors.ErrUndefined, "missing private key")
 		return
 	}
 	if len(k.private) != ed25519.PrivateKeySize {
-		err = fmt.Errorf("%w: invalid private key length %v", commonerrors.ErrInvalid, len(k.private))
+		err = commonerrors.Newf(commonerrors.ErrInvalid, "invalid private key length %v", len(k.private))
 		return
 	}
 
 	signature, err = k.private.Sign(nil, message, &ed25519.Options{})
 	if err != nil {
-		err = fmt.Errorf("%w: error occurred whilst signing: %v", commonerrors.ErrUnexpected, err.Error())
+		err = commonerrors.WrapError(commonerrors.ErrUnexpected, err, "error occurred whilst signing")
 		return
 	}
 
@@ -66,11 +66,11 @@ func (k *Ed25519Signer) GenerateSignature(message []byte) (signatureBase64 strin
 
 func (k *Ed25519Signer) Verify(message, signature []byte) (ok bool, err error) {
 	if len(k.Public) == 0 {
-		err = fmt.Errorf("%w: missing public key", commonerrors.ErrUndefined)
+		err = commonerrors.New(commonerrors.ErrUndefined, "missing public key")
 		return
 	}
 	if len(k.Public) != ed25519.PublicKeySize {
-		err = fmt.Errorf("%w: invalid public key length %v", commonerrors.ErrInvalid, len(k.Public))
+		err = commonerrors.Newf(commonerrors.ErrInvalid, "invalid public key length %v", len(k.Public))
 		return
 	}
 
@@ -91,17 +91,17 @@ func (k *Ed25519Signer) VerifySignature(message []byte, signatureBase64 string) 
 // NewEd25519Signer will create a Ed25519Signer that can both sign new messages as well as verify them
 func NewEd25519Signer(privateKey ed25519.PrivateKey) (signer *Ed25519Signer, err error) {
 	if privateKey == nil {
-		err = fmt.Errorf("%w: privateKey must be defined", commonerrors.ErrUndefined)
+		err = commonerrors.New(commonerrors.ErrUndefined, "privateKey must be defined")
 		return
 	}
 	if len(privateKey) != ed25519.PrivateKeySize {
-		err = fmt.Errorf("%w: private key must have length %v, it has length %v", commonerrors.ErrInvalid, ed25519.PrivateKeySize, len(privateKey))
+		err = commonerrors.Newf(commonerrors.ErrInvalid, "private key must have length %v, it has length %v", ed25519.PrivateKeySize, len(privateKey))
 		return
 	}
 
 	publicKey, ok := privateKey.Public().(ed25519.PublicKey)
 	if !ok {
-		err = fmt.Errorf("%w: could not extract public key from private key", commonerrors.ErrUnexpected)
+		err = commonerrors.New(commonerrors.ErrUnexpected, "could not extract public key from private key")
 		return
 	}
 
@@ -117,11 +117,11 @@ func NewEd25519Signer(privateKey ed25519.PrivateKey) (signer *Ed25519Signer, err
 // NewEd25519Verifier will create a Ed25519Signer with only a public key meaning it can only verify messages
 func NewEd25519Verifier(publicKey ed25519.PublicKey) (signer *Ed25519Signer, err error) {
 	if publicKey == nil {
-		err = fmt.Errorf("%w: publicKey must be defined", commonerrors.ErrUndefined)
+		err = commonerrors.New(commonerrors.ErrUndefined, "publicKey must be defined")
 		return
 	}
 	if len(publicKey) != ed25519.PublicKeySize {
-		err = fmt.Errorf("%w: public key must have length %v, it has length %v", commonerrors.ErrInvalid, ed25519.PrivateKeySize, len(publicKey))
+		err = commonerrors.Newf(commonerrors.ErrInvalid, "public key must have length %v, it has length %v", ed25519.PrivateKeySize, len(publicKey))
 		return
 	}
 
@@ -137,7 +137,7 @@ func NewEd25519Verifier(publicKey ed25519.PublicKey) (signer *Ed25519Signer, err
 func NewEd25519SignerFromBase64(privateKeyB64 string) (signer *Ed25519Signer, err error) {
 	privateKey, err := base64.StdEncoding.DecodeString(privateKeyB64)
 	if err != nil {
-		err = fmt.Errorf("%w: could not decode private key from base64: %v", commonerrors.ErrInvalid, err.Error())
+		err = commonerrors.WrapError(commonerrors.ErrInvalid, err, "could not decode private key from base64")
 		return
 	}
 
@@ -149,7 +149,7 @@ func NewEd25519SignerFromBase64(privateKeyB64 string) (signer *Ed25519Signer, er
 func NewEd25519VerifierFromBase64(publicKeyB64 string) (signer *Ed25519Signer, err error) {
 	publicKey, err := base64.StdEncoding.DecodeString(publicKeyB64)
 	if err != nil {
-		err = fmt.Errorf("%w: could not decode public key from base64: %v", commonerrors.ErrInvalid, err.Error())
+		err = commonerrors.WrapError(commonerrors.ErrInvalid, err, "could not decode public key from base64")
 		return
 	}
 


### PR DESCRIPTION

<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

Utilities to help wrapping errors and follow  convention `errorType: reason`

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
