### PR TITLE
:bug: `subprocess` Make sure that cancellation can't enter deadlock

### DIFF
--- a/changes/20250818160732.bugfix
+++ b/changes/20250818160732.bugfix
@@ -1,0 +1,1 @@
+:bug: `subprocess` Make sure that cancellation can't enter deadlock


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Make sure that cancellation can't enter deadlock

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
