### PR TITLE
:bug: `[parallelisation]` Clean cancel function store after functions have been cancelled

### DIFF
--- a/changes/20250710210822.bugfix
+++ b/changes/20250710210822.bugfix
@@ -1,0 +1,1 @@
+:bug: `[parallelisation]` Clean cancel function store after functions have been cancelled

--- a/utils/parallelisation/cancel_functions.go
+++ b/utils/parallelisation/cancel_functions.go
@@ -23,11 +23,12 @@ func (s *CancelFunctionStore) RegisterCancelFunction(cancel ...context.CancelFun
 }
 
 func (s *CancelFunctionStore) Cancel() {
-	defer s.mu.RUnlock()
-	s.mu.RLock()
+	defer s.mu.Unlock()
+	s.mu.Lock()
 	for _, c := range s.cancelFunctions {
 		c()
 	}
+	s.cancelFunctions = []context.CancelFunc{}
 }
 
 func (s *CancelFunctionStore) Len() int {


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

- fix a bug about the cancel function store which only grows even if not needed



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
