### PR TITLE
:bug: `proc` Make sure that invalid PIDs are ignored when stopping processes

### DIFF
--- a/changes/20250807104110.bugfix
+++ b/changes/20250807104110.bugfix
@@ -1,0 +1,1 @@
+:bug: `proc` Make sure that invalid PIDs are ignored when stopping processes

--- a/utils/proc/find/find_linux_test.go
+++ b/utils/proc/find/find_linux_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
+	"github.com/ARM-software/golang-utils/utils/filesystem"
 	"github.com/ARM-software/golang-utils/utils/logs"
 	"github.com/ARM-software/golang-utils/utils/logs/logstest"
 	"github.com/ARM-software/golang-utils/utils/subprocess"
@@ -87,4 +88,12 @@ func TestFind(t *testing.T) {
 		assert.Empty(t, processes)
 	})
 
+	t.Run("Exclude invalid", func(t *testing.T) {
+		ctx := context.Background()
+		allProcesses, err := filesystem.Glob(fmt.Sprintf("%v/[0-9]*/%v", procFS, procDataFile))
+		require.NoError(t, err)
+		processes, err := FindProcessByName(ctx, "") // empty name will return all processes that were valid according to the logic (e.g. no invalid names or empty cmdline files)
+		assert.NoError(t, err)
+		assert.LessOrEqual(t, len(processes), len(allProcesses))
+	})
 }


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Make sure that invalid PIDs are ignored when stopping processes

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
