### PR TITLE
:sparkles: `[parallelisation]` Define a transformation group

### DIFF
--- a/changes/20250905171217.feature
+++ b/changes/20250905171217.feature
@@ -1,0 +1,1 @@
+:sparkles: `[parallelisation]` Define a transformation group

--- a/changes/20250908111211.feature
+++ b/changes/20250908111211.feature
@@ -1,0 +1,1 @@
+:sparkles: `[collection]` Added a `Range` function to populate slices of integers

--- a/utils/collection/range.go
+++ b/utils/collection/range.go
@@ -1,0 +1,33 @@
+package collection
+
+import "github.com/ARM-software/golang-utils/utils/field"
+
+func sign(x int) int {
+	if x < 0 {
+		return -1
+	}
+	return 1
+}
+
+// Range returns a slice of integers similar to Python's built-in range().
+// https://docs.python.org/2/library/functions.html#range
+//
+//	Note: The stop value is always exclusive.
+func Range(start, stop int, step *int) []int {
+	s := field.OptionalInt(step, 1)
+	if s == 0 {
+		return []int{}
+	}
+
+	// Compute length
+	length := 0
+	if (s > 0 && start < stop) || (s < 0 && start > stop) {
+		length = (stop - start + s - sign(s)) / s
+	}
+
+	result := make([]int, length)
+	for i, v := 0, start; i < length; i, v = i+1, v+s {
+		result[i] = v
+	}
+	return result
+}

--- a/utils/collection/range_test.go
+++ b/utils/collection/range_test.go
@@ -1,0 +1,40 @@
+package collection
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ARM-software/golang-utils/utils/field"
+)
+
+func TestRange(t *testing.T) {
+	tests := []struct {
+		start    int
+		stop     int
+		step     *int
+		expected []int
+	}{
+
+		{2, 5, nil, []int{2, 3, 4}},
+		{5, 2, nil, []int{}}, // empty, since stop < start
+		{2, 10, field.ToOptionalInt(2), []int{2, 4, 6, 8}},
+		{0, 10, field.ToOptionalInt(3), []int{0, 3, 6, 9}},
+		{1, 10, field.ToOptionalInt(3), []int{1, 4, 7}},
+		{10, 2, field.ToOptionalInt(-2), []int{10, 8, 6, 4}},
+		{5, -1, field.ToOptionalInt(-1), []int{5, 4, 3, 2, 1, 0}},
+		{0, -5, field.ToOptionalInt(-2), []int{0, -2, -4}},
+		{0, 5, nil, []int{0, 1, 2, 3, 4}},
+		{0, 5, field.ToOptionalInt(0), []int{}},
+		{2, 2, field.ToOptionalInt(1), []int{}},
+		{2, 2, field.ToOptionalInt(-1), []int{}},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(fmt.Sprintf("[%v,%v,%v]", test.start, test.stop, test.step), func(t *testing.T) {
+			assert.Equal(t, test.expected, Range(test.start, test.stop, test.step))
+		})
+	}
+}

--- a/utils/collection/search.go
+++ b/utils/collection/search.go
@@ -71,8 +71,10 @@ func AnyFunc[S ~[]E, E any](s S, f func(E) bool) bool {
 	return conditions.Any()
 }
 
+type FilterFunc[E any] func(E) bool
+
 // Filter returns a new slice that contains elements from the input slice which return true when they’re passed as a parameter to the provided filtering function f.
-func Filter[S ~[]E, E any](s S, f func(E) bool) (result S) {
+func Filter[S ~[]E, E any](s S, f FilterFunc[E]) (result S) {
 	result = make(S, 0, len(s))
 
 	for i := range s {
@@ -84,8 +86,16 @@ func Filter[S ~[]E, E any](s S, f func(E) bool) (result S) {
 	return result
 }
 
+type MapFunc[T1, T2 any] func(T1) T2
+
+func IdentityMapFunc[T any]() MapFunc[T, T] {
+	return func(i T) T {
+		return i
+	}
+}
+
 // Map creates a new slice and populates it with the results of calling the provided function on every element in input slice.
-func Map[T1 any, T2 any](s []T1, f func(T1) T2) (result []T2) {
+func Map[T1 any, T2 any](s []T1, f MapFunc[T1, T2]) (result []T2) {
 	result = make([]T2, len(s))
 
 	for i := range s {
@@ -97,12 +107,14 @@ func Map[T1 any, T2 any](s []T1, f func(T1) T2) (result []T2) {
 
 // Reject is the opposite of Filter and returns the elements of collection for which the filtering function f returns false.
 // This is functionally equivalent to slices.DeleteFunc but it returns a new slice.
-func Reject[S ~[]E, E any](s S, f func(E) bool) S {
+func Reject[S ~[]E, E any](s S, f FilterFunc[E]) S {
 	return Filter(s, func(e E) bool { return !f(e) })
 }
 
+type ReduceFunc[T1, T2 any] func(T2, T1) T2
+
 // Reduce runs a reducer function f over all elements in the array, in ascending-index order, and accumulates them into a single value.
-func Reduce[T1, T2 any](s []T1, accumulator T2, f func(T2, T1) T2) (result T2) {
+func Reduce[T1, T2 any](s []T1, accumulator T2, f ReduceFunc[T1, T2]) (result T2) {
 	result = accumulator
 	for i := range s {
 		result = f(result, s[i])

--- a/utils/parallelisation/transform.go
+++ b/utils/parallelisation/transform.go
@@ -1,0 +1,121 @@
+package parallelisation
+
+import (
+	"context"
+
+	"go.uber.org/atomic"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/field"
+)
+
+type TransformFunc[I any, O any] func(context.Context, I) (output O, success bool, err error)
+
+type results[O any] struct {
+	terminated *atomic.Bool
+	r          chan O
+}
+
+func (r *results[O]) Append(o O) {
+	if !r.terminated.Load() {
+		r.r <- o
+	}
+}
+
+func (r *results[O]) Results(ctx context.Context) (slice []O, err error) {
+	if !r.terminated.Swap(true) {
+		close(r.r)
+	}
+	err = DetermineContextError(ctx)
+	if err != nil {
+		return
+	}
+	slice = make([]O, 0, len(r.r))
+	for output := range r.r {
+		err = DetermineContextError(ctx)
+		if err != nil {
+			return
+		}
+		slice = append(slice, output)
+	}
+	return
+}
+
+func newResults[O any](numberOfInput *int) *results[O] {
+	i := field.OptionalInt(numberOfInput, 0)
+	var channel chan O
+	if i <= 0 {
+		channel = make(chan O)
+	} else {
+		channel = make(chan O, i)
+	}
+
+	return &results[O]{
+		terminated: atomic.NewBool(false),
+		r:          channel,
+	}
+}
+
+type TransformGroup[I any, O any] struct {
+	ExecutionGroup[I]
+	results *atomic.Pointer[results[O]]
+}
+
+func (g *TransformGroup[I, O]) appendResult(o O) {
+	r := g.results.Load()
+	if r != nil {
+		r.Append(o)
+	}
+}
+
+// Inputs registers inputs to transform.
+func (g *TransformGroup[I, O]) Inputs(ctx context.Context, i ...I) error {
+	for j := range i {
+		err := DetermineContextError(ctx)
+		if err != nil {
+			return err
+		}
+		g.RegisterFunction(i[j])
+	}
+	return nil
+}
+
+// Outputs returns any input which have been transformed when the Transform function was called.
+func (g *TransformGroup[I, O]) Outputs(ctx context.Context) ([]O, error) {
+	r := g.results.Load()
+	if r == nil {
+		return nil, commonerrors.UndefinedVariable("results")
+	}
+	return r.Results(ctx)
+}
+
+// Transform actually performs the transformation
+func (g *TransformGroup[I, O]) Transform(ctx context.Context) error {
+	g.results.Store(newResults[O](field.ToOptionalInt(g.Len())))
+	return g.ExecutionGroup.Execute(ctx)
+}
+
+// NewTransformGroup returns a group transforming inputs into outputs.
+// To register inputs, call the Input function
+// To perform the transformation of inputs, then call Transform
+// To retrieve the output, then call Output
+func NewTransformGroup[I any, O any](transform TransformFunc[I, O], options ...StoreOption) *TransformGroup[I, O] {
+	g := &TransformGroup[I, O]{
+		results: atomic.NewPointer[results[O]](newResults[O](nil)),
+	}
+	g.ExecutionGroup = *NewExecutionGroup[I](func(fCtx context.Context, i I) error {
+		err := DetermineContextError(fCtx)
+		if err != nil {
+			return err
+		}
+		o, success, err := transform(fCtx, i)
+		if err != nil {
+			return commonerrors.WrapErrorf(commonerrors.ErrUnexpected, err, "an error occurred whilst handling an input [%+v]", i)
+		}
+		if success {
+			g.appendResult(o)
+		}
+		return nil
+	}, options...)
+	return g
+}

--- a/utils/parallelisation/transform_test.go
+++ b/utils/parallelisation/transform_test.go
@@ -7,11 +7,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	"github.com/ARM-software/golang-utils/utils/collection"
 )
 
 func TestNewTransformGroup(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	tr := func(ctx context.Context, i string) (o int, success bool, err error) {
 		err = DetermineContextError(ctx)
 		if err != nil {

--- a/utils/parallelisation/transform_test.go
+++ b/utils/parallelisation/transform_test.go
@@ -1,0 +1,72 @@
+package parallelisation
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ARM-software/golang-utils/utils/collection"
+)
+
+func TestNewTransformGroup(t *testing.T) {
+	tr := func(ctx context.Context, i string) (o int, success bool, err error) {
+		err = DetermineContextError(ctx)
+		if err != nil {
+			return
+		}
+		o, err = strconv.Atoi(i)
+		if err == nil {
+			success = true
+		}
+		return
+	}
+	g := NewTransformGroup[string, int](tr, RetainAfterExecution, Parallel)
+	assert.Zero(t, g.Len())
+	o, err := g.Outputs(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, o)
+	numberOfInput := 50
+	in := collection.Range(0, numberOfInput, nil)
+	in2 := make([]string, numberOfInput)
+	for i := 0; i < numberOfInput; i++ {
+		in2[i] = strconv.Itoa(i)
+	}
+	err = g.Inputs(context.Background(), in2...)
+	require.NoError(t, err)
+	assert.Equal(t, numberOfInput, g.Len())
+	o, err = g.Outputs(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, o)
+	err = g.Transform(context.Background())
+	require.NoError(t, err)
+	o, err = g.Outputs(context.Background())
+	require.NoError(t, err)
+	assert.ElementsMatch(t, in, o)
+	o, err = g.OrderedOutputs(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, o)
+	err = g.Transform(context.Background())
+	require.NoError(t, err)
+	o, err = g.OrderedOutputs(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, in, o)
+	err = g.Inputs(context.Background(), in2...)
+	require.NoError(t, err)
+	assert.Equal(t, 2*numberOfInput, g.Len())
+	o, err = g.Outputs(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, o)
+	err = g.Transform(context.Background())
+	require.NoError(t, err)
+	o, err = g.Outputs(context.Background())
+	require.NoError(t, err)
+	assert.ElementsMatch(t, append(in, in...), o)
+	err = g.Transform(context.Background())
+	require.NoError(t, err)
+	o, err = g.OrderedOutputs(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, append(in, in...), o)
+}

--- a/utils/signing/signing_test.go
+++ b/utils/signing/signing_test.go
@@ -37,7 +37,7 @@ func TestSigning(t *testing.T) {
 		signature, err := signer.Sign(message)
 		require.NoError(t, err)
 
-		ok, err := signer.Verify([]byte(faker.Word()), signature)
+		ok, err := signer.Verify([]byte(faker.Word()+faker.Word()), signature)
 		require.NoError(t, err)
 		assert.False(t, ok)
 	})
@@ -48,7 +48,7 @@ func TestSigning(t *testing.T) {
 		signer, err := NewEd25519SignerFromSeed(faker.Word())
 		require.NoError(t, err)
 
-		wrongSignature, err := signer.Sign([]byte(faker.Word()))
+		wrongSignature, err := signer.Sign([]byte(faker.Word() + faker.Word()))
 		require.NoError(t, err)
 
 		ok, err := signer.Verify(message, wrongSignature)


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

- Add a transform group
- reuse groups to define worker pools



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
