### PR TITLE
✨ Add support for specifying the directory in subprocess commands

### DIFF
--- a/changes/20260422120133.feature
+++ b/changes/20260422120133.feature
@@ -1,0 +1,1 @@
+:sparkles: Add support for specifying the directory in subprocess commands

--- a/utils/subprocess/command_wrapper.go
+++ b/utils/subprocess/command_wrapper.go
@@ -128,6 +128,7 @@ type command struct {
 	loggers    logs.Loggers
 	cmdWrapper cmdWrapper
 	io         ICommandIO
+	dir        string
 }
 
 func (c *command) createCommand(cmdCtx context.Context) *exec.Cmd {
@@ -140,6 +141,7 @@ func (c *command) createCommand(cmdCtx context.Context) *exec.Cmd {
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = c.io.Register(cmdCtx)
 	cmd.Env = cmd.Environ()
 	cmd.Env = append(cmd.Env, c.env...)
+	cmd.Dir = c.dir
 
 	// for any of our wait checks to work we need to set the group ID to the pid, otherwise the
 	// group ID will be the code that launched it (i.e. the code that calls exec.Cmd.Start). This
@@ -178,7 +180,7 @@ func (c *command) Check() (err error) {
 	return
 }
 
-func newCommand(loggers logs.Loggers, as *commandUtils.CommandAsDifferentUser, env []string, cmd string, args ...string) (osCmd *command) {
+func newCommand(loggers logs.Loggers, as *commandUtils.CommandAsDifferentUser, env []string, dir string, cmd string, args ...string) (osCmd *command) {
 	osCmd = &command{
 		cmd:        cmd,
 		args:       args,
@@ -187,11 +189,12 @@ func newCommand(loggers logs.Loggers, as *commandUtils.CommandAsDifferentUser, e
 		loggers:    loggers,
 		cmdWrapper: cmdWrapper{},
 		io:         NewIOFromLoggers(loggers),
+		dir:        dir,
 	}
 	return
 }
 
-func newCommandWithCustomIO(loggers logs.Loggers, io ICommandIO, as *commandUtils.CommandAsDifferentUser, env []string, cmd string, args ...string) (osCmd *command) {
+func newCommandWithCustomIO(loggers logs.Loggers, io ICommandIO, as *commandUtils.CommandAsDifferentUser, env []string, dir string, cmd string, args ...string) (osCmd *command) {
 	osCmd = &command{
 		cmd:        cmd,
 		args:       args,
@@ -200,6 +203,7 @@ func newCommandWithCustomIO(loggers logs.Loggers, io ICommandIO, as *commandUtil
 		loggers:    loggers,
 		cmdWrapper: cmdWrapper{},
 		io:         io,
+		dir:        dir,
 	}
 	return
 }

--- a/utils/subprocess/command_wrapper_test.go
+++ b/utils/subprocess/command_wrapper_test.go
@@ -56,9 +56,9 @@ func TestCmdRun(t *testing.T) {
 			loggers, err := logs.NewLogrLogger(logstest.NewTestLogger(t), "test")
 			require.NoError(t, err)
 			if platform.IsWindows() {
-				cmd = newCommand(loggers, commandUtils.Me(), nil, test.cmdWindows, test.argWindows...)
+				cmd = newCommand(loggers, commandUtils.Me(), nil, "", test.cmdWindows, test.argWindows...)
 			} else {
-				cmd = newCommand(loggers, commandUtils.Me(), nil, test.cmdOther, test.argOther...)
+				cmd = newCommand(loggers, commandUtils.Me(), nil, "", test.cmdOther, test.argOther...)
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
@@ -94,7 +94,7 @@ func TestCmdRunWithEnv(t *testing.T) {
 		if platform.IsWindows() {
 			cmd = newCommand(loggers, commandUtils.Me(), envTest.envVars, "powershell", "-Command", envTest.cmdWindows)
 		} else {
-			cmd = newCommand(loggers, commandUtils.Me(), envTest.envVars, envTest.cmdOther)
+			cmd = newCommand(loggers, commandUtils.Me(), envTest.envVars, "", envTest.cmdOther)
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
@@ -146,9 +146,9 @@ func TestCmdStartStop(t *testing.T) {
 			require.NoError(t, err)
 
 			if platform.IsWindows() {
-				cmd = newCommand(loggers, commandUtils.Me(), nil, test.cmdWindows, test.argWindows...)
+				cmd = newCommand(loggers, commandUtils.Me(), nil, "", test.cmdWindows, test.argWindows...)
 			} else {
-				cmd = newCommand(loggers, commandUtils.Me(), nil, test.cmdOther, test.argOther...)
+				cmd = newCommand(loggers, commandUtils.Me(), nil, "", test.cmdOther, test.argOther...)
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()

--- a/utils/subprocess/executor.go
+++ b/utils/subprocess/executor.go
@@ -74,11 +74,7 @@ func newSubProcess(ctx context.Context, loggers logs.Loggers, io ICommandIO, env
 	return
 }
 
-func newPlainSubProcess(ctx context.Context, loggers logs.Loggers, env []string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (p *Subprocess, err error) {
-	return newPlainSubProcessWithDir(ctx, loggers, env, as, "", cmd, args...)
-}
-
-func newPlainSubProcessWithDir(ctx context.Context, loggers logs.Loggers, env []string, as *commandUtils.CommandAsDifferentUser, dir string, cmd string, args ...string) (p *Subprocess, err error) {
+func newPlainSubProcess(ctx context.Context, loggers logs.Loggers, env []string, as *commandUtils.CommandAsDifferentUser, dir string, cmd string, args ...string) (p *Subprocess, err error) {
 	p = new(Subprocess)
 	err = p.setup(ctx, loggers, nil, env, false, "", "", "", as, dir, cmd, args...)
 	return
@@ -277,7 +273,7 @@ func OutputAsWithEnvironmentWithDir(ctx context.Context, loggers logs.Loggers, a
 	if err != nil {
 		return
 	}
-	p, err := newPlainSubProcessWithDir(ctx, mLoggers, additionalEnvVars, as, dir, cmd, args...)
+	p, err := newPlainSubProcess(ctx, mLoggers, additionalEnvVars, as, dir, cmd, args...)
 	if err != nil {
 		return
 	}

--- a/utils/subprocess/executor.go
+++ b/utils/subprocess/executor.go
@@ -29,76 +29,139 @@ type Subprocess struct {
 
 // New creates a subprocess description.
 func New(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (*Subprocess, error) {
-	return NewWithEnvironment(ctx, loggers, nil, messageOnStart, messageOnSuccess, messageOnFailure, cmd, args...)
+	return NewWithDir(ctx, loggers, messageOnStart, messageOnSuccess, messageOnFailure, "", cmd, args...)
+}
+
+// NewWithDir creates a subprocess description with a working directory.
+func NewWithDir(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, dir string, cmd string, args ...string) (*Subprocess, error) {
+	return NewWithEnvironmentWithDir(ctx, loggers, nil, messageOnStart, messageOnSuccess, messageOnFailure, dir, cmd, args...)
 }
 
 // NewWithEnvironment creates a subprocess description. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
 func NewWithEnvironment(ctx context.Context, loggers logs.Loggers, additionalEnvVars []string, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (p *Subprocess, err error) {
-	return NewWithEnvironmentWithIO(ctx, loggers, nil, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, cmd, args...)
+	return NewWithEnvironmentWithDir(ctx, loggers, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, "", cmd, args...)
+}
+
+// NewWithEnvironmentWithDir creates a subprocess description with a working directory. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
+func NewWithEnvironmentWithDir(ctx context.Context, loggers logs.Loggers, additionalEnvVars []string, messageOnStart string, messageOnSuccess, messageOnFailure string, dir string, cmd string, args ...string) (p *Subprocess, err error) {
+	return NewWithEnvironmentWithIOWithDir(ctx, loggers, nil, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, dir, cmd, args...)
 }
 
 // NewWithIO creates a subprocess description with overridden stdin/stdout/stderr.
 func NewWithIO(ctx context.Context, loggers logs.Loggers, io ICommandIO, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (*Subprocess, error) {
-	return NewWithEnvironmentWithIO(ctx, loggers, io, nil, messageOnStart, messageOnSuccess, messageOnFailure, cmd, args...)
+	return NewWithIOWithDir(ctx, loggers, io, messageOnStart, messageOnSuccess, messageOnFailure, "", cmd, args...)
+}
+
+// NewWithIOWithDir creates a subprocess description with a working directory and overridden stdin/stdout/stderr.
+func NewWithIOWithDir(ctx context.Context, loggers logs.Loggers, io ICommandIO, messageOnStart string, messageOnSuccess, messageOnFailure string, dir string, cmd string, args ...string) (*Subprocess, error) {
+	return NewWithEnvironmentWithIOWithDir(ctx, loggers, io, nil, messageOnStart, messageOnSuccess, messageOnFailure, dir, cmd, args...)
 }
 
 // NewWithEnvironmentWithIO creates a subprocess description with overridden stdin/stdout/stderr. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
 func NewWithEnvironmentWithIO(ctx context.Context, loggers logs.Loggers, io ICommandIO, additionalEnvVars []string, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (p *Subprocess, err error) {
-	p, err = newSubProcess(ctx, loggers, io, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, commandUtils.Me(), cmd, args...)
+	return NewWithEnvironmentWithIOWithDir(ctx, loggers, io, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, "", cmd, args...)
+}
+
+// NewWithEnvironmentWithIOWithDir creates a subprocess description with a working directory and overridden stdin/stdout/stderr. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
+func NewWithEnvironmentWithIOWithDir(ctx context.Context, loggers logs.Loggers, io ICommandIO, additionalEnvVars []string, messageOnStart string, messageOnSuccess, messageOnFailure string, dir string, cmd string, args ...string) (p *Subprocess, err error) {
+	p, err = newSubProcess(ctx, loggers, io, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, commandUtils.Me(), dir, cmd, args...)
 	return
 }
 
-// newSubProcess creates a subprocess description with custom IO
-func newSubProcess(ctx context.Context, loggers logs.Loggers, io ICommandIO, env []string, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (p *Subprocess, err error) {
+func newSubProcess(ctx context.Context, loggers logs.Loggers, io ICommandIO, env []string, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, dir string, cmd string, args ...string) (p *Subprocess, err error) {
 	p = new(Subprocess)
-	err = p.SetupAsWithEnvironmentWithCustomIO(ctx, loggers, io, env, messageOnStart, messageOnSuccess, messageOnFailure, as, cmd, args...)
+	err = p.SetupAsWithEnvironmentWithCustomIOWithDir(ctx, loggers, io, env, messageOnStart, messageOnSuccess, messageOnFailure, as, dir, cmd, args...)
 	return
 }
 
 func newPlainSubProcess(ctx context.Context, loggers logs.Loggers, env []string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (p *Subprocess, err error) {
+	return newPlainSubProcessWithDir(ctx, loggers, env, as, "", cmd, args...)
+}
+
+func newPlainSubProcessWithDir(ctx context.Context, loggers logs.Loggers, env []string, as *commandUtils.CommandAsDifferentUser, dir string, cmd string, args ...string) (p *Subprocess, err error) {
 	p = new(Subprocess)
-	err = p.setup(ctx, loggers, nil, env, false, "", "", "", as, cmd, args...)
+	err = p.setup(ctx, loggers, nil, env, false, "", "", "", as, dir, cmd, args...)
 	return
 }
 
 // ExecuteWithEnvironment executes a command (i.e. spawns a subprocess). It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
 func ExecuteWithEnvironment(ctx context.Context, loggers logs.Loggers, additionalEnvVars []string, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (err error) {
-	return ExecuteWithEnvironmentWithIO(ctx, loggers, nil, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, cmd, args...)
+	return ExecuteWithEnvironmentWithDir(ctx, loggers, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, "", cmd, args...)
+}
+
+// ExecuteWithEnvironmentWithDir executes a command (i.e. spawns a subprocess) with a working directory. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
+func ExecuteWithEnvironmentWithDir(ctx context.Context, loggers logs.Loggers, additionalEnvVars []string, messageOnStart string, messageOnSuccess, messageOnFailure string, dir string, cmd string, args ...string) (err error) {
+	return ExecuteWithEnvironmentWithIOWithDir(ctx, loggers, nil, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, dir, cmd, args...)
 }
 
 // StartWithEnvironment starts a command (i.e. spawns a subprocess). It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
 func StartWithEnvironment(ctx context.Context, loggers logs.Loggers, additionalEnvVars []string, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (*Subprocess, error) {
-	return StartWithEnvironmentWithIO(ctx, loggers, nil, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, cmd, args...)
+	return StartWithEnvironmentWithDir(ctx, loggers, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, "", cmd, args...)
+}
+
+// StartWithEnvironmentWithDir starts a command (i.e. spawns a subprocess) with a working directory. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
+func StartWithEnvironmentWithDir(ctx context.Context, loggers logs.Loggers, additionalEnvVars []string, messageOnStart string, messageOnSuccess, messageOnFailure string, dir string, cmd string, args ...string) (*Subprocess, error) {
+	return StartWithEnvironmentWithIOWithDir(ctx, loggers, nil, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, dir, cmd, args...)
 }
 
 // Execute executes a command (i.e. spawns a subprocess).
 func Execute(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) error {
-	return ExecuteWithEnvironment(ctx, loggers, nil, messageOnStart, messageOnSuccess, messageOnFailure, cmd, args...)
+	return ExecuteWithDir(ctx, loggers, messageOnStart, messageOnSuccess, messageOnFailure, "", cmd, args...)
+}
+
+// ExecuteWithDir executes a command (i.e. spawns a subprocess) with a working directory.
+func ExecuteWithDir(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, dir string, cmd string, args ...string) error {
+	return ExecuteWithEnvironmentWithDir(ctx, loggers, nil, messageOnStart, messageOnSuccess, messageOnFailure, dir, cmd, args...)
 }
 
 // Start starts a command (i.e. spawns a subprocess).
 func Start(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (*Subprocess, error) {
-	return StartWithEnvironment(ctx, loggers, nil, messageOnStart, messageOnSuccess, messageOnFailure, cmd, args...)
+	return StartWithDir(ctx, loggers, messageOnStart, messageOnSuccess, messageOnFailure, "", cmd, args...)
+}
+
+// StartWithDir starts a command (i.e. spawns a subprocess) with a working directory.
+func StartWithDir(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, dir string, cmd string, args ...string) (*Subprocess, error) {
+	return StartWithEnvironmentWithDir(ctx, loggers, nil, messageOnStart, messageOnSuccess, messageOnFailure, dir, cmd, args...)
 }
 
 // ExecuteAs executes a command (i.e. spawns a subprocess) as a different user.
 func ExecuteAs(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) error {
-	return ExecuteAsWithEnvironment(ctx, loggers, nil, messageOnStart, messageOnSuccess, messageOnFailure, as, cmd, args...)
+	return ExecuteAsWithDir(ctx, loggers, messageOnStart, messageOnSuccess, messageOnFailure, as, "", cmd, args...)
+}
+
+// ExecuteAsWithDir executes a command (i.e. spawns a subprocess) as a different user with a working directory.
+func ExecuteAsWithDir(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, dir string, cmd string, args ...string) error {
+	return ExecuteAsWithEnvironmentWithDir(ctx, loggers, nil, messageOnStart, messageOnSuccess, messageOnFailure, as, dir, cmd, args...)
 }
 
 // ExecuteAsWithEnvironment executes a command (i.e. spawns a subprocess) as a different user. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
 func ExecuteAsWithEnvironment(ctx context.Context, loggers logs.Loggers, additionalEnvVars []string, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (err error) {
-	return ExecuteAsWithEnvironmentWithIO(ctx, loggers, nil, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, as, cmd, args...)
+	return ExecuteAsWithEnvironmentWithDir(ctx, loggers, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, as, "", cmd, args...)
+}
+
+// ExecuteAsWithEnvironmentWithDir executes a command (i.e. spawns a subprocess) as a different user with a working directory. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
+func ExecuteAsWithEnvironmentWithDir(ctx context.Context, loggers logs.Loggers, additionalEnvVars []string, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, dir string, cmd string, args ...string) (err error) {
+	return ExecuteAsWithEnvironmentWithIOWithDir(ctx, loggers, nil, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, as, dir, cmd, args...)
 }
 
 // ExecuteWithSudo executes a command (i.e. spawns a subprocess) as root.
 func ExecuteWithSudo(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) error {
-	return ExecuteAs(ctx, loggers, messageOnStart, messageOnSuccess, messageOnFailure, commandUtils.Sudo(), cmd, args...)
+	return ExecuteWithSudoWithDir(ctx, loggers, messageOnStart, messageOnSuccess, messageOnFailure, "", cmd, args...)
+}
+
+// ExecuteWithSudoWithDir executes a command (i.e. spawns a subprocess) as root with a working directory.
+func ExecuteWithSudoWithDir(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, dir string, cmd string, args ...string) error {
+	return ExecuteAsWithDir(ctx, loggers, messageOnStart, messageOnSuccess, messageOnFailure, commandUtils.Sudo(), dir, cmd, args...)
 }
 
 // ExecuteWithEnvironmentWithIO executes a command (i.e. spawns a subprocess) with overridden stdin/stdout/stderr. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
 func ExecuteWithEnvironmentWithIO(ctx context.Context, loggers logs.Loggers, io ICommandIO, additionalEnvVars []string, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (err error) {
-	p, err := NewWithEnvironmentWithIO(ctx, loggers, io, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, cmd, args...)
+	return ExecuteWithEnvironmentWithIOWithDir(ctx, loggers, io, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, "", cmd, args...)
+}
+
+// ExecuteWithEnvironmentWithIOWithDir executes a command (i.e. spawns a subprocess) with a working directory and overridden stdin/stdout/stderr. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
+func ExecuteWithEnvironmentWithIOWithDir(ctx context.Context, loggers logs.Loggers, io ICommandIO, additionalEnvVars []string, messageOnStart string, messageOnSuccess, messageOnFailure string, dir string, cmd string, args ...string) (err error) {
+	p, err := NewWithEnvironmentWithIOWithDir(ctx, loggers, io, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, dir, cmd, args...)
 	if err != nil {
 		return
 	}
@@ -107,7 +170,12 @@ func ExecuteWithEnvironmentWithIO(ctx context.Context, loggers logs.Loggers, io 
 
 // StartWithEnvironmentWithIO starts a command (i.e. spawns a subprocess) with overridden stdin/stdout/stderr. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
 func StartWithEnvironmentWithIO(ctx context.Context, loggers logs.Loggers, io ICommandIO, additionalEnvVars []string, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (p *Subprocess, err error) {
-	p, err = NewWithEnvironmentWithIO(ctx, loggers, io, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, cmd, args...)
+	return StartWithEnvironmentWithIOWithDir(ctx, loggers, io, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, "", cmd, args...)
+}
+
+// StartWithEnvironmentWithIOWithDir starts a command (i.e. spawns a subprocess) with a working directory and overridden stdin/stdout/stderr. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
+func StartWithEnvironmentWithIOWithDir(ctx context.Context, loggers logs.Loggers, io ICommandIO, additionalEnvVars []string, messageOnStart string, messageOnSuccess, messageOnFailure string, dir string, cmd string, args ...string) (p *Subprocess, err error) {
+	p, err = NewWithEnvironmentWithIOWithDir(ctx, loggers, io, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, dir, cmd, args...)
 	if err != nil {
 		return
 	}
@@ -117,17 +185,32 @@ func StartWithEnvironmentWithIO(ctx context.Context, loggers logs.Loggers, io IC
 
 // ExecuteWithIO executes a command (i.e. spawns a subprocess) with overridden stdin/stdout/stderr.
 func ExecuteWithIO(ctx context.Context, loggers logs.Loggers, io ICommandIO, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) error {
-	return ExecuteWithEnvironmentWithIO(ctx, loggers, io, nil, messageOnStart, messageOnSuccess, messageOnFailure, cmd, args...)
+	return ExecuteWithIOWithDir(ctx, loggers, io, messageOnStart, messageOnSuccess, messageOnFailure, "", cmd, args...)
+}
+
+// ExecuteWithIOWithDir executes a command (i.e. spawns a subprocess) with a working directory and overridden stdin/stdout/stderr.
+func ExecuteWithIOWithDir(ctx context.Context, loggers logs.Loggers, io ICommandIO, messageOnStart string, messageOnSuccess, messageOnFailure string, dir string, cmd string, args ...string) error {
+	return ExecuteWithEnvironmentWithIOWithDir(ctx, loggers, io, nil, messageOnStart, messageOnSuccess, messageOnFailure, dir, cmd, args...)
 }
 
 // ExecuteAsWithIO executes a command (i.e. spawns a subprocess) as a different user with overridden stdin/stdout/stderr.
 func ExecuteAsWithIO(ctx context.Context, loggers logs.Loggers, io ICommandIO, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) error {
-	return ExecuteAsWithEnvironmentWithIO(ctx, loggers, io, nil, messageOnStart, messageOnSuccess, messageOnFailure, as, cmd, args...)
+	return ExecuteAsWithIOWithDir(ctx, loggers, io, messageOnStart, messageOnSuccess, messageOnFailure, as, "", cmd, args...)
+}
+
+// ExecuteAsWithIOWithDir executes a command (i.e. spawns a subprocess) as a different user with a working directory and overridden stdin/stdout/stderr.
+func ExecuteAsWithIOWithDir(ctx context.Context, loggers logs.Loggers, io ICommandIO, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, dir string, cmd string, args ...string) error {
+	return ExecuteAsWithEnvironmentWithIOWithDir(ctx, loggers, io, nil, messageOnStart, messageOnSuccess, messageOnFailure, as, dir, cmd, args...)
 }
 
 // ExecuteAsWithEnvironmentWithIO executes a command (i.e. spawns a subprocess) as a different user with overridden stdin/stdout/stderr. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
 func ExecuteAsWithEnvironmentWithIO(ctx context.Context, loggers logs.Loggers, io ICommandIO, additionalEnvVars []string, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (err error) {
-	p, err := newSubProcess(ctx, loggers, io, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, as, cmd, args...)
+	return ExecuteAsWithEnvironmentWithIOWithDir(ctx, loggers, io, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, as, "", cmd, args...)
+}
+
+// ExecuteAsWithEnvironmentWithIOWithDir executes a command (i.e. spawns a subprocess) as a different user with a working directory and overridden stdin/stdout/stderr. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
+func ExecuteAsWithEnvironmentWithIOWithDir(ctx context.Context, loggers logs.Loggers, io ICommandIO, additionalEnvVars []string, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, dir string, cmd string, args ...string) (err error) {
+	p, err := newSubProcess(ctx, loggers, io, additionalEnvVars, messageOnStart, messageOnSuccess, messageOnFailure, as, dir, cmd, args...)
 	if err != nil {
 		return
 	}
@@ -136,26 +219,51 @@ func ExecuteAsWithEnvironmentWithIO(ctx context.Context, loggers logs.Loggers, i
 
 // ExecuteWithSudoWithIO executes a command (i.e. spawns a subprocess) as root with overridden stdin/stdout/stderr.
 func ExecuteWithSudoWithIO(ctx context.Context, loggers logs.Loggers, io ICommandIO, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) error {
-	return ExecuteAsWithIO(ctx, loggers, io, messageOnStart, messageOnSuccess, messageOnFailure, commandUtils.Sudo(), cmd, args...)
+	return ExecuteWithSudoWithIOWithDir(ctx, loggers, io, messageOnStart, messageOnSuccess, messageOnFailure, "", cmd, args...)
+}
+
+// ExecuteWithSudoWithIOWithDir executes a command (i.e. spawns a subprocess) as root with a working directory and overridden stdin/stdout/stderr.
+func ExecuteWithSudoWithIOWithDir(ctx context.Context, loggers logs.Loggers, io ICommandIO, messageOnStart string, messageOnSuccess, messageOnFailure string, dir string, cmd string, args ...string) error {
+	return ExecuteAsWithIOWithDir(ctx, loggers, io, messageOnStart, messageOnSuccess, messageOnFailure, commandUtils.Sudo(), dir, cmd, args...)
 }
 
 // Output executes a command and returns its output (stdOutput and stdErr are merged) as string.
 func Output(ctx context.Context, loggers logs.Loggers, cmd string, args ...string) (string, error) {
-	return OutputWithEnvironment(ctx, loggers, nil, cmd, args...)
+	return OutputWithDir(ctx, loggers, "", cmd, args...)
+}
+
+// OutputWithDir executes a command with a working directory and returns its output (stdOutput and stdErr are merged) as string.
+func OutputWithDir(ctx context.Context, loggers logs.Loggers, dir string, cmd string, args ...string) (string, error) {
+	return OutputWithEnvironmentWithDir(ctx, loggers, nil, dir, cmd, args...)
 }
 
 // OutputWithEnvironment executes a command and returns its output (stdOutput and stdErr are merged) as string. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
 func OutputWithEnvironment(ctx context.Context, loggers logs.Loggers, additionalEnvVars []string, cmd string, args ...string) (string, error) {
-	return OutputAsWithEnvironment(ctx, loggers, additionalEnvVars, commandUtils.Me(), cmd, args...)
+	return OutputWithEnvironmentWithDir(ctx, loggers, additionalEnvVars, "", cmd, args...)
+}
+
+// OutputWithEnvironmentWithDir executes a command with a working directory and returns its output (stdOutput and stdErr are merged) as string. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
+func OutputWithEnvironmentWithDir(ctx context.Context, loggers logs.Loggers, additionalEnvVars []string, dir string, cmd string, args ...string) (string, error) {
+	return OutputAsWithEnvironmentWithDir(ctx, loggers, additionalEnvVars, commandUtils.Me(), dir, cmd, args...)
 }
 
 // OutputAs executes a command as a different user and returns its output (stdOutput and stdErr are merged) as string.
 func OutputAs(ctx context.Context, loggers logs.Loggers, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (string, error) {
-	return OutputAsWithEnvironment(ctx, loggers, nil, as, cmd, args...)
+	return OutputAsWithDir(ctx, loggers, as, "", cmd, args...)
+}
+
+// OutputAsWithDir executes a command as a different user with a working directory and returns its output (stdOutput and stdErr are merged) as string.
+func OutputAsWithDir(ctx context.Context, loggers logs.Loggers, as *commandUtils.CommandAsDifferentUser, dir string, cmd string, args ...string) (string, error) {
+	return OutputAsWithEnvironmentWithDir(ctx, loggers, nil, as, dir, cmd, args...)
 }
 
 // OutputAsWithEnvironment executes a command as a different user and returns its output (stdOutput and stdErr are merged) as string. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
 func OutputAsWithEnvironment(ctx context.Context, loggers logs.Loggers, additionalEnvVars []string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (output string, err error) {
+	return OutputAsWithEnvironmentWithDir(ctx, loggers, additionalEnvVars, as, "", cmd, args...)
+}
+
+// OutputAsWithEnvironmentWithDir executes a command as a different user with a working directory and returns its output (stdOutput and stdErr are merged) as string. It allows to specify the environment the subprocess should use. Each entry is of the form "key=value".
+func OutputAsWithEnvironmentWithDir(ctx context.Context, loggers logs.Loggers, additionalEnvVars []string, as *commandUtils.CommandAsDifferentUser, dir string, cmd string, args ...string) (output string, err error) {
 	if loggers == nil {
 		err = commonerrors.ErrNoLogger
 		return
@@ -169,7 +277,7 @@ func OutputAsWithEnvironment(ctx context.Context, loggers logs.Loggers, addition
 	if err != nil {
 		return
 	}
-	p, err := newPlainSubProcess(ctx, mLoggers, additionalEnvVars, as, cmd, args...)
+	p, err := newPlainSubProcessWithDir(ctx, mLoggers, additionalEnvVars, as, dir, cmd, args...)
 	if err != nil {
 		return
 	}
@@ -180,46 +288,86 @@ func OutputAsWithEnvironment(ctx context.Context, loggers logs.Loggers, addition
 
 // Setup sets up a sub-process i.e. defines the command cmd and the messages on start, success and failure.
 func (s *Subprocess) Setup(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (err error) {
-	return s.SetupWithEnvironment(ctx, loggers, nil, messageOnStart, messageOnSuccess, messageOnFailure, cmd, args...)
+	return s.SetupWithDir(ctx, loggers, messageOnStart, messageOnSuccess, messageOnFailure, "", cmd, args...)
+}
+
+// SetupWithDir sets up a sub-process i.e. defines the command cmd and the messages on start, success and failure with a working directory.
+func (s *Subprocess) SetupWithDir(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, dir string, cmd string, args ...string) (err error) {
+	return s.SetupWithEnvironmentWithDir(ctx, loggers, nil, messageOnStart, messageOnSuccess, messageOnFailure, dir, cmd, args...)
 }
 
 // SetupWithEnvironment sets up a sub-process i.e. defines the command cmd and the messages on start, success and failure. Compared to Setup, it allows specifying additional environment variables to be used by the process.
 func (s *Subprocess) SetupWithEnvironment(ctx context.Context, loggers logs.Loggers, additionalEnv []string, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (err error) {
-	return s.setup(ctx, loggers, nil, additionalEnv, true, messageOnStart, messageOnSuccess, messageOnFailure, commandUtils.Me(), cmd, args...)
+	return s.SetupWithEnvironmentWithDir(ctx, loggers, additionalEnv, messageOnStart, messageOnSuccess, messageOnFailure, "", cmd, args...)
+}
+
+// SetupWithEnvironmentWithDir sets up a sub-process i.e. defines the command cmd and the messages on start, success and failure with a working directory. Compared to SetupWithDir, it allows specifying additional environment variables to be used by the process.
+func (s *Subprocess) SetupWithEnvironmentWithDir(ctx context.Context, loggers logs.Loggers, additionalEnv []string, messageOnStart string, messageOnSuccess, messageOnFailure string, dir string, cmd string, args ...string) (err error) {
+	return s.setup(ctx, loggers, nil, additionalEnv, true, messageOnStart, messageOnSuccess, messageOnFailure, commandUtils.Me(), dir, cmd, args...)
 }
 
 // SetupAs is similar to Setup but allows the command to be run as a different user.
 func (s *Subprocess) SetupAs(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (err error) {
-	return s.SetupAsWithEnvironment(ctx, loggers, nil, messageOnStart, messageOnSuccess, messageOnFailure, as, cmd, args...)
+	return s.SetupAsWithDir(ctx, loggers, messageOnStart, messageOnSuccess, messageOnFailure, as, "", cmd, args...)
+}
+
+// SetupAsWithDir is similar to SetupWithDir but allows the command to be run as a different user.
+func (s *Subprocess) SetupAsWithDir(ctx context.Context, loggers logs.Loggers, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, dir string, cmd string, args ...string) (err error) {
+	return s.SetupAsWithEnvironmentWithDir(ctx, loggers, nil, messageOnStart, messageOnSuccess, messageOnFailure, as, dir, cmd, args...)
 }
 
 // SetupAsWithEnvironment is similar to Setup but allows the command to be run as a different user. Compared to SetupAs, it allows specifying additional environment variables to be used by the process.
 func (s *Subprocess) SetupAsWithEnvironment(ctx context.Context, loggers logs.Loggers, additionalEnv []string, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (err error) {
-	return s.setup(ctx, loggers, nil, additionalEnv, true, messageOnStart, messageOnSuccess, messageOnFailure, as, cmd, args...)
+	return s.SetupAsWithEnvironmentWithDir(ctx, loggers, additionalEnv, messageOnStart, messageOnSuccess, messageOnFailure, as, "", cmd, args...)
+}
+
+// SetupAsWithEnvironmentWithDir is similar to SetupWithDir but allows the command to be run as a different user. Compared to SetupAsWithDir, it allows specifying additional environment variables to be used by the process.
+func (s *Subprocess) SetupAsWithEnvironmentWithDir(ctx context.Context, loggers logs.Loggers, additionalEnv []string, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, dir string, cmd string, args ...string) (err error) {
+	return s.setup(ctx, loggers, nil, additionalEnv, true, messageOnStart, messageOnSuccess, messageOnFailure, as, dir, cmd, args...)
 }
 
 // SetupWithCustomIO sets up a sub-process i.e. defines the command cmd and the messages on start, success and failure. It allows the stdin, stdout, and stderr to be overridden.
 func (s *Subprocess) SetupWithCustomIO(ctx context.Context, loggers logs.Loggers, io ICommandIO, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (err error) {
-	return s.SetupWithEnvironmentWithCustomIO(ctx, loggers, io, nil, messageOnStart, messageOnSuccess, messageOnFailure, cmd, args...)
+	return s.SetupWithCustomIOWithDir(ctx, loggers, io, messageOnStart, messageOnSuccess, messageOnFailure, "", cmd, args...)
+}
+
+// SetupWithCustomIOWithDir sets up a sub-process i.e. defines the command cmd and the messages on start, success and failure with a working directory. It allows the stdin, stdout, and stderr to be overridden.
+func (s *Subprocess) SetupWithCustomIOWithDir(ctx context.Context, loggers logs.Loggers, io ICommandIO, messageOnStart string, messageOnSuccess, messageOnFailure string, dir string, cmd string, args ...string) (err error) {
+	return s.SetupWithEnvironmentWithCustomIOWithDir(ctx, loggers, io, nil, messageOnStart, messageOnSuccess, messageOnFailure, dir, cmd, args...)
 }
 
 // SetupWithEnvironmentWithCustomIO sets up a sub-process i.e. defines the command cmd and the messages on start, success and failure. Compared to SetupWithCustomIO, it allows specifying additional environment variables to be used by the process. It allows the stdin, stdout, and stderr to be overridden.
 func (s *Subprocess) SetupWithEnvironmentWithCustomIO(ctx context.Context, loggers logs.Loggers, io ICommandIO, additionalEnv []string, messageOnStart string, messageOnSuccess, messageOnFailure string, cmd string, args ...string) (err error) {
-	return s.setup(ctx, loggers, io, additionalEnv, true, messageOnStart, messageOnSuccess, messageOnFailure, commandUtils.Me(), cmd, args...)
+	return s.SetupWithEnvironmentWithCustomIOWithDir(ctx, loggers, io, additionalEnv, messageOnStart, messageOnSuccess, messageOnFailure, "", cmd, args...)
+}
+
+// SetupWithEnvironmentWithCustomIOWithDir sets up a sub-process i.e. defines the command cmd and the messages on start, success and failure with a working directory. Compared to SetupWithCustomIOWithDir, it allows specifying additional environment variables to be used by the process. It allows the stdin, stdout, and stderr to be overridden.
+func (s *Subprocess) SetupWithEnvironmentWithCustomIOWithDir(ctx context.Context, loggers logs.Loggers, io ICommandIO, additionalEnv []string, messageOnStart string, messageOnSuccess, messageOnFailure string, dir string, cmd string, args ...string) (err error) {
+	return s.setup(ctx, loggers, io, additionalEnv, true, messageOnStart, messageOnSuccess, messageOnFailure, commandUtils.Me(), dir, cmd, args...)
 }
 
 // SetupAsWithCustomIO is similar to SetupWithCustomIO but allows the command to be run as a different user. It allows the stdin, stdout, and stderr to be overridden.
 func (s *Subprocess) SetupAsWithCustomIO(ctx context.Context, loggers logs.Loggers, io ICommandIO, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (err error) {
-	return s.SetupAsWithEnvironmentWithCustomIO(ctx, loggers, io, nil, messageOnStart, messageOnSuccess, messageOnFailure, as, cmd, args...)
+	return s.SetupAsWithCustomIOWithDir(ctx, loggers, io, messageOnStart, messageOnSuccess, messageOnFailure, as, "", cmd, args...)
+}
+
+// SetupAsWithCustomIOWithDir is similar to SetupWithCustomIOWithDir but allows the command to be run as a different user. It allows the stdin, stdout, and stderr to be overridden.
+func (s *Subprocess) SetupAsWithCustomIOWithDir(ctx context.Context, loggers logs.Loggers, io ICommandIO, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, dir string, cmd string, args ...string) (err error) {
+	return s.SetupAsWithEnvironmentWithCustomIOWithDir(ctx, loggers, io, nil, messageOnStart, messageOnSuccess, messageOnFailure, as, dir, cmd, args...)
 }
 
 // SetupAsWithEnvironmentWithCustomIO is similar to SetupWithCustomIO but allows the command to be run as a different user. Compared to SetupAsWithCustomIO, it allows specifying additional environment variables to be used by the process. It allows the stdin, stdout, and stderr to be overridden.
 func (s *Subprocess) SetupAsWithEnvironmentWithCustomIO(ctx context.Context, loggers logs.Loggers, io ICommandIO, additionalEnv []string, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (err error) {
-	return s.setup(ctx, loggers, io, additionalEnv, true, messageOnStart, messageOnSuccess, messageOnFailure, as, cmd, args...)
+	return s.SetupAsWithEnvironmentWithCustomIOWithDir(ctx, loggers, io, additionalEnv, messageOnStart, messageOnSuccess, messageOnFailure, as, "", cmd, args...)
+}
+
+// SetupAsWithEnvironmentWithCustomIOWithDir is similar to SetupWithCustomIOWithDir but allows the command to be run as a different user. Compared to SetupAsWithCustomIOWithDir, it allows specifying additional environment variables to be used by the process. It allows the stdin, stdout, and stderr to be overridden.
+func (s *Subprocess) SetupAsWithEnvironmentWithCustomIOWithDir(ctx context.Context, loggers logs.Loggers, io ICommandIO, additionalEnv []string, messageOnStart string, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, dir string, cmd string, args ...string) (err error) {
+	return s.setup(ctx, loggers, io, additionalEnv, true, messageOnStart, messageOnSuccess, messageOnFailure, as, dir, cmd, args...)
 }
 
 // Setup sets up a sub-process i.e. defines the command cmd and the messages on start, success and failure as well as the stdin, stdout, and stderr.
-func (s *Subprocess) setup(ctx context.Context, loggers logs.Loggers, io ICommandIO, env []string, withAdditionalMessages bool, messageOnStart, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, cmd string, args ...string) (err error) {
+func (s *Subprocess) setup(ctx context.Context, loggers logs.Loggers, io ICommandIO, env []string, withAdditionalMessages bool, messageOnStart, messageOnSuccess, messageOnFailure string, as *commandUtils.CommandAsDifferentUser, dir string, cmd string, args ...string) (err error) {
 	if s.IsOn() {
 		err = s.Stop()
 		if err != nil {
@@ -231,9 +379,9 @@ func (s *Subprocess) setup(ctx context.Context, loggers logs.Loggers, io IComman
 	s.isRunning.Store(false)
 	s.processMonitoring = newSubprocessMonitoring(ctx)
 	if io != nil {
-		s.command = newCommandWithCustomIO(loggers, io, as, env, cmd, args...)
+		s.command = newCommandWithCustomIO(loggers, io, as, env, dir, cmd, args...)
 	} else {
-		s.command = newCommand(loggers, as, env, cmd, args...)
+		s.command = newCommand(loggers, as, env, dir, cmd, args...)
 	}
 	s.messaging = newSubprocessMessaging(loggers, withAdditionalMessages, messageOnSuccess, messageOnFailure, messageOnStart, s.command.GetPath())
 	s.reset()

--- a/utils/subprocess/executor_test.go
+++ b/utils/subprocess/executor_test.go
@@ -530,10 +530,6 @@ func TestStart(t *testing.T) {
 					defer func() { _ = p.Stop() }()
 					require.NoError(t, p.Wait(context.Background()))
 
-					if executor.io != nil && test.expectIO {
-						assert.NotZero(t, executor.io.out.Len()+executor.io.err.Len())
-					}
-
 					p.Cancel()
 				})
 			}

--- a/utils/subprocess/executor_test.go
+++ b/utils/subprocess/executor_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
+	"github.com/ARM-software/golang-utils/utils/filesystem"
 	"github.com/ARM-software/golang-utils/utils/logs"
 	"github.com/ARM-software/golang-utils/utils/logs/logstest"
 	"github.com/ARM-software/golang-utils/utils/parallelisation"
@@ -596,7 +597,7 @@ func TestExecuteWithDir(t *testing.T) {
 			err = run(context.Background(), loggers, cmd, args...)
 			require.NoError(t, err)
 
-			_, err = os.Stat(createdFilePath)
+			_, err = filesystem.Stat(createdFilePath)
 			require.NoError(t, err)
 		})
 	}
@@ -642,7 +643,7 @@ func TestStartWithDir(t *testing.T) {
 
 			require.NoError(t, p.Wait(context.Background()))
 
-			_, err = os.Stat(createdFilePath)
+			_, err = filesystem.Stat(createdFilePath)
 			require.NoError(t, err)
 		})
 	}

--- a/utils/subprocess/executor_test.go
+++ b/utils/subprocess/executor_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -70,6 +71,26 @@ func newCustomIOExecutor(t *testing.T, customIO *testIO) execFunc {
 	}
 }
 
+func newDefaultExecutorWithDir(t *testing.T, dir string) execFunc {
+	t.Helper()
+	return func(ctx context.Context, l logs.Loggers, cmd string, args ...string) error {
+		return ExecuteWithDir(ctx, l, "", "", "", dir, cmd, args...)
+	}
+}
+
+func newCustomIOExecutorWithDir(t *testing.T, customIO *testIO, dir string) execFunc {
+	t.Helper()
+	return func(ctx context.Context, l logs.Loggers, cmd string, args ...string) (err error) {
+		p := &Subprocess{}
+		err = p.SetupWithEnvironmentWithCustomIOWithDir(ctx, l, customIO, nil, "", "", "", dir, cmd, args...)
+		if err != nil {
+			return
+		}
+
+		return p.Execute()
+	}
+}
+
 func newDefaultStarter(t *testing.T) startFunc {
 	t.Helper()
 	return func(ctx context.Context, l logs.Loggers, cmd string, args ...string) (*Subprocess, error) {
@@ -88,6 +109,39 @@ func newCustomIOStarter(t *testing.T, customIO *testIO) startFunc {
 		err = p.Start()
 		return
 	}
+}
+
+func newDefaultStarterWithDir(t *testing.T, dir string) startFunc {
+	t.Helper()
+	return func(ctx context.Context, l logs.Loggers, cmd string, args ...string) (*Subprocess, error) {
+		return StartWithDir(ctx, l, "", "", "", dir, cmd, args...)
+	}
+}
+
+func newCustomIOStarterWithDir(t *testing.T, customIO *testIO, dir string) startFunc {
+	t.Helper()
+	return func(ctx context.Context, l logs.Loggers, cmd string, args ...string) (p *Subprocess, err error) {
+		p = &Subprocess{}
+		err = p.SetupWithEnvironmentWithCustomIOWithDir(ctx, l, customIO, nil, "", "", "", dir, cmd, args...)
+		if err != nil {
+			return
+		}
+
+		err = p.Start()
+		return
+	}
+}
+
+func newRelativeFileCreateCommand(fileName string) (cmd string, args []string) {
+	if platform.IsWindows() {
+		cmd = "powershell"
+		args = []string{"-Command", fmt.Sprintf("New-Item -Path %q -ItemType File -Force | Out-Null", fileName)}
+		return
+	}
+
+	cmd = "touch"
+	args = []string{fileName}
+	return
 }
 
 func TestExecuteEmptyLines(t *testing.T) {
@@ -359,14 +413,19 @@ func TestExecute(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			defer goleak.VerifyNone(t)
 
+			dir := t.TempDir()
+
 			customIO := newTestIO()
+			customIOWithDir := newTestIO()
 			executors := []struct {
 				name string
 				run  execFunc
 				io   *testIO
 			}{
-				{"normal", newDefaultExecutor(t), nil},
-				{"with IO", newCustomIOExecutor(t, customIO), customIO},
+				{name: "normal", run: newDefaultExecutor(t)},
+				{name: "with IO", run: newCustomIOExecutor(t, customIO), io: customIO},
+				{name: "normal with dir", run: newDefaultExecutorWithDir(t, dir)},
+				{name: "with IO with dir", run: newCustomIOExecutorWithDir(t, customIOWithDir, dir), io: customIOWithDir},
 			}
 
 			for _, executor := range executors {
@@ -432,14 +491,19 @@ func TestStart(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			defer goleak.VerifyNone(t)
 
+			dir := t.TempDir()
+
 			customIO := newTestIO()
+			customIOWithDir := newTestIO()
 			executors := []struct {
 				name  string
 				start startFunc
 				io    *testIO
 			}{
-				{"normal", newDefaultStarter(t), nil},
-				{"with IO", newCustomIOStarter(t, customIO), customIO},
+				{name: "normal", start: newDefaultStarter(t)},
+				{name: "with IO", start: newCustomIOStarter(t, customIO), io: customIO},
+				{name: "normal with dir", start: newDefaultStarterWithDir(t, dir)},
+				{name: "with IO with dir", start: newCustomIOStarterWithDir(t, customIOWithDir, dir), io: customIOWithDir},
 			}
 
 			for _, executor := range executors {
@@ -464,6 +528,11 @@ func TestStart(t *testing.T) {
 					require.NotNil(t, p)
 					defer func() { _ = p.Stop() }()
 					require.NoError(t, p.Wait(context.Background()))
+
+					if executor.io != nil && test.expectIO {
+						assert.NotZero(t, executor.io.out.Len()+executor.io.err.Len())
+					}
+
 					p.Cancel()
 				})
 			}
@@ -489,6 +558,94 @@ func TestExecuteWithCustomIO_Stderr(t *testing.T) {
 
 	require.Empty(t, customIO.out.String()) // should be no stdout
 	require.Equal(t, fmt.Sprintln(msg), customIO.err.String())
+}
+
+func TestExecuteWithDir(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	for _, test := range []struct {
+		name string
+		run  func(t *testing.T, dir string) execFunc
+	}{
+		{
+			name: "normal",
+			run: func(t *testing.T, dir string) execFunc {
+				t.Helper()
+				return newDefaultExecutorWithDir(t, dir)
+			},
+		},
+		{
+			name: "with IO",
+			run: func(t *testing.T, dir string) execFunc {
+				t.Helper()
+				return newCustomIOExecutorWithDir(t, newTestIO(), dir)
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			createdFileName := "created-by-execute.txt"
+			createdFilePath := filepath.Join(dir, createdFileName)
+
+			cmd, args := newRelativeFileCreateCommand(createdFileName)
+
+			loggers, err := logs.NewLogrLogger(logstest.NewTestLogger(t), "test")
+			require.NoError(t, err)
+
+			run := test.run(t, dir)
+			err = run(context.Background(), loggers, cmd, args...)
+			require.NoError(t, err)
+
+			_, err = os.Stat(createdFilePath)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestStartWithDir(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	for _, test := range []struct {
+		name  string
+		start func(t *testing.T, dir string) startFunc
+	}{
+		{
+			name: "normal",
+			start: func(t *testing.T, dir string) startFunc {
+				t.Helper()
+				return newDefaultStarterWithDir(t, dir)
+			},
+		},
+		{
+			name: "with IO",
+			start: func(t *testing.T, dir string) startFunc {
+				t.Helper()
+				return newCustomIOStarterWithDir(t, newTestIO(), dir)
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			createdFileName := "created-by-start.txt"
+			createdFilePath := filepath.Join(dir, createdFileName)
+
+			cmd, args := newRelativeFileCreateCommand(createdFileName)
+
+			loggers, err := logs.NewLogrLogger(logstest.NewTestLogger(t), "test")
+			require.NoError(t, err)
+
+			start := test.start(t, dir)
+			p, err := start(context.Background(), loggers, cmd, args...)
+			require.NoError(t, err)
+			require.NotNil(t, p)
+			defer func() { _ = p.Stop() }()
+
+			require.NoError(t, p.Wait(context.Background()))
+
+			_, err = os.Stat(createdFilePath)
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestOutput(t *testing.T) {


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Add support for specifying the directory in subprocess commands

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
