### PR TITLE
:bug: `filesystem` Unlink files before attempting to remove them in Remove

### DIFF
--- a/changes/20250801093542.bugfix
+++ b/changes/20250801093542.bugfix
@@ -1,0 +1,1 @@
+:bug: `filsystem` Unlink files before attempting to remove them in Remove

--- a/changes/20250801105019.feature
+++ b/changes/20250801105019.feature
@@ -1,0 +1,1 @@
+:sparkles: `commonerrors` Add IgnoreCorrespondTo function

--- a/utils/commonerrors/errors.go
+++ b/utils/commonerrors/errors.go
@@ -255,7 +255,7 @@ func Ignore(target error, ignore ...error) error {
 	return target
 }
 
-// IgnoreCorrespondTo will return nil if the target error matches one of the errors to ignore
+// IgnoreCorrespondTo will return nil if the target error matches one of the descriptions of errors to ignore
 func IgnoreCorrespondTo(target error, ignore ...string) error {
 	if CorrespondTo(target, ignore...) {
 		return nil

--- a/utils/commonerrors/errors.go
+++ b/utils/commonerrors/errors.go
@@ -255,6 +255,14 @@ func Ignore(target error, ignore ...error) error {
 	return target
 }
 
+// IgnoreCorrespondTo will return nil if the target error matches one of the errors to ignore
+func IgnoreCorrespondTo(target error, ignore ...string) error {
+	if CorrespondTo(target, ignore...) {
+		return nil
+	}
+	return target
+}
+
 // IsEmpty states whether an error is empty or not.
 // An error is considered empty if it is `nil` or has no description.
 func IsEmpty(err error) bool {

--- a/utils/commonerrors/errors_test.go
+++ b/utils/commonerrors/errors_test.go
@@ -49,6 +49,13 @@ func TestCorrespondTo(t *testing.T) {
 	assert.True(t, CorrespondTo(fmt.Errorf("%v %v", faker.Sentence(), strings.ToUpper(ErrUndefined.Error())), strings.ToLower(ErrUndefined.Error())))
 }
 
+func TestIgnoreCorrespondTo(t *testing.T) {
+	assert.NoError(t, IgnoreCorrespondTo(errors.New("test"), "test"))
+	assert.NoError(t, IgnoreCorrespondTo(errors.New("test 123"), "test"))
+	assert.Error(t, IgnoreCorrespondTo(errors.New("test 123"), "abc", "def", faker.Word()))
+	assert.NoError(t, IgnoreCorrespondTo(ErrCondition, "condition"))
+}
+
 func TestContextErrorConversion(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	task := func(ctx context.Context) {

--- a/utils/filesystem/extendedosfs.go
+++ b/utils/filesystem/extendedosfs.go
@@ -25,7 +25,8 @@ func (c *ExtendedOsFs) Remove(name string) (err error) {
 	// The following is to ensure sockets are correctly removed
 	// https://stackoverflow.com/questions/16681944/how-to-reliably-unlink-a-unix-domain-socket-in-go-programming-language
 	err = commonerrors.Ignore(ConvertFileSystemError(syscall.Unlink(name)), commonerrors.ErrNotFound)
-	if err != nil && !commonerrors.CorrespondTo(err, "is a directory") {
+	err = commonerrors.IgnoreCorrespondTo(err, "is a directory")
+	if err != nil {
 		return
 	}
 

--- a/utils/filesystem/extendedosfs.go
+++ b/utils/filesystem/extendedosfs.go
@@ -22,13 +22,14 @@ type ExtendedOsFs struct {
 }
 
 func (c *ExtendedOsFs) Remove(name string) (err error) {
-	err = commonerrors.Ignore(ConvertFileSystemError(c.OsFs.Remove(name)), commonerrors.ErrNotFound)
-	if err != nil {
-		return
-	}
 	// The following is to ensure sockets are correctly removed
 	// https://stackoverflow.com/questions/16681944/how-to-reliably-unlink-a-unix-domain-socket-in-go-programming-language
 	err = commonerrors.Ignore(ConvertFileSystemError(syscall.Unlink(name)), commonerrors.ErrNotFound)
+	if err != nil {
+		return
+	}
+
+	err = commonerrors.Ignore(ConvertFileSystemError(c.OsFs.Remove(name)), commonerrors.ErrNotFound)
 	return
 }
 

--- a/utils/filesystem/extendedosfs.go
+++ b/utils/filesystem/extendedosfs.go
@@ -25,7 +25,7 @@ func (c *ExtendedOsFs) Remove(name string) (err error) {
 	// The following is to ensure sockets are correctly removed
 	// https://stackoverflow.com/questions/16681944/how-to-reliably-unlink-a-unix-domain-socket-in-go-programming-language
 	err = commonerrors.Ignore(ConvertFileSystemError(syscall.Unlink(name)), commonerrors.ErrNotFound)
-	if err != nil {
+	if err != nil && !commonerrors.CorrespondTo(err, "is a directory") {
 		return
 	}
 


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Unlink files before attempting to remove them in Remove. This is because for things like socket files the remove will fail if they are linked.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [x]  Additional tests are not required for this change (e.g. documentation update).
