### PR TITLE
:sparkles: `encryption` Add utility to encrypt payloads using public RSA key directly instead of using the certificate

### DIFF
--- a/changes/20250328135041.feature
+++ b/changes/20250328135041.feature
@@ -1,1 +1,1 @@
-:sparkles: `encruption` Add utility to encrypt payloads using public RSA key directly instead of using the certificate
+:sparkles: `encryption` Add utility to encrypt payloads using public RSA key directly instead of using the certificate

--- a/changes/20250328135041.feature
+++ b/changes/20250328135041.feature
@@ -1,0 +1,1 @@
+:sparkles: `encruption` Add utility to encrypt payloads using public RSA key directly instead of using the certificate

--- a/utils/encryption/aesrsa/encryption.go
+++ b/utils/encryption/aesrsa/encryption.go
@@ -150,7 +150,7 @@ func encryptWithRSAKey(rsaPub *rsa.PublicKey, payload []byte) (encrypted *Hybrid
 	return
 }
 
-// EncryptHybridAESRSAEncryptedPayloadFromPublickKeyBytes takes a bublic key for key encypherment and uses it to
+// EncryptHybridAESRSAEncryptedPayloadFromPublickKeyBytes takes a public key for key encypherment and uses it to
 // encode a payload using hybrid RSA AES encryption where an AES key is used to encrypt the content in payload and the
 // AES key is encrypted using RSA encryption. AES encryption is used to encode the payload itself as it is faster than
 // RSA for larger payloads. RSA is used to encrypt the relatively small AES key and allows asymmetric encryption

--- a/utils/encryption/aesrsa/encryption.go
+++ b/utils/encryption/aesrsa/encryption.go
@@ -8,7 +8,6 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/pem"
-	"fmt"
 
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/filesystem"
@@ -17,24 +16,24 @@ import (
 // ParsePEMBlock will parse the first PEM block found within path
 func ParsePEMBlock(path string) (block *pem.Block, err error) {
 	if path == "" {
-		err = fmt.Errorf("%w: no certificate provided", commonerrors.ErrUndefined)
+		err = commonerrors.New(commonerrors.ErrUndefined, "no certificate provided")
 		return
 	}
 
 	if !filesystem.Exists(path) {
-		err = fmt.Errorf("%w: could not find certificate at '%v'", commonerrors.ErrNotFound, path)
+		err = commonerrors.Newf(commonerrors.ErrNotFound, "could not find certificate at '%v'", path)
 		return
 	}
 
 	certBytes, err := filesystem.ReadFile(path)
 	if err != nil {
-		err = fmt.Errorf("%w: failed to read certificate: %v", commonerrors.ErrUnexpected, err.Error())
+		err = commonerrors.WrapError(commonerrors.ErrUnexpected, err, "failed to read certificate")
 		return
 	}
 
 	block, _ = pem.Decode(certBytes)
 	if block == nil {
-		err = fmt.Errorf("%w: failed to decode PEM block from certificate", commonerrors.ErrUnexpected)
+		err = commonerrors.New(commonerrors.ErrUnexpected, "failed to decode PEM block from certificate")
 		return
 	}
 
@@ -47,60 +46,60 @@ func ParsePEMBlock(path string) (block *pem.Block, err error) {
 func DecryptHybridAESRSAEncryptedPayloadFromPrivateKey(privateKeyPath string, payload *HybridAESRSAEncryptedPayload) (decrypted []byte, err error) {
 	block, err := ParsePEMBlock(privateKeyPath)
 	if err != nil {
-		err = fmt.Errorf("%w: could not parse PEM block from '%v': %v", commonerrors.ErrUnexpected, privateKeyPath, err.Error())
+		err = commonerrors.WrapErrorf(commonerrors.ErrUnexpected, err, "could not parse PEM block from '%v'", privateKeyPath)
 		return
 	}
 
 	if block == nil {
-		err = fmt.Errorf("%w: block was empty", commonerrors.ErrEmpty)
+		err = commonerrors.New(commonerrors.ErrEmpty, "block was empty")
 		return
 	}
 
 	return DecryptHybridAESRSAEncryptedPayloadFromBytes(block.Bytes, payload)
 }
 
-// DecryptHybridAESRSAEncryptedPayloadFromPrivateKeyPath takes a path to an RSA private key PEM file and uses it to
+// DecryptHybridAESRSAEncryptedPayloadFromBytes takes a path to an RSA private key PEM file and uses it to
 // decode the AES key in a hybrid encoded payload. This AES key is then used to decode the actual payload contents.
 // Information of the use of hybrid AES RSA encryption can be found here https://www.ijrar.org/papers/IJRAR23B1852.pdf
 func DecryptHybridAESRSAEncryptedPayloadFromBytes(block []byte, payload *HybridAESRSAEncryptedPayload) (decrypted []byte, err error) {
 	if payload == nil {
-		err = fmt.Errorf("%w: payload must not be nil", commonerrors.ErrUndefined)
+		err = commonerrors.New(commonerrors.ErrUndefined, "payload must not be nil")
 		return
 	}
 
 	priv, err := x509.ParsePKCS1PrivateKey(block)
 	if err != nil {
-		err = fmt.Errorf("%w: could not parse private key %v", commonerrors.ErrUnexpected, err.Error())
+		err = commonerrors.WrapError(commonerrors.ErrUnexpected, err, "could not parse private key")
 		return
 	}
 
 	ciphertext, encryptedKey, nonce, err := DecodeHybridAESRSAEncryptedPayload(payload)
 	if err != nil {
-		err = fmt.Errorf("%w: could not decode payload: %v", commonerrors.ErrUnexpected, err.Error())
+		err = commonerrors.WrapError(commonerrors.ErrUnexpected, err, "could not decode payload")
 		return
 	}
 
 	aesKey, err := rsa.DecryptOAEP(sha256.New(), rand.Reader, priv, encryptedKey, []byte{})
 	if err != nil {
-		err = fmt.Errorf("%w: could not decrypt private key %v", commonerrors.ErrUnexpected, err.Error())
+		err = commonerrors.WrapError(commonerrors.ErrUnexpected, err, "could not decrypt private key")
 		return
 	}
 
 	blockCipher, err := aes.NewCipher(aesKey)
 	if err != nil {
-		err = fmt.Errorf("%w: could not create new cipher %v", commonerrors.ErrUnexpected, err.Error())
+		err = commonerrors.WrapError(commonerrors.ErrUnexpected, err, "could not create new cipher")
 		return
 	}
 
 	aesGCM, err := cipher.NewGCM(blockCipher)
 	if err != nil {
-		err = fmt.Errorf("%w: could not create new GCM %v", commonerrors.ErrUnexpected, err.Error())
+		err = commonerrors.WrapError(commonerrors.ErrUnexpected, err, "could not create new GCM")
 		return
 	}
 
 	decrypted, err = aesGCM.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
-		err = fmt.Errorf("%w: could not open ciphertext %v", commonerrors.ErrUnexpected, err.Error())
+		err = commonerrors.WrapError(commonerrors.ErrUnexpected, err, "could not open ciphertext")
 		return
 	}
 
@@ -109,40 +108,40 @@ func DecryptHybridAESRSAEncryptedPayloadFromBytes(block []byte, payload *HybridA
 
 func encryptWithRSAKey(rsaPub *rsa.PublicKey, payload []byte) (encrypted *HybridAESRSAEncryptedPayload, err error) {
 	if rsaPub == nil {
-		err = fmt.Errorf("%w: rsa public key is undefined", commonerrors.ErrUndefined)
+		err = commonerrors.New(commonerrors.ErrUndefined, "rsa public key is undefined")
 		return
 	}
 
 	aesKey := make([]byte, 32)
 	_, err = rand.Read(aesKey)
 	if err != nil {
-		err = fmt.Errorf("%w: failed generating AES key: %v", commonerrors.ErrUnexpected, err.Error())
+		err = commonerrors.WrapError(commonerrors.ErrUnexpected, err, "failed generating AES key")
 		return
 	}
 
 	blockCipher, err := aes.NewCipher(aesKey)
 	if err != nil {
-		err = fmt.Errorf("%w: failed to create cipher: %v", commonerrors.ErrUnexpected, err.Error())
+		err = commonerrors.WrapError(commonerrors.ErrUnexpected, err, "failed to create cipher")
 		return
 	}
 
 	aesGCM, err := cipher.NewGCM(blockCipher)
 	if err != nil {
-		err = fmt.Errorf("%w: failed creating GCM: %v", commonerrors.ErrUnexpected, err.Error())
+		err = commonerrors.WrapError(commonerrors.ErrUnexpected, err, "failed creating GCM")
 		return
 	}
 
 	nonce := make([]byte, aesGCM.NonceSize())
 	_, err = rand.Read(nonce)
 	if err != nil {
-		err = fmt.Errorf("%w: failed to generate nonce: %v", commonerrors.ErrUnexpected, err.Error())
+		err = commonerrors.WrapError(commonerrors.ErrUnexpected, err, "failed to generate nonce")
 		return
 	}
 
 	ciphertext := aesGCM.Seal(nil, nonce, payload, nil)
 	encryptedAESKey, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, rsaPub, aesKey, []byte{})
 	if err != nil {
-		err = fmt.Errorf("%w: could not complete RSA encryption: %v", commonerrors.ErrUnexpected, err.Error())
+		err = commonerrors.WrapError(commonerrors.ErrUnexpected, err, "could not complete RSA encryption")
 		return
 	}
 
@@ -158,12 +157,12 @@ func encryptWithRSAKey(rsaPub *rsa.PublicKey, payload []byte) (encrypted *Hybrid
 func EncryptHybridAESRSAEncryptedPayloadFromPublickKeyBytes(publicKeyBytes []byte, payload []byte) (encrypted *HybridAESRSAEncryptedPayload, err error) {
 	block, _ := pem.Decode(publicKeyBytes)
 	if block == nil {
-		err = fmt.Errorf("%w: failed to decode PEM block from certificate", commonerrors.ErrUnexpected)
+		err = commonerrors.New(commonerrors.ErrUnexpected, "failed to decode PEM block from certificate")
 		return
 	}
 
 	if block == nil {
-		err = fmt.Errorf("%w: block was empty", commonerrors.ErrEmpty)
+		err = commonerrors.New(commonerrors.ErrEmpty, "block was empty")
 		return
 	}
 
@@ -171,7 +170,7 @@ func EncryptHybridAESRSAEncryptedPayloadFromPublickKeyBytes(publicKeyBytes []byt
 	if err != nil {
 		pkcs1PublicKey, subErr := x509.ParsePKCS1PublicKey(block.Bytes)
 		if subErr != nil {
-			err = fmt.Errorf("failed to parse public key as PKIX or PKCS1: %v, %v", err, subErr)
+			err = commonerrors.Newf(commonerrors.ErrUnexpected, "failed to parse public key as PKIX or PKCS1: %v, %v", err, subErr)
 			return
 		}
 
@@ -180,7 +179,7 @@ func EncryptHybridAESRSAEncryptedPayloadFromPublickKeyBytes(publicKeyBytes []byt
 
 	rsaPub, ok := pub.(*rsa.PublicKey)
 	if !ok {
-		err = fmt.Errorf("%w: could not parse PKIX pem block as RSA key", commonerrors.ErrUnexpected)
+		err = commonerrors.New(commonerrors.ErrUnexpected, "could not parse PKIX pem block as RSA key")
 		return
 	}
 
@@ -195,13 +194,13 @@ func EncryptHybridAESRSAEncryptedPayloadFromPublickKeyBytes(publicKeyBytes []byt
 func EncryptHybridAESRSAEncryptedPayloadFromBytes(block []byte, payload []byte) (encrypted *HybridAESRSAEncryptedPayload, err error) {
 	cert, err := x509.ParseCertificate(block)
 	if err != nil {
-		err = fmt.Errorf("%w: failed parsing certificate: %v", commonerrors.ErrUnexpected, err.Error())
+		err = commonerrors.WrapError(commonerrors.ErrUnexpected, err, "failed parsing certificate")
 		return
 	}
 
 	rsaPub, ok := cert.PublicKey.(*rsa.PublicKey)
 	if !ok {
-		err = fmt.Errorf("%w: public key in certificate is not RSA", commonerrors.ErrInvalid)
+		err = commonerrors.New(commonerrors.ErrInvalid, "public key in certificate is not RSA")
 		return
 	}
 
@@ -216,12 +215,12 @@ func EncryptHybridAESRSAEncryptedPayloadFromBytes(block []byte, payload []byte) 
 func EncryptHybridAESRSAEncryptedPayloadFromCertificate(certPath string, payload []byte) (encrypted *HybridAESRSAEncryptedPayload, err error) {
 	block, err := ParsePEMBlock(certPath)
 	if err != nil {
-		err = fmt.Errorf("%w: could not parse PEM block from '%v': %v", commonerrors.ErrUnexpected, certPath, err.Error())
+		err = commonerrors.WrapErrorf(commonerrors.ErrUnexpected, err, "could not parse PEM block from '%v'", certPath)
 		return
 	}
 
 	if block == nil {
-		err = fmt.Errorf("%w: block was empty", commonerrors.ErrEmpty)
+		err = commonerrors.New(commonerrors.ErrEmpty, "block was empty")
 		return
 	}
 

--- a/utils/encryption/aesrsa/encryption.go
+++ b/utils/encryption/aesrsa/encryption.go
@@ -107,7 +107,7 @@ func DecryptHybridAESRSAEncryptedPayloadFromBytes(block []byte, payload *HybridA
 	return
 }
 
-func encrypteWithRSAKey(rsaPub *rsa.PublicKey, payload []byte) (encrypted *HybridAESRSAEncryptedPayload, err error) {
+func encryptWithRSAKey(rsaPub *rsa.PublicKey, payload []byte) (encrypted *HybridAESRSAEncryptedPayload, err error) {
 	if rsaPub == nil {
 		err = fmt.Errorf("%w: rsa public key is undefined", commonerrors.ErrUndefined)
 		return
@@ -175,7 +175,7 @@ func EncryptHybridAESRSAEncryptedPayloadFromPublickKeyBytes(publicKeyBytes []byt
 			return
 		}
 
-		return encrypteWithRSAKey(pkcs1PublicKey, payload)
+		return encryptWithRSAKey(pkcs1PublicKey, payload)
 	}
 
 	rsaPub, ok := pub.(*rsa.PublicKey)
@@ -184,7 +184,7 @@ func EncryptHybridAESRSAEncryptedPayloadFromPublickKeyBytes(publicKeyBytes []byt
 		return
 	}
 
-	return encrypteWithRSAKey(rsaPub, payload)
+	return encryptWithRSAKey(rsaPub, payload)
 }
 
 // EncryptHybridAESRSAEncryptedPayloadFromBytes takes an x509 certificate for key encypherment and uses it to
@@ -205,7 +205,7 @@ func EncryptHybridAESRSAEncryptedPayloadFromBytes(block []byte, payload []byte) 
 		return
 	}
 
-	return encrypteWithRSAKey(rsaPub, payload)
+	return encryptWithRSAKey(rsaPub, payload)
 }
 
 // EncryptHybridAESRSAEncryptedPayloadFromCertificate takes a path to a valid x509 certificate for key encypherment

--- a/utils/encryption/aesrsa/encryption.go
+++ b/utils/encryption/aesrsa/encryption.go
@@ -107,6 +107,82 @@ func DecryptHybridAESRSAEncryptedPayloadFromBytes(block []byte, payload *HybridA
 	return
 }
 
+func encrypteWithRSAKey(rsaPub *rsa.PublicKey, payload []byte) (encrypted *HybridAESRSAEncryptedPayload, err error) {
+	if rsaPub == nil {
+		err = fmt.Errorf("%w: rsa public key is undefined", commonerrors.ErrUndefined)
+		return
+	}
+
+	aesKey := make([]byte, 32)
+	_, err = rand.Read(aesKey)
+	if err != nil {
+		err = fmt.Errorf("%w: failed generating AES key: %v", commonerrors.ErrUnexpected, err.Error())
+		return
+	}
+
+	blockCipher, err := aes.NewCipher(aesKey)
+	if err != nil {
+		err = fmt.Errorf("%w: failed to create cipher: %v", commonerrors.ErrUnexpected, err.Error())
+		return
+	}
+	aesGCM, err := cipher.NewGCM(blockCipher)
+	if err != nil {
+		err = fmt.Errorf("%w: failed creating GCM: %v", commonerrors.ErrUnexpected, err.Error())
+		return
+	}
+	nonce := make([]byte, aesGCM.NonceSize())
+	_, err = rand.Read(nonce)
+	if err != nil {
+		err = fmt.Errorf("%w: failed to generate nonce: %v", commonerrors.ErrUnexpected, err.Error())
+		return
+	}
+	ciphertext := aesGCM.Seal(nil, nonce, payload, nil)
+	encryptedAESKey, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, rsaPub, aesKey, []byte{})
+	if err != nil {
+		err = fmt.Errorf("%w: could not complete RSA encryption: %v", commonerrors.ErrUnexpected, err.Error())
+		return
+	}
+	encrypted = EncodeHybridAESRSAEncryptedPayload(ciphertext, encryptedAESKey, nonce)
+	return
+}
+
+// EncryptHybridAESRSAEncryptedPayloadFromPublickKeyBytes takes a bublic key for key encypherment and uses it to
+// encode a payload using hybrid RSA AES encryption where an AES key is used to encrypt the content in payload and the
+// AES key is encrypted using RSA encryption. AES encryption is used to encode the payload itself as it is faster than
+// RSA for larger payloads. RSA is used to encrypt the relatively small AES key and allows asymmetric encryption
+// whilst also being fast. More information can be found at https://www.ijrar.org/papers/IJRAR23B1852.pdf
+func EncryptHybridAESRSAEncryptedPayloadFromPublickKeyBytes(publicKeyBytes []byte, payload []byte) (encrypted *HybridAESRSAEncryptedPayload, err error) {
+	block, _ := pem.Decode(publicKeyBytes)
+	if block == nil {
+		err = fmt.Errorf("%w: failed to decode PEM block from certificate", commonerrors.ErrUnexpected)
+		return
+	}
+
+	if block == nil {
+		err = fmt.Errorf("%w: block was empty", commonerrors.ErrEmpty)
+		return
+	}
+
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		pkcs1PublicKey, subErr := x509.ParsePKCS1PublicKey(block.Bytes)
+		if subErr != nil {
+			err = fmt.Errorf("failed to parse public key as PKIX or PKCS1: %v, %v", err, subErr)
+			return
+		}
+
+		return encrypteWithRSAKey(pkcs1PublicKey, payload)
+	}
+
+	rsaPub, ok := pub.(*rsa.PublicKey)
+	if !ok {
+		err = fmt.Errorf("%w: could not parse PKIX pem block as RSA key", commonerrors.ErrUnexpected)
+		return
+	}
+
+	return encrypteWithRSAKey(rsaPub, payload)
+}
+
 // EncryptHybridAESRSAEncryptedPayloadFromBytes takes an x509 certificate for key encypherment and uses it to
 // encode a payload using hybrid RSA AES encryption where an AES key is used to encrypt the content in payload and the
 // AES key is encrypted using RSA encryption. AES encryption is used to encode the payload itself as it is faster than
@@ -125,41 +201,7 @@ func EncryptHybridAESRSAEncryptedPayloadFromBytes(block []byte, payload []byte) 
 		return
 	}
 
-	aesKey := make([]byte, 32)
-	_, err = rand.Read(aesKey)
-	if err != nil {
-		err = fmt.Errorf("%w: failed generating AES key: %v", commonerrors.ErrUnexpected, err.Error())
-		return
-	}
-
-	blockCipher, err := aes.NewCipher(aesKey)
-	if err != nil {
-		err = fmt.Errorf("%w: failed to create cipher: %v", commonerrors.ErrUnexpected, err.Error())
-		return
-	}
-
-	aesGCM, err := cipher.NewGCM(blockCipher)
-	if err != nil {
-		err = fmt.Errorf("%w: failed creating GCM: %v", commonerrors.ErrUnexpected, err.Error())
-		return
-	}
-
-	nonce := make([]byte, aesGCM.NonceSize())
-	_, err = rand.Read(nonce)
-	if err != nil {
-		err = fmt.Errorf("%w: failed to generate nonce: %v", commonerrors.ErrUnexpected, err.Error())
-		return
-	}
-
-	ciphertext := aesGCM.Seal(nil, nonce, payload, nil)
-	encryptedAESKey, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, rsaPub, aesKey, []byte{})
-	if err != nil {
-		err = fmt.Errorf("%w: could not complete RSA encryption: %v", commonerrors.ErrUnexpected, err.Error())
-		return
-	}
-
-	encrypted = EncodeHybridAESRSAEncryptedPayload(ciphertext, encryptedAESKey, nonce)
-	return
+	return encrypteWithRSAKey(rsaPub, payload)
 }
 
 // EncryptHybridAESRSAEncryptedPayloadFromCertificate takes a path to a valid x509 certificate for key encypherment

--- a/utils/encryption/aesrsa/encryption.go
+++ b/utils/encryption/aesrsa/encryption.go
@@ -125,23 +125,27 @@ func encrypteWithRSAKey(rsaPub *rsa.PublicKey, payload []byte) (encrypted *Hybri
 		err = fmt.Errorf("%w: failed to create cipher: %v", commonerrors.ErrUnexpected, err.Error())
 		return
 	}
+
 	aesGCM, err := cipher.NewGCM(blockCipher)
 	if err != nil {
 		err = fmt.Errorf("%w: failed creating GCM: %v", commonerrors.ErrUnexpected, err.Error())
 		return
 	}
+
 	nonce := make([]byte, aesGCM.NonceSize())
 	_, err = rand.Read(nonce)
 	if err != nil {
 		err = fmt.Errorf("%w: failed to generate nonce: %v", commonerrors.ErrUnexpected, err.Error())
 		return
 	}
+
 	ciphertext := aesGCM.Seal(nil, nonce, payload, nil)
 	encryptedAESKey, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, rsaPub, aesKey, []byte{})
 	if err != nil {
 		err = fmt.Errorf("%w: could not complete RSA encryption: %v", commonerrors.ErrUnexpected, err.Error())
 		return
 	}
+
 	encrypted = EncodeHybridAESRSAEncryptedPayload(ciphertext, encryptedAESKey, nonce)
 	return
 }


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Add utility to encrypt payloads using public RSA key directly instead of using the certificate

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
