### PR TITLE
:bug: `[commonerrors]` fix string representation

### DIFF
--- a/changes/20250521081848.bugfix
+++ b/changes/20250521081848.bugfix
@@ -1,0 +1,1 @@
+:bug: `[commonerrors]` fix string representation

--- a/utils/commonerrors/errors.go
+++ b/utils/commonerrors/errors.go
@@ -277,7 +277,12 @@ func Errorf(targetErr error, format string, args ...any) error {
 	if len(args) > 0 {
 		msg = fmt.Sprintf(format, args...)
 	}
-	return fmt.Errorf("%w%v %v", tErr, string(TypeReasonErrorSeparator), msg)
+	cleansedMsg := strings.TrimSpace(msg)
+	if cleansedMsg == "" {
+		return tErr
+	} else {
+		return fmt.Errorf("%w%v %v", tErr, string(TypeReasonErrorSeparator), cleansedMsg)
+	}
 }
 
 // WrapError wraps an error into a particular targetError. However, if the original error has to do with a contextual error (i.e. ErrCancelled or ErrTimeout), it will be passed through without having is type changed.
@@ -295,7 +300,12 @@ func WrapError(targetError, originalError error, msg string) error {
 	if originalError == nil {
 		return New(tErr, msg)
 	} else {
-		return Errorf(tErr, "%v%v %v", msg, string(TypeReasonErrorSeparator), originalError.Error())
+		cleansedMsg := strings.TrimSpace(msg)
+		if cleansedMsg == "" {
+			return New(tErr, originalError.Error())
+		} else {
+			return Errorf(tErr, "%v%v %v", cleansedMsg, string(TypeReasonErrorSeparator), originalError.Error())
+		}
 	}
 }
 

--- a/utils/commonerrors/errors_test.go
+++ b/utils/commonerrors/errors_test.go
@@ -221,3 +221,21 @@ func TestWrapError(t *testing.T) {
 	assert.True(t, Any(WrapIfNotCommonError(ErrUndefined, errors.New(faker.Sentence()), faker.Sentence()), ErrUndefined))
 	assert.True(t, Any(WrapIfNotCommonErrorf(ErrUndefined, errors.New(faker.Sentence()), faker.Sentence()), ErrUndefined))
 }
+
+func TestString(t *testing.T) {
+	assert.Equal(t, "unknown", New(nil, "").Error())
+	assert.Equal(t, "unknown", Newf(nil, "").Error())
+	assert.Equal(t, "unknown", WrapError(nil, nil, "").Error())
+	assert.Equal(t, "unknown", WrapErrorf(nil, nil, "").Error())
+	assert.Equal(t, "unsupported", New(ErrUnsupported, "").Error())
+	assert.Equal(t, "unsupported", Newf(ErrUnsupported, "").Error())
+	assert.Equal(t, "unsupported", WrapError(ErrUnsupported, nil, "").Error())
+	assert.Equal(t, "unsupported", WrapErrorf(ErrUnsupported, nil, "").Error())
+	assert.Equal(t, "unsupported: test", New(ErrUnsupported, "test").Error())
+	assert.Equal(t, "unknown: test", New(nil, "test").Error())
+	assert.Equal(t, "unsupported: test 56", Newf(ErrUnsupported, "test %v", 56).Error())
+	assert.Equal(t, "unsupported: test", WrapError(ErrUnsupported, nil, "test").Error())
+	assert.Equal(t, "unsupported: not found", WrapError(ErrUnsupported, ErrNotFound, "").Error())
+	assert.Equal(t, "unknown: test: unsupported", WrapError(nil, ErrUnsupported, "test").Error())
+	assert.Equal(t, "unsupported: test 56: not found", WrapErrorf(ErrUnsupported, ErrNotFound, "test %v", 56).Error())
+}


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

fix string formatting of errors


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
