### PR TITLE
:bug: `filsystem` IsFile should return true for special unix files not just regular files

### DIFF
--- a/changes/20250801151058.bugfix
+++ b/changes/20250801151058.bugfix
@@ -1,1 +1,1 @@
-:bug: `filsystem` IsFile should return true for special unix files not just regular files
+:bug: `filesystem` IsFile should return true for special unix files not just regular files

--- a/utils/filesystem/files.go
+++ b/utils/filesystem/files.go
@@ -778,7 +778,7 @@ func (fs *VFS) IsFile(path string) (result bool, err error) {
 	if err != nil {
 		return
 	}
-	result = IsRegularFile(fi) || IsSpecialFile(fi)
+	result = IsRegularFile(fi) || IsSpecialFile(fi) // We want to treat special files as files (otherwise the only distinction is a directory which special files are not)
 	return
 }
 
@@ -789,6 +789,7 @@ func IsRegularFile(fi os.FileInfo) bool {
 	return fi.Mode().IsRegular()
 }
 
+// IsSpecialFile returns true for files that are not regular files. This includes: unix socket files, device files, and named pipes
 func IsSpecialFile(fi os.FileInfo) bool {
 	if fi == nil {
 		return false


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

IsFile should return true for special unix files not just regular files

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
