### PR TITLE
:sparkles: [parallelisation] Add an option to collate all the errors found during a function store execution

### DIFF
--- a/changes/20250813180357.feature
+++ b/changes/20250813180357.feature
@@ -1,0 +1,1 @@
+:sparkles: [parallelisation] Add an option to collate all the errors found during a function store execution

--- a/utils/parallelisation/onclose.go
+++ b/utils/parallelisation/onclose.go
@@ -51,6 +51,13 @@ func CloseAll(cs ...io.Closer) error {
 	return group.Close()
 }
 
+// CloseAllAndCollateErrors calls concurrently Close on all io.Closer implementations passed as arguments and returns the errors encountered
+func CloseAllAndCollateErrors(cs ...io.Closer) error {
+	group := NewCloserStoreWithOptions(ExecuteAll, Parallel, JoinErrors)
+	group.RegisterFunction(cs...)
+	return group.Close()
+}
+
 // CloseAllWithContext is similar to CloseAll but can be controlled using a context.
 func CloseAllWithContext(ctx context.Context, cs ...io.Closer) error {
 	group := NewCloserStore(false)
@@ -58,9 +65,23 @@ func CloseAllWithContext(ctx context.Context, cs ...io.Closer) error {
 	return group.Execute(ctx)
 }
 
+// CloseAllWithContextAndCollateErrors is similar to CloseAllAndCollateErrors but can be controlled using a context.
+func CloseAllWithContextAndCollateErrors(ctx context.Context, cs ...io.Closer) error {
+	group := NewCloserStoreWithOptions(ExecuteAll, Parallel, JoinErrors)
+	group.RegisterFunction(cs...)
+	return group.Execute(ctx)
+}
+
 // CloseAllFunc calls concurrently all Close functions passed as arguments and returns the first error encountered
 func CloseAllFunc(cs ...CloseFunc) error {
 	group := NewCloseFunctionStoreStore(false)
+	group.RegisterFunction(cs...)
+	return group.Close()
+}
+
+// CloseAllFuncAndCollateErrors calls concurrently all Close functions passed as arguments and returns the errors encountered
+func CloseAllFuncAndCollateErrors(cs ...CloseFunc) error {
+	group := NewCloseFunctionStore(ExecuteAll, Parallel, JoinErrors)
 	group.RegisterFunction(cs...)
 	return group.Close()
 }

--- a/utils/parallelisation/onclose_test.go
+++ b/utils/parallelisation/onclose_test.go
@@ -2,6 +2,7 @@ package parallelisation
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,6 +26,16 @@ func TestCloseAll(t *testing.T) {
 		require.NoError(t, CloseAll(closerMock, closerMock, closerMock))
 	})
 
+	t.Run("close and join errors", func(t *testing.T) {
+		ctlr := gomock.NewController(t)
+		defer ctlr.Finish()
+
+		closerMock := mocks.NewMockCloser(ctlr)
+		closerMock.EXPECT().Close().Return(nil).MinTimes(1)
+
+		require.NoError(t, CloseAllAndCollateErrors(closerMock, closerMock, closerMock))
+	})
+
 	t.Run("close with error", func(t *testing.T) {
 		ctlr := gomock.NewController(t)
 		defer ctlr.Finish()
@@ -36,10 +47,27 @@ func TestCloseAll(t *testing.T) {
 		errortest.AssertError(t, CloseAll(closerMock, closerMock, closerMock), closeError)
 	})
 
+	t.Run("close with errors", func(t *testing.T) {
+		ctlr := gomock.NewController(t)
+		defer ctlr.Finish()
+		closeError := commonerrors.ErrUnexpected
+
+		closerMock := mocks.NewMockCloser(ctlr)
+		closerMock.EXPECT().Close().Return(closeError).MinTimes(1)
+
+		errortest.AssertError(t, CloseAllAndCollateErrors(closerMock, closerMock, closerMock), closeError)
+	})
+
 	t.Run("close with 1 error", func(t *testing.T) {
 		closeError := commonerrors.ErrUnexpected
 
 		errortest.AssertError(t, CloseAllFunc(func() error { return nil }, func() error { return nil }, func() error { return closeError }, func() error { return nil }), closeError)
+	})
+
+	t.Run("close with 1 error but error collection", func(t *testing.T) {
+		closeError := commonerrors.ErrUnexpected
+
+		errortest.AssertError(t, CloseAllFuncAndCollateErrors(func() error { return nil }, func() error { return nil }, func() error { return closeError }, func() error { return nil }), closeError)
 	})
 
 }
@@ -98,39 +126,63 @@ func TestCancelOnClose(t *testing.T) {
 	})
 }
 
-func TestStopOnFirstError(t *testing.T) {
-	t.Run("sequentially", func(t *testing.T) {
-		closeStore := NewCloseFunctionStore(StopOnFirstError, Sequential)
-		ctx1, cancel1 := context.WithCancel(context.Background())
-		closeStore.RegisterCloseFunction(func() error { cancel1(); return DetermineContextError(ctx1) })
-		ctx2, cancel2 := context.WithCancel(context.Background())
-		closeStore.RegisterCloseFunction(func() error { cancel2(); return DetermineContextError(ctx2) })
-		ctx3, cancel3 := context.WithCancel(context.Background())
-		closeStore.RegisterCloseFunction(func() error { cancel3(); return DetermineContextError(ctx3) })
-		assert.Equal(t, 3, closeStore.Len())
-		require.NoError(t, DetermineContextError(ctx1))
-		require.NoError(t, DetermineContextError(ctx2))
-		require.NoError(t, DetermineContextError(ctx3))
-		errortest.AssertError(t, closeStore.Close(), commonerrors.ErrCancelled)
-		errortest.AssertError(t, DetermineContextError(ctx1), commonerrors.ErrCancelled)
-		assert.NoError(t, DetermineContextError(ctx2))
-		assert.NoError(t, DetermineContextError(ctx3))
-	})
-	t.Run("reverse", func(t *testing.T) {
-		closeStore := NewCloseFunctionStore(StopOnFirstError, SequentialInReverse)
-		ctx1, cancel1 := context.WithCancel(context.Background())
-		closeStore.RegisterCloseFunction(func() error { cancel1(); return DetermineContextError(ctx1) })
-		ctx2, cancel2 := context.WithCancel(context.Background())
-		closeStore.RegisterCloseFunction(func() error { cancel2(); return DetermineContextError(ctx2) })
-		ctx3, cancel3 := context.WithCancel(context.Background())
-		closeStore.RegisterCloseFunction(func() error { cancel3(); return DetermineContextError(ctx3) })
-		assert.Equal(t, 3, closeStore.Len())
-		require.NoError(t, DetermineContextError(ctx1))
-		require.NoError(t, DetermineContextError(ctx2))
-		require.NoError(t, DetermineContextError(ctx3))
-		errortest.AssertError(t, closeStore.Close(), commonerrors.ErrCancelled)
-		assert.NoError(t, DetermineContextError(ctx1))
-		assert.NoError(t, DetermineContextError(ctx2))
-		errortest.AssertError(t, DetermineContextError(ctx3), commonerrors.ErrCancelled)
-	})
+func TestSequentialExecution(t *testing.T) {
+	tests := []struct {
+		option StoreOption
+	}{
+		{StopOnFirstError},
+		{JoinErrors},
+	}
+	for i := range tests {
+		test := tests[i]
+		t.Run(fmt.Sprintf("%v-%#v", i, test.option), func(t *testing.T) {
+			opt := test.option(&StoreOptions{})
+			t.Run("sequentially", func(t *testing.T) {
+				closeStore := NewCloseFunctionStore(test.option, Sequential)
+				ctx1, cancel1 := context.WithCancel(context.Background())
+				closeStore.RegisterCloseFunction(func() error { cancel1(); return DetermineContextError(ctx1) })
+				ctx2, cancel2 := context.WithCancel(context.Background())
+				closeStore.RegisterCloseFunction(func() error { cancel2(); return DetermineContextError(ctx2) })
+				ctx3, cancel3 := context.WithCancel(context.Background())
+				closeStore.RegisterCloseFunction(func() error { cancel3(); return DetermineContextError(ctx3) })
+				assert.Equal(t, 3, closeStore.Len())
+				require.NoError(t, DetermineContextError(ctx1))
+				require.NoError(t, DetermineContextError(ctx2))
+				require.NoError(t, DetermineContextError(ctx3))
+
+				errortest.AssertError(t, closeStore.Close(), commonerrors.ErrCancelled)
+				errortest.AssertError(t, DetermineContextError(ctx1), commonerrors.ErrCancelled)
+				if opt.stopOnFirstError {
+					assert.NoError(t, DetermineContextError(ctx2))
+					assert.NoError(t, DetermineContextError(ctx3))
+				} else {
+					errortest.AssertError(t, DetermineContextError(ctx2), commonerrors.ErrCancelled)
+					errortest.AssertError(t, DetermineContextError(ctx3), commonerrors.ErrCancelled)
+				}
+
+			})
+			t.Run("reverse", func(t *testing.T) {
+				closeStore := NewCloseFunctionStore(test.option, SequentialInReverse)
+				ctx1, cancel1 := context.WithCancel(context.Background())
+				closeStore.RegisterCloseFunction(func() error { cancel1(); return DetermineContextError(ctx1) })
+				ctx2, cancel2 := context.WithCancel(context.Background())
+				closeStore.RegisterCloseFunction(func() error { cancel2(); return DetermineContextError(ctx2) })
+				ctx3, cancel3 := context.WithCancel(context.Background())
+				closeStore.RegisterCloseFunction(func() error { cancel3(); return DetermineContextError(ctx3) })
+				assert.Equal(t, 3, closeStore.Len())
+				require.NoError(t, DetermineContextError(ctx1))
+				require.NoError(t, DetermineContextError(ctx2))
+				require.NoError(t, DetermineContextError(ctx3))
+				errortest.AssertError(t, closeStore.Close(), commonerrors.ErrCancelled)
+				if opt.stopOnFirstError {
+					assert.NoError(t, DetermineContextError(ctx1))
+					assert.NoError(t, DetermineContextError(ctx2))
+				} else {
+					errortest.AssertError(t, DetermineContextError(ctx1), commonerrors.ErrCancelled)
+					errortest.AssertError(t, DetermineContextError(ctx2), commonerrors.ErrCancelled)
+				}
+				errortest.AssertError(t, DetermineContextError(ctx3), commonerrors.ErrCancelled)
+			})
+		})
+	}
 }


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description
Added an option so that it is possible to join all errors during the execution of functions of a store

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
