### PR TITLE
:bug: `proc` In process find, ignore processes that have stopped between listing and matching

### DIFF
--- a/changes/20250730095330.bugfix
+++ b/changes/20250730095330.bugfix
@@ -1,0 +1,1 @@
+:bug: `proc` In process find, ignore processes that have stopped between listing and matching

--- a/utils/proc/find/find_linux.go
+++ b/utils/proc/find/find_linux.go
@@ -29,9 +29,9 @@ func checkProcessMatch(ctx context.Context, fs filesystem.FS, re *regexp.Regexp,
 
 	data, err := fs.ReadFile(procEntry)
 	if err != nil {
-		if commonerrors.CorrespondTo(err, "no bytes were read") {
+		if commonerrors.CorrespondTo(err, "no bytes were read", "no such file or directory") {
 			err = nil
-			return // ignore special descriptors since our cmdline will have content (we still have to check since all files in proc have size zero)
+			return // ignore special descriptors since our cmdline will have content (we still have to check since all files in proc have size zero) as well as processes that have stopped since the listing occurred
 		}
 		err = commonerrors.WrapErrorf(commonerrors.ErrUnexpected, err, "could not read proc entry '%v'", procEntry)
 		return


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

In process find, ignore processes that have stopped between listing and matching

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [x]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
