### PR TITLE
:bug: `validation` Make sure to expose validation rule as a `validation.Rule`

### DIFF
--- a/changes/20250708131716.bugfix
+++ b/changes/20250708131716.bugfix
@@ -1,0 +1,1 @@
+:bug: `validation` Make sure to expose validation rule as a `validation.Rule`

--- a/utils/validation/rules.go
+++ b/utils/validation/rules.go
@@ -12,28 +12,28 @@ import (
 
 // IsPort validates whether a value is a port using is.Port from github.com/go-ozzo/ozzo-validation/v4.
 // However it supports all base go integer types not just strings.
-func IsPort() validation.Rule {
-	return validation.By(func(vRaw any) (err error) {
-		switch val := reflect.ValueOf(vRaw); val.Kind() {
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			err = is.Port.Validate(strconv.FormatInt(val.Int(), 10))
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			err = is.Port.Validate(strconv.FormatUint(val.Uint(), 10))
-		case reflect.String:
-			err = is.Port.Validate(val.String())
-		case reflect.Slice:
-			if b, ok := vRaw.([]byte); ok {
-				err = is.Port.Validate(string(b))
-			}
-		default:
-			return commonerrors.Newf(commonerrors.ErrMarshalling, "unsupported type for port validation '%T'", vRaw)
-		}
+var IsPort = validation.By(isPort)
 
-		if err != nil {
-			err = commonerrors.WrapError(commonerrors.ErrInvalid, err, "")
-			return
+func isPort(vRaw any) (err error) {
+	switch val := reflect.ValueOf(vRaw); val.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		err = is.Port.Validate(strconv.FormatInt(val.Int(), 10))
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		err = is.Port.Validate(strconv.FormatUint(val.Uint(), 10))
+	case reflect.String:
+		err = is.Port.Validate(val.String())
+	case reflect.Slice:
+		if b, ok := vRaw.([]byte); ok {
+			err = is.Port.Validate(string(b))
 		}
+	default:
+		return commonerrors.Newf(commonerrors.ErrMarshalling, "unsupported type for port validation '%T'", vRaw)
+	}
 
+	if err != nil {
+		err = commonerrors.WrapError(commonerrors.ErrInvalid, err, "")
 		return
-	})
+	}
+
+	return
 }

--- a/utils/validation/rules_test.go
+++ b/utils/validation/rules_test.go
@@ -44,7 +44,7 @@ func TestCastingToInt(t *testing.T) {
 		{"nil", nil, commonerrors.ErrMarshalling},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			err := IsPort().Validate(test.value)
+			err := IsPort.Validate(test.value)
 			if test.err == nil {
 				assert.NoError(t, err)
 			} else {


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Make sure to expose validation rule as a `validation.Rule`

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
