### PR TITLE
:boom: Upgrade `go` version to `1.23`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 # Set environment variables available in all jobs and steps
 env:
-  go_version: "1.22"
+  go_version: "1.23"
   go_cache_macOS_path: |
     ~/Library/Caches/go-build
   go_cache_windows_path: |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 -->
 # Golang utilities
 
-[![Go Badge](https://img.shields.io/badge/go-v1.22-blue)](https://golang.org/)
+[![Go Badge](https://img.shields.io/badge/go-v1.23-blue)](https://golang.org/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/ARM-software/golang-utils/actions/workflows/ci.yml/badge.svg)](https://github.com/ARM-software/golang-utils/actions/workflows/ci.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/ARM-software/golang-utils/utils.svg)](https://pkg.go.dev/github.com/ARM-software/golang-utils/utils)

--- a/changes/20250312094629.feature
+++ b/changes/20250312094629.feature
@@ -1,0 +1,1 @@
+:boom: Upgrade `go` version to `1.23`

--- a/utils/go.mod
+++ b/utils/go.mod
@@ -1,6 +1,6 @@
 module github.com/ARM-software/golang-utils/utils
 
-go 1.22.0
+go 1.23.0
 
 toolchain go1.24.0
 


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

- ⬆️ Upgrade the go version so dependencies can be updated



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
