### PR TITLE
📝 Remove code climate references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,19 +107,6 @@ jobs:
         run: go build -v ./...
         working-directory: ${{ matrix.go-module }}
 
-      - if: ${{ startsWith(matrix.os, 'ubuntu') }}
-        name: Test [${{ matrix.go-module }} on ${{ matrix.os }}] & Publish Code Coverage
-        uses: paambaati/codeclimate-action@v5.0.0
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        with:
-          debug: true
-          workingDirectory: ${{ matrix.go-module }}
-          coverageCommand: go test -race -cover -v -tags integration -timeout 30m -coverprofile ${{ matrix.go-module }}_coverage.out ./...
-          prefix: github.com/ARM-software/${{ github.event.repository.name }}/${{ matrix.go-module }}
-          coverageLocations:
-            "${{github.workspace}}/${{ matrix.go-module }}/${{ matrix.go-module }}_coverage.out:gocov"
-
 # FIXME: Run tests on Mac and Windows
 #      - if: ${{ startsWith(matrix.os, 'windows') || startsWith(matrix.os, 'macOS') }}
 #        run: go test -race -cover -v ./...

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -67,6 +67,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -272,5 +276,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-04T19:30:24Z"
+  "generated_at": "2025-06-13T15:31:00Z"
 }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -49,17 +49,6 @@ If you want to manually run all pre-commit hooks on a repository without creatin
 
 To run individual hooks use `pre-commit run <hook_id>`.
 
-## Code Climate
-
-Code Climate is integrated with our GitHub flow. Failing the configured rules will yield a pull request not mergeable.
-
-If you prefer to view the Code Climate report on your machine, prior to sending a pull request, you can use the [cli provided by Code Climate](https://docs.codeclimate.com/docs/command-line-interface).
-
-Plugins for various tools are also available:
-  - [Atom](https://docs.codeclimate.com/docs/code-climate-atom-package)
-  - [PyCharm](https://plugins.jetbrains.com/plugin/13306-code-cleaner-with-code-climate-cli)
-  - [Vim](https://docs.codeclimate.com/docs/vim-plugin)
-
 # Dependency upgrades
 
 For dependency upgrades, dependabot is relied upon and news files are auto-generated in order to document such change. Nonetheless, due to a change in [GitHub actions](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions), secrets are not available in the build triggered by the pull request unless they are [re-run manually](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#manually-re-running-a-workflow). So please re-run every dependabot PR CI jobs.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ SPDX-License-Identifier: Apache-2.0
 [![Go Reference](https://pkg.go.dev/badge/github.com/ARM-software/golang-utils/utils.svg)](https://pkg.go.dev/github.com/ARM-software/golang-utils/utils)
 [![Documentation](https://badgen.net/badge/Documentation/GitHub%20Pages/blue?icon=github)](https://arm-software.github.io/golang-utils)
 [![Go Report Card](https://goreportcard.com/badge/github.com/ARM-software/golang-utils)](https://goreportcard.com/report/github.com/ARM-software/golang-utils)
-[![Maintainability](https://api.codeclimate.com/v1/badges/dbe25c45c2756142fd08/maintainability)](https://codeclimate.com/github/ARM-software/golang-utils/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/dbe25c45c2756142fd08/test_coverage)](https://codeclimate.com/github/ARM-software/golang-utils/test_coverage)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/6531/badge)](https://bestpractices.coreinfrastructure.org/projects/6531)
 ![Scorecard](https://img.shields.io/ossf-scorecard/github.com/ARM-software/golang-utils?label=openssf%20scorecard&style=flat)
 

--- a/changes/20250613163053.misc
+++ b/changes/20250613163053.misc
@@ -1,0 +1,1 @@
+:memo: Remove code climate references


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

This removes code climate references in files as we have now migrated to Qlty Cloud.

_NB: The work to integrate Qlty Cloud changes will be a separate PR as it's dependent on the existence of a repo/organisation level secret for authentication with Qlty._

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [X]  Additional tests are not required for this change (e.g. documentation update).
