### PR TITLE
:bug: [parallelisation] Make sure options are not overridden for a close store

### DIFF
--- a/changes/20250814104556.bugfix
+++ b/changes/20250814104556.bugfix
@@ -1,0 +1,1 @@
+:bug: [parallelisation] Make sure options are not overridden for a close store

--- a/utils/parallelisation/onclose.go
+++ b/utils/parallelisation/onclose.go
@@ -29,7 +29,7 @@ func NewCloserStore(stopOnFirstError bool) *CloserStore {
 	if stopOnFirstError {
 		option = StopOnFirstError
 	}
-	return NewCloserStoreWithOptions(option, Parallel)
+	return NewCloserStoreWithOptions(option, Parallel, RetainAfterExecution)
 }
 
 // NewCloserStoreWithOptions returns a store of io.Closer object which will all be closed on Close(). The first error received if any will be returned
@@ -40,7 +40,7 @@ func NewCloserStoreWithOptions(opts ...StoreOption) *CloserStore {
 				return commonerrors.UndefinedVariable("closer object")
 			}
 			return closerObj.Close()
-		}, append(opts, RetainAfterExecution)...),
+		}, opts...),
 	}
 }
 
@@ -125,7 +125,7 @@ func NewCloseFunctionStore(options ...StoreOption) *CloseFunctionStore {
 	return &CloseFunctionStore{
 		store: *newFunctionStore[CloseFunc](func(_ context.Context, closerObj CloseFunc) error {
 			return closerObj()
-		}, append(options, RetainAfterExecution)...),
+		}, options...),
 	}
 }
 
@@ -141,5 +141,5 @@ func NewConcurrentCloseFunctionStore(stopOnFirstError bool) *CloseFunctionStore 
 	if stopOnFirstError {
 		option = StopOnFirstError
 	}
-	return NewCloseFunctionStore(option, Parallel)
+	return NewCloseFunctionStore(option, Parallel, RetainAfterExecution)
 }


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description
- close stores require to be used slightly differently to what they used to.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
