### PR TITLE
:bug: [parallelisation] Revert the behaviour change of close stores i…

### DIFF
--- a/changes/20250828111444.bugfix
+++ b/changes/20250828111444.bugfix
@@ -1,0 +1,1 @@
+:bug: [parallelisation] Revert the behaviour change of close stores introduced in recent release

--- a/utils/parallelisation/group.go
+++ b/utils/parallelisation/group.go
@@ -52,6 +52,13 @@ func (o *StoreOptions) MergeWithOptions(opt ...StoreOption) *StoreOptions {
 	return o.Merge(WithOptions(opt...))
 }
 
+func (o *StoreOptions) Apply(opt StoreOption) *StoreOptions {
+	if opt == nil {
+		return o
+	}
+	return opt(o)
+}
+
 func (o *StoreOptions) Overwrite(opts *StoreOptions) *StoreOptions {
 	return o.Default().Merge(opts)
 }

--- a/utils/parallelisation/onclose.go
+++ b/utils/parallelisation/onclose.go
@@ -25,11 +25,12 @@ func (s *CloserStore) Len() int {
 
 // NewCloserStore returns a store of io.Closer object which will all be closed concurrently on Close(). The first error received will be returned
 func NewCloserStore(stopOnFirstError bool) *CloserStore {
-	option := ExecuteAll
-	if stopOnFirstError {
-		option = StopOnFirstError
-	}
-	return NewCloserStoreWithOptions(option, Parallel, OnlyOnce, RetainAfterExecution)
+	return NewCloserStoreWithOptions(closeDefaultOptions(stopOnFirstError).Options()...)
+}
+
+// NewCloserOnceStore is similar to NewCloserStore but only close the closers once.
+func NewCloserOnceStore(stopOnFirstError bool) *CloserStore {
+	return NewCloserStoreWithOptions(closeDefaultOptions(stopOnFirstError).Apply(OnlyOnce).Options()...)
 }
 
 // NewCloserStoreWithOptions returns a store of io.Closer object which will all be closed on Close(). The first error received if any will be returned
@@ -177,11 +178,22 @@ func NewCloseFunctionStoreStore(stopOnFirstError bool) *CloseFunctionStore {
 // NewConcurrentCloseFunctionStore returns a store closing functions which will all be called concurrently on Close(). The first error received will be returned.
 // Prefer using NewCloseFunctionStore where possible
 func NewConcurrentCloseFunctionStore(stopOnFirstError bool) *CloseFunctionStore {
-	option := ExecuteAll
+	return NewCloseFunctionStore(closeDefaultOptions(stopOnFirstError).Options()...)
+}
+
+// NewConcurrentCloseOnceFunctionStore returns a store closing functions once on Close(). It is similar to NewConcurrentCloseFunctionStore otherwise.
+func NewConcurrentCloseOnceFunctionStore(stopOnFirstError bool) *CloseFunctionStore {
+	return NewCloseFunctionStore(closeDefaultOptions(stopOnFirstError).Apply(OnlyOnce).Options()...)
+}
+
+func closeDefaultOptions(stopOnFirstError bool) *StoreOptions {
+	opts := WithOptions(Parallel, RetainAfterExecution)
 	if stopOnFirstError {
-		option = StopOnFirstError
+		opts = opts.Apply(StopOnFirstError)
+	} else {
+		opts = opts.Apply(ExecuteAll)
 	}
-	return NewCloseFunctionStore(option, Parallel, RetainAfterExecution, OnlyOnce)
+	return opts
 }
 
 // NewCloseOnceGroup is the same as NewCloseFunctionStore but ensures any closing functions are only executed once.


### PR DESCRIPTION
…ntroduced in recent release

<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

Fix a change of behaviour



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
