### PR TITLE
:sparkles: `subprocess` Add support for overriding the stdin/stdout/stderr of a process when running it with subprocess.Execute

### DIFF
--- a/changes/20250911130716.feature
+++ b/changes/20250911130716.feature
@@ -1,0 +1,1 @@
+:sparkles: `subprocess` Add support for overriding the stdin/stdout/stderr of a process when running it with subprocess.Execute


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Add support for overriding the stdin/stdout/stderr of a process when running it with subprocess.Execute

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
