### PR TITLE
:bug: `[commonerrors]` Ensure the wrapping of an already wrapped error does not result in message duplication

### DIFF
--- a/changes/20250911133122.bugfix
+++ b/changes/20250911133122.bugfix
@@ -1,0 +1,1 @@
+:bug: `[commonerrors]` Ensure the wrapping of an already wrapped error does not result in message duplication such as `unknown: unknown: blah` or `unexpected: unexpected: blah`

--- a/utils/commonerrors/errors.go
+++ b/utils/commonerrors/errors.go
@@ -389,6 +389,10 @@ func WrapError(targetError, originalError error, msg string) error {
 	} else {
 		cleansedMsg := strings.TrimSpace(msg)
 		if cleansedMsg == "" {
+			if Any(tErr, originalError) {
+				// The error is already wrapped and of the same type.
+				return originalError
+			}
 			return New(tErr, originalError.Error())
 		} else {
 			return Errorf(

--- a/utils/commonerrors/errors_test.go
+++ b/utils/commonerrors/errors_test.go
@@ -272,4 +272,5 @@ func TestString(t *testing.T) {
 	assert.Equal(t, "unsupported: not found", WrapError(ErrUnsupported, ErrNotFound, "").Error())
 	assert.Equal(t, "unknown: test: unsupported", WrapError(nil, ErrUnsupported, "test").Error())
 	assert.Equal(t, "unsupported: test 56: not found", WrapErrorf(ErrUnsupported, ErrNotFound, "test %v", 56).Error())
+	assert.Equal(t, "unsupported: test", WrapError(ErrUnsupported, Newf(ErrUnsupported, "test"), "").Error())
 }


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

- fix error message for wrapped errors

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
