### PR TITLE
:sparkles: `[unit]` Add helpers to format memory values and parse strings

### DIFF
--- a/changes/20250414165452.feature
+++ b/changes/20250414165452.feature
@@ -1,0 +1,1 @@
+:sparkles: `[unit]` Add helpers to format memory values and parse strings

--- a/utils/units/size/units.go
+++ b/utils/units/size/units.go
@@ -1,7 +1,17 @@
 // Package size define common size units
 package size
 
-import "github.com/ARM-software/golang-utils/utils/units/multiplication"
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/safecast"
+	"github.com/ARM-software/golang-utils/utils/units/multiplication"
+)
 
 const (
 	B = 1
@@ -24,3 +34,194 @@ const (
 	ZiB = float64(1 << 70)
 	YiB = float64(1 << 80)
 )
+
+var (
+	DecimalSIUnits = map[string]float64{
+		"B":  B,
+		"KB": KB,
+		"MB": MB,
+		"GB": GB,
+		"TB": TB,
+		"PB": PB,
+		"EB": EB,
+		"ZB": ZB,
+		"YB": YB,
+	}
+	BinarySIUnits = map[string]float64{
+		"B":   B,
+		"KiB": KiB,
+		"MiB": MiB,
+		"GiB": GiB,
+		"TiB": TiB,
+		"PiB": PiB,
+		"EiB": EiB,
+		"ZiB": ZiB,
+		"YiB": YiB,
+	}
+)
+
+var sizeRegex = regexp.MustCompile(`\s*(?P<value>[+-]?\s*[0-9]+[0-9,]*[.]?[0-9]*)\s*(?P<unit>[KkMmGgTtPpEeZzYy]i?[Bb]?)?`)
+
+func ParseSize(s string) (value float64, err error) {
+	matches := sizeRegex.FindStringSubmatch(s)
+	if len(matches) == 0 {
+		return 0, commonerrors.New(commonerrors.ErrInvalid, "string does not represent a size")
+	}
+	valueIndex := sizeRegex.SubexpIndex("value")
+	valuePart, err := strconv.ParseFloat(matches[valueIndex], 64)
+	if err != nil {
+		return 0, commonerrors.WrapError(commonerrors.ErrMarshalling, err, "failed parsing the size")
+	}
+	unitIndex := sizeRegex.SubexpIndex("unit")
+	unitValue := 1.0
+	if unitIndex >= 0 {
+		unitValue, _, err = FindUnit(matches[unitIndex])
+		if err != nil {
+			err = commonerrors.WrapError(commonerrors.ErrMarshalling, err, "failed parsing the size")
+			return
+		}
+	}
+	value = valuePart * unitValue
+	return
+}
+
+func FindUnit(unitStr string) (value float64, canonicalUnit string, err error) {
+	canonicalUnit = strings.ToUpper(strings.TrimSpace(unitStr))
+	if canonicalUnit == "" {
+		canonicalUnit = "B"
+		value = 1
+		return
+	}
+	if !strings.HasSuffix(unitStr, "B") {
+		canonicalUnit += "B"
+	}
+	canonicalUnit = strings.ReplaceAll(canonicalUnit, "I", "i")
+	value, ok := DecimalSIUnits[canonicalUnit]
+	if ok {
+		return
+	}
+	value, ok = BinarySIUnits[canonicalUnit]
+	if ok {
+		return
+	}
+	err = commonerrors.Newf(commonerrors.ErrNotFound, "unknown unit [%v]", canonicalUnit)
+	canonicalUnit = ""
+	return
+}
+
+// FormatSizeAsDecimalSI formats a size into a decimal SI string (https://en.wikipedia.org/wiki/Binary_prefix)
+// scale corresponds to the number of decimal places. For no limits, set to a negative number
+func FormatSizeAsDecimalSI(value float64, scale int) (string, error) {
+	return formatSize(value, decimalFormatFunc, scale)
+}
+
+// FormatSizeAsBinarySI formats a size into a binary SI string (https://en.wikipedia.org/wiki/Binary_prefix)
+// scale corresponds to the number of decimal places. For no limits, set to a negative number
+func FormatSizeAsBinarySI(value float64, scale int) (string, error) {
+	return formatSize(value, binaryFormatFunc, scale)
+}
+
+func formatSize(value float64, formatValueFunc func(value float64) (valueInUnit float64, unit string), scale int) (str string, err error) {
+	builder := strings.Builder{}
+	if value < 0 {
+		_, err = builder.WriteString("-")
+		if err != nil {
+			err = commonerrors.WrapError(commonerrors.ErrMarshalling, err, "failed formatting the size")
+			return
+		}
+		value = math.Abs(value)
+	}
+
+	valueInUnit, unit := formatValueFunc(value)
+	formatDecimal := ""
+	switch {
+	case scale == 0:
+		formatDecimal = "%d"
+	case scale > 0:
+		formatDecimal = "%" + fmt.Sprintf(".%vf", scale)
+	default:
+		formatDecimal = "%v"
+	}
+	if scale == 0 {
+		_, err = builder.WriteString(fmt.Sprintf(formatDecimal, safecast.ToUint64(math.Round(valueInUnit))))
+	} else {
+		_, err = builder.WriteString(fmt.Sprintf(formatDecimal, valueInUnit))
+	}
+	if err != nil {
+		err = commonerrors.WrapError(commonerrors.ErrMarshalling, err, "failed formatting the size")
+		return
+	}
+	_, err = builder.WriteString(unit)
+	if err != nil {
+		err = commonerrors.WrapError(commonerrors.ErrMarshalling, err, "failed formatting the size")
+		return
+	}
+	str = strings.TrimSpace(builder.String())
+	return
+}
+
+func decimalFormatFunc(value float64) (valueInUnit float64, unit string) {
+	switch {
+	case value < KB:
+		unit = "B"
+		valueInUnit = value
+	case value < MB:
+		unit = "KB"
+		valueInUnit = value / KB
+	case value < GB:
+		unit = "MB"
+		valueInUnit = value / MB
+	case value < TB:
+		unit = "GB"
+		valueInUnit = value / GB
+	case value < PB:
+		unit = "TB"
+		valueInUnit = value / TB
+	case value < EB:
+		unit = "PB"
+		valueInUnit = value / PB
+	case value < ZB:
+		unit = "EB"
+		valueInUnit = value / EB
+	case value < YB:
+		unit = "ZB"
+		valueInUnit = value / ZB
+	default:
+		unit = "YB"
+		valueInUnit = value / YB
+	}
+	return
+}
+
+func binaryFormatFunc(value float64) (valueInUnit float64, unit string) {
+	switch {
+	case value < KiB:
+		unit = "B"
+		valueInUnit = value
+	case value < MiB:
+		unit = "KiB"
+		valueInUnit = value / KiB
+	case value < GiB:
+		unit = "MiB"
+		valueInUnit = value / MiB
+	case value < TiB:
+		unit = "GiB"
+		valueInUnit = value / GiB
+	case value < PiB:
+		unit = "TiB"
+		valueInUnit = value / TiB
+	case value < EiB:
+		unit = "PiB"
+		valueInUnit = value / PiB
+	case value < ZiB:
+		unit = "EiB"
+		valueInUnit = value / EiB
+	case value < YiB:
+		unit = "ZiB"
+		valueInUnit = value / ZiB
+	default:
+		unit = "YiB"
+		valueInUnit = value / YiB
+	}
+	return
+}

--- a/utils/units/size/units_test.go
+++ b/utils/units/size/units_test.go
@@ -1,19 +1,27 @@
 package size
 
 import (
+	"fmt"
+	"sort"
+	"strconv"
 	"testing"
 
+	"github.com/go-faker/faker/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
 )
 
 func TestSizes(t *testing.T) {
-	sizes := []float64{B, KB, MB, GB, TB, PB, EB, ZB, YB}
+	sizes := maps.Values(DecimalSIUnits)
+	sort.Float64s(sizes)
 	for i := range sizes {
 		if i > 0 {
 			assert.Equal(t, sizes[i], 1000*sizes[i-1])
 		}
 	}
-	sizes = []float64{B, KiB, MiB, GiB, TiB, PiB, EiB, ZiB, YiB}
+	sizes = maps.Values(BinarySIUnits)
+	sort.Float64s(sizes)
 	for i := range sizes {
 		if i > 0 {
 			assert.Equal(t, sizes[i], 1024*sizes[i-1])
@@ -24,4 +32,101 @@ func TestSizes(t *testing.T) {
 	assert.Equal(t, GiB, float64(1<<30))
 	assert.Equal(t, 10*GiB, float64(10<<30))
 	assert.Equal(t, MiB, float64(1<<20))
+}
+
+func TestParseSize(t *testing.T) {
+	tests := []struct {
+		name       string
+		units      map[string]float64
+		formatFunc func(float64, int) (string, error)
+	}{
+		{
+			name:       "decimal SI",
+			units:      DecimalSIUnits,
+			formatFunc: FormatSizeAsDecimalSI,
+		},
+		{
+			name:       "binary SI",
+			units:      BinarySIUnits,
+			formatFunc: FormatSizeAsBinarySI,
+		},
+	}
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			for k, v := range test.units {
+				t.Run(k, func(t *testing.T) {
+					random, err := faker.RandomInt(0, 999, 2)
+					require.NoError(t, err)
+					valueRandom, err := strconv.ParseFloat(fmt.Sprintf("%v.%v", random[0], random[1]), 64)
+					require.NoError(t, err)
+					expectedValue := valueRandom * v
+					valueStr1, err := test.formatFunc(expectedValue, -1)
+					require.NoError(t, err)
+					valueStr2 := fmt.Sprintf("%v %v", valueRandom, k)
+					parsedValue1, err := ParseSize(valueStr1)
+					require.NoError(t, err)
+					parsedValue2, err := ParseSize(valueStr2)
+					require.NoError(t, err)
+					assert.Equal(t, expectedValue, parsedValue1)
+					assert.Equal(t, expectedValue, parsedValue2)
+				})
+			}
+		})
+	}
+
+}
+
+func TestFormatSizeAsDecimalSI(t *testing.T) {
+	valueStr, err := FormatSizeAsDecimalSI(-1605.0, -1)
+	require.NoError(t, err)
+	assert.Equal(t, "-1.605KB", valueStr)
+	valueStr, err = FormatSizeAsDecimalSI(-1605.0, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "-2KB", valueStr)
+	valueStr, err = FormatSizeAsDecimalSI(-1605.0, 1)
+	require.NoError(t, err)
+	assert.Equal(t, "-1.6KB", valueStr)
+	valueStr, err = FormatSizeAsDecimalSI(-1605.0, 2)
+	require.NoError(t, err)
+	assert.Equal(t, "-1.60KB", valueStr)
+	valueStr, err = FormatSizeAsDecimalSI(1605.0, -1)
+	require.NoError(t, err)
+	assert.Equal(t, "1.605KB", valueStr)
+	valueStr, err = FormatSizeAsDecimalSI(1605.0, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "2KB", valueStr)
+	valueStr, err = FormatSizeAsDecimalSI(1605.0, 1)
+	require.NoError(t, err)
+	assert.Equal(t, "1.6KB", valueStr)
+	valueStr, err = FormatSizeAsDecimalSI(1605.0, 2)
+	require.NoError(t, err)
+	assert.Equal(t, "1.60KB", valueStr)
+}
+
+func TestFormatSizeAsBinarySI(t *testing.T) {
+	valueStr, err := FormatSizeAsBinarySI(-1605.0, -1)
+	require.NoError(t, err)
+	assert.Equal(t, "-1.5673828125KiB", valueStr)
+	valueStr, err = FormatSizeAsBinarySI(-1605.0, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "-2KiB", valueStr)
+	valueStr, err = FormatSizeAsBinarySI(-1605.0, 1)
+	require.NoError(t, err)
+	assert.Equal(t, "-1.6KiB", valueStr)
+	valueStr, err = FormatSizeAsBinarySI(-1605.0, 2)
+	require.NoError(t, err)
+	assert.Equal(t, "-1.57KiB", valueStr)
+	valueStr, err = FormatSizeAsBinarySI(1605.0, -1)
+	require.NoError(t, err)
+	assert.Equal(t, "1.5673828125KiB", valueStr)
+	valueStr, err = FormatSizeAsBinarySI(1605.0, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "2KiB", valueStr)
+	valueStr, err = FormatSizeAsBinarySI(1605.0, 1)
+	require.NoError(t, err)
+	assert.Equal(t, "1.6KiB", valueStr)
+	valueStr, err = FormatSizeAsBinarySI(1605.0, 2)
+	require.NoError(t, err)
+	assert.Equal(t, "1.57KiB", valueStr)
 }


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description
Help generating strings from size and parsing size values


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
