### PR TITLE
:gear: Add filesytem aware `FilePathBase()` to filepath Utils

### DIFF
--- a/changes/20250409132457.bugfix
+++ b/changes/20250409132457.bugfix
@@ -1,0 +1,1 @@
+:gear: Add filesytem aware `Base()` to filepath Utils

--- a/changes/20250409132457.bugfix
+++ b/changes/20250409132457.bugfix
@@ -1,1 +1,0 @@
-:gear: Add filesytem aware `Base()` to filepath Utils

--- a/changes/20250409132457.feature
+++ b/changes/20250409132457.feature
@@ -1,1 +1,1 @@
-:gear: `[filesystem]` Add filesytem aware `Base()` and `Clean()` to filepath Utils
+:sparkles: `[filesystem]` Add filesytem aware `Base()` and `Clean()` to filepath Utils

--- a/changes/20250409132457.feature
+++ b/changes/20250409132457.feature
@@ -1,0 +1,1 @@
+:gear: `[filesystem]` Add filesytem aware `Base()` and `Clean()` to filepath Utils

--- a/utils/filesystem/filepath.go
+++ b/utils/filesystem/filepath.go
@@ -67,7 +67,7 @@ func FilePathJoin(fs FS, element ...string) string {
 	return joinedPath
 }
 
-// Same behaviour as filepath.Base, but can handle different filesystems.
+// FilePathBase has the same behaviour as filepath.Base, but can handle different filesystems.
 func FilePathBase(fs FS, fp string) string {
 	if fs == nil {
 		return ""
@@ -84,7 +84,7 @@ func FilePathBase(fs FS, fp string) string {
 	return filepath.Base(fp)
 }
 
-// Same behaviour as filepath.Clean, but can handle different filesystems.
+// FilePathClean has the same behaviour as filepath.Clean, but can handle different filesystems.
 func FilePathClean(fs FS, fp string) string {
 	if fs == nil {
 		return ""

--- a/utils/filesystem/filepath_test.go
+++ b/utils/filesystem/filepath_test.go
@@ -325,7 +325,7 @@ func TestFilePathJoin(t *testing.T) {
 	}
 }
 
-func TestBase(t *testing.T) {
+func TestFilePathBase(t *testing.T) {
 	embedFS, err := NewEmbedFileSystem(&testContent)
 	require.NoError(t, err)
 	tests := []struct {
@@ -380,7 +380,7 @@ func TestBase(t *testing.T) {
 		}
 
 		t.Run(fmt.Sprintf("%v %v", fsType, testPath), func(t *testing.T) {
-			assert.Equal(t, test.expectedBase, Base(test.fs, testPath))
+			assert.Equal(t, test.expectedBase, FilePathBase(test.fs, testPath))
 		})
 	}
 }

--- a/utils/filesystem/files.go
+++ b/utils/filesystem/files.go
@@ -456,6 +456,10 @@ func PathSeparator() rune {
 }
 
 func (fs *VFS) PathSeparator() rune {
+	if fs.pathSeparator == 0 {
+		return os.PathSeparator
+	}
+
 	return fs.pathSeparator
 }
 


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description
Same function as `filepath.Base` but is aware of the different file systems, mainly solves the issue of how `embed` works with `/` regardless of the OS.

Also, refactored `FilePathJoin` to work the same way.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [X]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
