### PR TITLE
:bug: `[subprocess]` make sure child processes are killed on context cancellation

### DIFF
--- a/changes/20250714171923.bugfix
+++ b/changes/20250714171923.bugfix
@@ -1,0 +1,1 @@
+:bug: `[subprocess]` make sure child processes are killed on context cancellation

--- a/changes/20250715105927.feature
+++ b/changes/20250715105927.feature
@@ -1,0 +1,1 @@
+:sparkles: `[proc]` Add utilities to kill processes gracefully

--- a/utils/proc/errors.go
+++ b/utils/proc/errors.go
@@ -5,7 +5,6 @@
 package proc
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"syscall"
@@ -33,17 +32,17 @@ func ConvertProcessError(err error) error {
 		// ESRCH is "no such process", meaning the process has already exited.
 		return nil
 	case commonerrors.Any(err, exec.ErrWaitDelay):
-		return fmt.Errorf("%w: %v", commonerrors.ErrTimeout, err.Error())
+		return commonerrors.WrapError(commonerrors.ErrTimeout, err, "")
 	case commonerrors.Any(err, exec.ErrDot, exec.ErrNotFound):
-		return fmt.Errorf("%w: %v", commonerrors.ErrNotFound, err.Error())
+		return commonerrors.WrapError(commonerrors.ErrNotFound, err, "")
 	case commonerrors.Any(process.ErrorNotPermitted):
-		return fmt.Errorf("%w: %v", commonerrors.ErrForbidden, err.Error())
+		return commonerrors.WrapError(commonerrors.ErrForbidden, err, "")
 	case commonerrors.Any(process.ErrorProcessNotRunning):
-		return fmt.Errorf("%w: %v", commonerrors.ErrNotFound, err.Error())
+		return commonerrors.WrapError(commonerrors.ErrNotFound, err, "")
 	case commonerrors.CorrespondTo(err, errAccessDenied):
-		return fmt.Errorf("%w: %v", commonerrors.ErrNotFound, err.Error())
+		return commonerrors.WrapError(commonerrors.ErrNotFound, err, "")
 	case commonerrors.CorrespondTo(err, errNotImplemented):
-		return fmt.Errorf("%w: %v", commonerrors.ErrNotImplemented, err.Error())
+		return commonerrors.WrapError(commonerrors.ErrNotImplemented, err, "")
 	default:
 		return err
 	}

--- a/utils/proc/interrupt.go
+++ b/utils/proc/interrupt.go
@@ -1,0 +1,64 @@
+package proc
+
+import (
+	"context"
+	"time"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/parallelisation"
+)
+
+//go:generate go run github.com/dmarkham/enumer -type=InterruptType -text -json -yaml
+type InterruptType int
+
+const (
+	SigInt  InterruptType = 2
+	SigKill InterruptType = 9
+	SigTerm InterruptType = 15
+)
+
+func InterruptProcess(ctx context.Context, pid int, signal InterruptType) (err error) {
+	err = parallelisation.DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+	process, err := FindProcess(ctx, pid)
+	if err != nil || process == nil {
+		err = commonerrors.Ignore(err, commonerrors.ErrNotFound)
+		return
+	}
+
+	switch signal {
+	case SigInt:
+		err = process.Interrupt(ctx)
+	case SigKill:
+		err = process.KillWithChildren(ctx)
+	case SigTerm:
+		err = process.Terminate(ctx)
+	default:
+		err = commonerrors.New(commonerrors.ErrInvalid, "unknown interrupt type for process")
+	}
+	return
+}
+
+// TerminateGracefully follows the pattern set by [kubernetes](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination) and terminates processes gracefully by first sending a SIGTERM and then a SIGKILL after the grace period has elapsed.
+func TerminateGracefully(ctx context.Context, pid int, gracePeriod time.Duration) (err error) {
+	defer func() { _ = InterruptProcess(context.Background(), pid, SigKill) }()
+	err = InterruptProcess(ctx, pid, SigInt)
+	if err != nil {
+		return
+	}
+	err = InterruptProcess(ctx, pid, SigTerm)
+	if err != nil {
+		return
+	}
+	_, fErr := FindProcess(ctx, pid)
+	if commonerrors.Any(fErr, commonerrors.ErrNotFound) {
+		// The process no longer exist.
+		// No need to wait the grace period
+		return
+	}
+	parallelisation.SleepWithContext(ctx, gracePeriod)
+	err = InterruptProcess(ctx, pid, SigKill)
+	return
+}

--- a/utils/proc/interrupt_test.go
+++ b/utils/proc/interrupt_test.go
@@ -1,0 +1,74 @@
+package proc
+
+import (
+	"context"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/go-faker/faker/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
+)
+
+func TestTerminateGracefully(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	t.Run("single process", func(t *testing.T) {
+		cmd := exec.Command("sleep", "50")
+		require.NoError(t, cmd.Start())
+		defer func() { _ = cmd.Wait() }()
+		process, err := FindProcess(context.Background(), cmd.Process.Pid)
+		require.NoError(t, err)
+		assert.True(t, process.IsRunning())
+		require.NoError(t, TerminateGracefully(context.Background(), cmd.Process.Pid, 100*time.Millisecond))
+		time.Sleep(500 * time.Millisecond)
+		process, err = FindProcess(context.Background(), cmd.Process.Pid)
+		if err == nil {
+			require.NotEmpty(t, process)
+			assert.False(t, process.IsRunning())
+		} else {
+			errortest.AssertError(t, err, commonerrors.ErrNotFound)
+			assert.Empty(t, process)
+		}
+	})
+	t.Run("process with children", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("test with bash")
+		}
+		// see https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773
+		// https://forum.golangbridge.org/t/killing-child-process-on-timeout-in-go-code/995/16
+		cmd := exec.Command("bash", "-c", "watch date > date.txt 2>&1")
+		require.NoError(t, cmd.Start())
+		defer func() { _ = cmd.Wait() }()
+		require.NotNil(t, cmd.Process)
+		p, err := FindProcess(context.Background(), cmd.Process.Pid)
+		require.NoError(t, err)
+		assert.True(t, p.IsRunning())
+		require.NoError(t, TerminateGracefully(context.Background(), cmd.Process.Pid, 100*time.Millisecond))
+		p, err = FindProcess(context.Background(), cmd.Process.Pid)
+		if err == nil {
+			require.NotEmpty(t, p)
+			assert.False(t, p.IsRunning())
+		} else {
+			errortest.AssertError(t, err, commonerrors.ErrNotFound)
+			assert.Empty(t, p)
+		}
+	})
+	t.Run("no process", func(t *testing.T) {
+		random, err := faker.RandomInt(9000, 20000, 1)
+		require.NoError(t, err)
+		require.NoError(t, TerminateGracefully(context.Background(), random[0], 100*time.Millisecond))
+	})
+	t.Run("cancelled", func(t *testing.T) {
+		random, err := faker.RandomInt(9000, 20000, 1)
+		require.NoError(t, err)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		errortest.AssertError(t, TerminateGracefully(ctx, random[0], 100*time.Millisecond), commonerrors.ErrCancelled)
+	})
+}

--- a/utils/subprocess/command_wrapper.go
+++ b/utils/subprocess/command_wrapper.go
@@ -82,7 +82,6 @@ func (c *cmdWrapper) interruptWithContext(ctx context.Context, interrupt proc.In
 			if commonerrors.Any(sErr, commonerrors.ErrInvalid, commonerrors.ErrCancelled, commonerrors.ErrTimeout) {
 				stopErr.Store(sErr)
 			}
-			return
 		})
 	}
 

--- a/utils/subprocess/command_wrapper.go
+++ b/utils/subprocess/command_wrapper.go
@@ -7,7 +7,6 @@ package subprocess
 
 import (
 	"context"
-	"fmt"
 	"os/exec"
 	"time"
 
@@ -45,7 +44,7 @@ func (c *cmdWrapper) Start() error {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if c.cmd == nil {
-		return fmt.Errorf("%w:undefined command", commonerrors.ErrUndefined)
+		return commonerrors.UndefinedVariable("command")
 	}
 	return ConvertCommandError(c.cmd.Start())
 }
@@ -54,7 +53,7 @@ func (c *cmdWrapper) Run() error {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if c.cmd == nil {
-		return fmt.Errorf("%w:undefined command", commonerrors.ErrUndefined)
+		return commonerrors.UndefinedVariable("command")
 	}
 	return ConvertCommandError(c.cmd.Run())
 }
@@ -71,7 +70,7 @@ func (c *cmdWrapper) interruptWithContext(ctx context.Context, interrupt interru
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if c.cmd == nil {
-		return commonerrors.New(commonerrors.ErrUndefined, "undefined command")
+		return commonerrors.UndefinedVariable("command")
 	}
 	subprocess := c.cmd.Process
 	ctx, cancel := context.WithCancel(ctx)
@@ -121,12 +120,12 @@ func (c *cmdWrapper) Pid() (pid int, err error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if c.cmd == nil {
-		err = fmt.Errorf("%w:undefined command", commonerrors.ErrUndefined)
+		err = commonerrors.UndefinedVariable("command")
 		return
 	}
 	subprocess := c.cmd.Process
 	if subprocess == nil {
-		err = fmt.Errorf("%w:undefined subprocess", commonerrors.ErrUndefined)
+		err = commonerrors.UndefinedVariable("subprocess")
 		return
 	}
 	pid = subprocess.Pid
@@ -169,11 +168,11 @@ func (c *command) Reset() {
 
 func (c *command) Check() (err error) {
 	if c.cmd == "" {
-		err = fmt.Errorf("missing command: %w", commonerrors.ErrUndefined)
+		err = commonerrors.UndefinedVariable("command")
 		return
 	}
 	if c.as == nil {
-		err = fmt.Errorf("missing command translator: %w", commonerrors.ErrUndefined)
+		err = commonerrors.UndefinedVariable("command translator")
 		return
 	}
 	if c.loggers == nil {

--- a/utils/subprocess/command_wrapper.go
+++ b/utils/subprocess/command_wrapper.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/sasha-s/go-deadlock"
+	"go.uber.org/atomic"
 
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/logs"
@@ -18,6 +19,8 @@ import (
 	"github.com/ARM-software/golang-utils/utils/proc"
 	commandUtils "github.com/ARM-software/golang-utils/utils/subprocess/command"
 )
+
+const subprocessTerminationGracePeriod = 10 * time.Millisecond
 
 // INTERNAL
 // wrapper over an exec cmd.
@@ -58,15 +61,7 @@ func (c *cmdWrapper) Run() error {
 	return ConvertCommandError(c.cmd.Run())
 }
 
-type interruptType int
-
-const (
-	sigint  interruptType = 2
-	sigkill interruptType = 9
-	sigterm interruptType = 15
-)
-
-func (c *cmdWrapper) interruptWithContext(ctx context.Context, interrupt interruptType) error {
+func (c *cmdWrapper) interruptWithContext(ctx context.Context, interrupt proc.InterruptType) error {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if c.cmd == nil {
@@ -75,24 +70,19 @@ func (c *cmdWrapper) interruptWithContext(ctx context.Context, interrupt interru
 	subprocess := c.cmd.Process
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	var stopErr error
+	stopErr := atomic.NewError(nil)
 	if subprocess != nil {
 		pid := subprocess.Pid
-		parallelisation.ScheduleAfter(ctx, 10*time.Millisecond, func(time.Time) {
-			process, err := proc.FindProcess(ctx, pid)
-			if process == nil || err != nil {
+		parallelisation.ScheduleAfter(ctx, subprocessTerminationGracePeriod, func(time.Time) {
+			process, sErr := proc.FindProcess(ctx, pid)
+			if process == nil || sErr != nil {
 				return
 			}
-			switch interrupt {
-			case sigint:
-				_ = process.Interrupt(ctx)
-			case sigkill:
-				_ = process.KillWithChildren(ctx)
-			case sigterm:
-				_ = process.Terminate(ctx)
-			default:
-				stopErr = commonerrors.New(commonerrors.ErrInvalid, "unknown interrupt type for process")
+			sErr = proc.InterruptProcess(ctx, pid, interrupt)
+			if commonerrors.Any(sErr, commonerrors.ErrInvalid, commonerrors.ErrCancelled, commonerrors.ErrTimeout) {
+				stopErr.Store(sErr)
 			}
+			return
 		})
 	}
 
@@ -101,19 +91,19 @@ func (c *cmdWrapper) interruptWithContext(ctx context.Context, interrupt interru
 		return err
 	}
 
-	return stopErr
+	return stopErr.Load()
 }
 
-func (c *cmdWrapper) interrupt(interrupt interruptType) error {
+func (c *cmdWrapper) interrupt(interrupt proc.InterruptType) error {
 	return c.interruptWithContext(context.Background(), interrupt)
 }
 
 func (c *cmdWrapper) Stop() error {
-	return c.interrupt(sigkill)
+	return c.interrupt(proc.SigKill)
 }
 
 func (c *cmdWrapper) Interrupt(ctx context.Context) error {
-	return c.interruptWithContext(ctx, sigint)
+	return c.interruptWithContext(ctx, proc.SigInt)
 }
 
 func (c *cmdWrapper) Pid() (pid int, err error) {
@@ -145,6 +135,13 @@ type command struct {
 func (c *command) createCommand(cmdCtx context.Context) *exec.Cmd {
 	newCmd, newArgs := c.as.Redefine(c.cmd, c.args...)
 	cmd := exec.CommandContext(cmdCtx, newCmd, newArgs...) //nolint:gosec
+	cmd.Cancel = func() error {
+		p := cmd.Process
+		if p == nil {
+			return nil
+		}
+		return proc.TerminateGracefully(context.Background(), p.Pid, subprocessTerminationGracePeriod)
+	}
 	cmd.Stdout = newOutStreamer(cmdCtx, c.loggers)
 	cmd.Stderr = newErrLogStreamer(cmdCtx, c.loggers)
 	cmd.Env = cmd.Environ()
@@ -198,6 +195,7 @@ func ConvertCommandError(err error) error {
 	return proc.ConvertProcessError(err)
 }
 
+// CleanKillOfCommand tries to terminate a command gracefully.
 func CleanKillOfCommand(ctx context.Context, cmd *exec.Cmd) (err error) {
 	if cmd == nil {
 		return
@@ -211,13 +209,7 @@ func CleanKillOfCommand(ctx context.Context, cmd *exec.Cmd) (err error) {
 	thisP := cmd.Process
 	if thisP == nil {
 		return
-	} else {
-		p, subErr := proc.FindProcess(ctx, thisP.Pid)
-		if subErr != nil {
-			err = subErr
-			return
-		}
-		err = p.KillWithChildren(ctx)
 	}
+	err = proc.TerminateGracefully(ctx, thisP.Pid, subprocessTerminationGracePeriod)
 	return
 }

--- a/utils/subprocess/executor.go
+++ b/utils/subprocess/executor.go
@@ -8,14 +8,12 @@ package subprocess
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/sasha-s/go-deadlock"
 	"go.uber.org/atomic"
 
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/logs"
-	"github.com/ARM-software/golang-utils/utils/platform"
 	"github.com/ARM-software/golang-utils/utils/proc"
 	commandUtils "github.com/ARM-software/golang-utils/utils/subprocess/command"
 )
@@ -167,7 +165,7 @@ func (s *Subprocess) check() (err error) {
 	// In GO, there is no reentrant locks and so following what is described there
 	// https://groups.google.com/forum/#!msg/golang-nuts/XqW1qcuZgKg/Ui3nQkeLV80J
 	if s.command == nil {
-		err = fmt.Errorf("missing command: %w", commonerrors.ErrUndefined)
+		err = commonerrors.UndefinedVariable("command")
 		return
 	}
 	err = s.command.Check()
@@ -202,11 +200,6 @@ func (s *Subprocess) Wait(ctx context.Context) (err error) {
 		pid = s.command.cmdWrapper.cmd.Process.Pid
 	} else {
 		return commonerrors.New(commonerrors.ErrConflict, "command not started")
-	}
-
-	// FIXME: verify proc.WaitForCompletion works on windows. Remove this platform check once this is verified.
-	if platform.IsWindows() {
-		return s.command.cmdWrapper.cmd.Wait()
 	}
 
 	return proc.WaitForCompletion(ctx, pid)
@@ -267,7 +260,7 @@ func (s *Subprocess) Execute() (err error) {
 	defer s.Cancel()
 
 	if s.IsOn() {
-		return fmt.Errorf("process is already started: %w", commonerrors.ErrConflict)
+		return commonerrors.New(commonerrors.ErrConflict, "process is already started")
 	}
 	s.processMonitoring.Reset()
 	s.command.Reset()

--- a/utils/subprocess/executor_test.go
+++ b/utils/subprocess/executor_test.go
@@ -94,7 +94,11 @@ test 1
 			loggers, err := logs.NewStringLogger("Test") // clean log between each test
 			require.NoError(t, err)
 
-			err = Execute(context.Background(), loggers, "", "", "", "echo", testInput)
+			if platform.IsWindows() {
+				err = Execute(context.Background(), loggers, "", "", "", "cmd", "/c", "echo", testInput)
+			} else {
+				err = Execute(context.Background(), loggers, "", "", "", "sh", "-c", "echo", testInput)
+			}
 			require.NoError(t, err)
 
 			contents := loggers.GetLogContent()
@@ -125,14 +129,14 @@ func TestStartStop(t *testing.T) {
 		{
 			name:       "ShortProcess",
 			cmdWindows: "cmd",
-			argWindows: []string{"dir", currentDir},
+			argWindows: []string{"/c", "dir", currentDir},
 			cmdOther:   "ls",
 			argOther:   []string{"-l", currentDir},
 		},
 		{
 			name:       "LongProcess",
 			cmdWindows: "cmd",
-			argWindows: []string{"SLEEP 1"},
+			argWindows: []string{"/c", "SLEEP 1"},
 			cmdOther:   "sleep",
 			argOther:   []string{"1"},
 		},
@@ -194,14 +198,14 @@ func TestStartInterrupt(t *testing.T) {
 		{
 			name:       "ShortProcess",
 			cmdWindows: "cmd",
-			argWindows: []string{"dir", currentDir},
+			argWindows: []string{"/c", "dir", currentDir},
 			cmdOther:   "ls",
 			argOther:   []string{"-l", currentDir},
 		},
 		{
 			name:       "LongProcess",
 			cmdWindows: "cmd",
-			argWindows: []string{"SLEEP 1"},
+			argWindows: []string{"/c", "SLEEP 1"},
 			cmdOther:   "sleep",
 			argOther:   []string{"1"},
 		},
@@ -262,14 +266,14 @@ func TestExecute(t *testing.T) {
 		{
 			name:       "ShortProcess",
 			cmdWindows: "cmd",
-			argWindows: []string{"dir", currentDir},
+			argWindows: []string{"/c", "dir", currentDir},
 			cmdOther:   "ls",
 			argOther:   []string{"-l", currentDir},
 		},
 		{
 			name:       "LongProcess",
 			cmdWindows: "cmd",
-			argWindows: []string{"SLEEP 1"},
+			argWindows: []string{"/c", "SLEEP 1"},
 			cmdOther:   "sleep",
 			argOther:   []string{"1"},
 		},
@@ -315,7 +319,7 @@ func TestOutput(t *testing.T) {
 		{
 			name:         "ShortProcess",
 			cmdWindows:   "cmd",
-			argWindows:   []string{"dir", currentDir},
+			argWindows:   []string{"/c", "dir", currentDir},
 			cmdOther:     "ls",
 			argOther:     []string{"-l", currentDir},
 			expectOutput: true,
@@ -324,7 +328,7 @@ func TestOutput(t *testing.T) {
 		{
 			name:       "LongProcess",
 			cmdWindows: "cmd",
-			argWindows: []string{"SLEEP 1"},
+			argWindows: []string{"/c", "SLEEP 1"},
 			cmdOther:   "sleep",
 			argOther:   []string{"1"},
 			runCount:   1,
@@ -373,7 +377,7 @@ func TestCancelledSubprocess(t *testing.T) {
 		{
 			name:       "LongProcess",
 			cmdWindows: "cmd",
-			argWindows: []string{"SLEEP 4"},
+			argWindows: []string{"/c", "SLEEP 4"},
 			cmdOther:   "sleep",
 			argOther:   []string{"4"},
 		},
@@ -419,7 +423,7 @@ func TestCancelledSubprocess2(t *testing.T) {
 		{
 			name:       "LongProcess",
 			cmdWindows: "cmd",
-			argWindows: []string{"SLEEP 4"},
+			argWindows: []string{"/c", "SLEEP 4"},
 			cmdOther:   "sleep",
 			argOther:   []string{"4"},
 		},
@@ -468,7 +472,7 @@ func TestCancelledSubprocess3(t *testing.T) {
 		{
 			name:       "LongProcess",
 			cmdWindows: "cmd",
-			argWindows: []string{"SLEEP 4"},
+			argWindows: []string{"/c", "SLEEP 4"},
 			cmdOther:   "sleep",
 			argOther:   []string{"4"},
 		},

--- a/utils/subprocess/executor_test.go
+++ b/utils/subprocess/executor_test.go
@@ -599,7 +599,8 @@ func TestWait(t *testing.T) {
 	t.Run("Valid subprocess returns no error", func(t *testing.T) {
 		var cmd *exec.Cmd
 		if platform.IsWindows() {
-			cmd = exec.Command("cmd", "/c", fmt.Sprintf("ping -n 2 -w %v localhost > nul", (time.Second).Milliseconds())) // See https://stackoverflow.com/a/79268314/45375 //nolint: gosec G204: Subprocess launched with a potential tainted input or cmd arguments
+			// See https://stackoverflow.com/a/79268314/45375
+			cmd = exec.Command("cmd", "/c", fmt.Sprintf("ping -n 2 -w %v localhost > nul", (time.Second).Milliseconds())) //nolint:gosec // Causes G204: Subprocess launched with a potential tainted input or cmd arguments
 		} else {
 			cmd = exec.Command("sh", "-c", "sleep 1")
 		}
@@ -628,7 +629,8 @@ func TestWait(t *testing.T) {
 	t.Run("Cancelled context returns error", func(t *testing.T) {
 		var cmd *exec.Cmd
 		if platform.IsWindows() {
-			cmd = exec.Command("cmd", "/c", fmt.Sprintf("ping -n 2 -w %v localhost > nul", (10*time.Second).Milliseconds())) // See https://stackoverflow.com/a/79268314/45375  //nolint: gosec G204: Subprocess launched with a potential tainted input or cmd arguments
+			// See https://stackoverflow.com/a/79268314/45375
+			cmd = exec.Command("cmd", "/c", fmt.Sprintf("ping -n 2 -w %v localhost > nul", (10*time.Second).Milliseconds())) //nolint:gosec // Causes G204: Subprocess launched with a potential tainted input or cmd arguments
 		} else {
 			cmd = exec.Command("sh", "-c", "sleep 10")
 		}


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

Improvements about processes cancellation



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
