### PR TITLE
:sparkles: `[useragent]` Added a `useragent` module to help generate `User-Agent` header

### DIFF
--- a/changes/20250328120125.bugfix
+++ b/changes/20250328120125.bugfix
@@ -1,0 +1,1 @@
+:recycle: [reflection] Modified IsEmpty behaviour with regards to strings to consider strings with only whitespaces as empty

--- a/changes/20250328120920.feature
+++ b/changes/20250328120920.feature
@@ -1,0 +1,1 @@
+:sparkles: `[useragent]` Added a `useragent` module to help generate `User-Agent`

--- a/utils/http/useragent/useragent.go
+++ b/utils/http/useragent/useragent.go
@@ -1,0 +1,44 @@
+package useragent
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/reflection"
+)
+
+// AddValuesToUserAgent extends a user agent string with new elements. See https://en.wikipedia.org/wiki/User-Agent_header#Format_for_human-operated_web_browsers
+func AddValuesToUserAgent(userAgent string, elements ...string) (newUserAgent string) {
+	if len(elements) == 0 {
+		newUserAgent = userAgent
+		return
+	}
+	newUserAgent = strings.Join(elements, " ")
+	newUserAgent = strings.TrimSpace(newUserAgent)
+	if newUserAgent == "" {
+		newUserAgent = userAgent
+		return
+	}
+	if !reflection.IsEmpty(userAgent) {
+		newUserAgent = fmt.Sprintf("%v %v", userAgent, newUserAgent)
+	}
+	return
+}
+
+// GenerateUserAgentValue generates a user agent value. See https://en.wikipedia.org/wiki/User-Agent_header#Format_for_human-operated_web_browsers
+func GenerateUserAgentValue(product string, productVersion string, comment string) (userAgent string, err error) {
+	if reflection.IsEmpty(product) {
+		err = commonerrors.UndefinedVariable("product")
+		return
+	}
+	if reflection.IsEmpty(productVersion) {
+		err = commonerrors.UndefinedVariable("product version")
+		return
+	}
+	userAgent = fmt.Sprintf("%v/%v", product, productVersion)
+	if !reflection.IsEmpty(comment) {
+		userAgent = fmt.Sprintf("%v (%v)", userAgent, comment)
+	}
+	return
+}

--- a/utils/http/useragent/useragent_test.go
+++ b/utils/http/useragent/useragent_test.go
@@ -1,0 +1,37 @@
+package useragent
+
+import (
+	"testing"
+
+	"github.com/go-faker/faker/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
+)
+
+func TestAddValuesToUserAgent(t *testing.T) {
+	userAgent, err := GenerateUserAgentValue(faker.Name(), faker.Word(), faker.Sentence())
+	require.NoError(t, err)
+	newAgent := AddValuesToUserAgent(userAgent, faker.Word())
+	assert.Contains(t, newAgent, userAgent)
+	elem := faker.Word()
+	newAgent = AddValuesToUserAgent("   ", elem)
+	assert.Equal(t, elem, newAgent)
+}
+
+func TestGenerateUserAgentValue(t *testing.T) {
+	userAgent, err := GenerateUserAgentValue("", "", "")
+	errortest.AssertError(t, err, commonerrors.ErrUndefined, commonerrors.ErrInvalid)
+	assert.Empty(t, userAgent)
+	userAgent, err = GenerateUserAgentValue("      ", "          ", faker.Sentence())
+	errortest.AssertError(t, err, commonerrors.ErrUndefined, commonerrors.ErrInvalid)
+	assert.Empty(t, userAgent)
+	userAgent, err = GenerateUserAgentValue(faker.Name(), "", faker.Sentence())
+	errortest.AssertError(t, err, commonerrors.ErrUndefined, commonerrors.ErrInvalid)
+	assert.Empty(t, userAgent)
+	userAgent, err = GenerateUserAgentValue(faker.Name(), faker.Word(), faker.Sentence())
+	assert.NoError(t, err)
+	assert.NotEmpty(t, userAgent)
+}

--- a/utils/reflection/reflection.go
+++ b/utils/reflection/reflection.go
@@ -7,6 +7,7 @@ package reflection
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"unsafe"
 
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
@@ -195,9 +196,20 @@ func InheritsFrom(object interface{}, parentType reflect.Type) bool {
 }
 
 // IsEmpty checks whether a value is empty i.e. "", nil, 0, [], {}, false, etc.
-func IsEmpty(value interface{}) bool {
+// For Strings, a string is considered empty if it is "" or if it only contains whitespaces
+func IsEmpty(value any) bool {
 	if value == nil {
 		return true
+	}
+	if valueStr, ok := value.(string); ok {
+		return len(strings.TrimSpace(valueStr)) == 0
+	}
+	if valueStrPtr, ok := value.(*string); ok {
+		return len(strings.TrimSpace(*valueStrPtr)) == 0
+	}
+	if valueBool, ok := value.(bool); ok {
+		// if set to true, then value is not empty
+		return !valueBool
 	}
 	objValue := reflect.ValueOf(value)
 	switch objValue.Kind() {

--- a/utils/reflection/reflection_test.go
+++ b/utils/reflection/reflection_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/field"
 )
 
 type structtest struct {
@@ -398,8 +399,9 @@ func TestIsEmpty(t *testing.T) {
 	aFilledChannel := make(chan struct{}, 1)
 	aFilledChannel <- struct{}{}
 	tests := []struct {
-		value   interface{}
-		isEmpty bool
+		value                  interface{}
+		isEmpty                bool
+		differsFromAssertEmpty bool
 	}{
 		{
 			value:   nil,
@@ -420,6 +422,16 @@ func TestIsEmpty(t *testing.T) {
 		{
 			value:   "",
 			isEmpty: true,
+		},
+		{
+			value:                  "                                   ",
+			isEmpty:                true,
+			differsFromAssertEmpty: true,
+		},
+		{
+			value:                  field.ToOptionalString("                                   "),
+			isEmpty:                true,
+			differsFromAssertEmpty: true,
 		},
 		{
 			value:   false,
@@ -485,9 +497,9 @@ func TestIsEmpty(t *testing.T) {
 
 	for i := range tests {
 		test := tests[i]
-		t.Run(fmt.Sprintf("subtest #%v", i), func(t *testing.T) {
+		t.Run(fmt.Sprintf("subtest #%v (%v)", i, test.value), func(t *testing.T) {
 			assert.Equal(t, test.isEmpty, IsEmpty(test.value))
-			if test.isEmpty {
+			if test.isEmpty && !test.differsFromAssertEmpty {
 				assert.Empty(t, test.value)
 			} else {
 				assert.NotEmpty(t, test.value)


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

- Moved utilities to generate user agent header
- Modified the `IsEmpty` behaviour to be more performant with regards to strings


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
