### PR TITLE
:bug: `[subprocess]` Improve the error reporting when a process is cancelled

### DIFF
--- a/changes/20250718123400.bugfix
+++ b/changes/20250718123400.bugfix
@@ -1,0 +1,1 @@
+:bug: `[subprocess]` Improve the error reporting when a process is cancelled

--- a/utils/subprocess/supervisor/supervisor.go
+++ b/utils/subprocess/supervisor/supervisor.go
@@ -2,7 +2,6 @@ package supervisor
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -113,7 +112,7 @@ func (s *Supervisor) Run(ctx context.Context) (err error) {
 				if commonerrors.Any(err, commonerrors.ErrCancelled, commonerrors.ErrTimeout) {
 					return err
 				}
-				return fmt.Errorf("%w: error running pre-start hook: %v", commonerrors.ErrUnexpected, err.Error())
+				return commonerrors.WrapError(commonerrors.ErrUnexpected, err, "error running pre-start hook")
 			}
 		}
 
@@ -123,10 +122,10 @@ func (s *Supervisor) Run(ctx context.Context) (err error) {
 			if commonerrors.Any(err, commonerrors.ErrCancelled, commonerrors.ErrTimeout) {
 				return err
 			}
-			return fmt.Errorf("%w: error occurred when creating new command: %v", commonerrors.ErrUnexpected, err.Error())
+			return commonerrors.WrapError(commonerrors.ErrUnexpected, err, "error occurred when creating new command")
 		}
 		if s.cmd == nil {
-			return fmt.Errorf("%w: command was undefined", commonerrors.ErrUndefined)
+			return commonerrors.UndefinedVariable("command to be supervised")
 		}
 
 		g.Go(s.cmd.Execute)
@@ -137,7 +136,7 @@ func (s *Supervisor) Run(ctx context.Context) (err error) {
 				if commonerrors.Any(err, commonerrors.ErrCancelled, commonerrors.ErrTimeout) {
 					return err
 				}
-				return fmt.Errorf("%w: error running post-start hook: %v", commonerrors.ErrUnexpected, err.Error())
+				return commonerrors.WrapError(commonerrors.ErrUnexpected, err, "error running post-start hook")
 			}
 		}
 
@@ -149,7 +148,7 @@ func (s *Supervisor) Run(ctx context.Context) (err error) {
 				if commonerrors.Any(err, commonerrors.ErrCancelled, commonerrors.ErrTimeout) {
 					return err
 				}
-				return fmt.Errorf("%w: error running post-stop hook: %v", commonerrors.ErrUnexpected, err.Error())
+				return commonerrors.WrapError(commonerrors.ErrUnexpected, err, "error running post-stop hook")
 			}
 		}
 


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

 Improve the error reported when a process is cancelled


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
