### PR TITLE
fix: mac dir delete

### DIFF
--- a/changes/202605290935.bugfix
+++ b/changes/202605290935.bugfix
@@ -1,0 +1,1 @@
+Fixed filesystem removal on macOS when deleting directories using unlink.

--- a/utils/filesystem/extendedosfs.go
+++ b/utils/filesystem/extendedosfs.go
@@ -7,6 +7,7 @@ package filesystem
 
 import (
 	"context"
+	"errors"
 	"os"
 	"syscall"
 
@@ -24,13 +25,19 @@ type ExtendedOsFs struct {
 func (c *ExtendedOsFs) Remove(name string) (err error) {
 	// The following is to ensure sockets are correctly removed
 	// https://stackoverflow.com/questions/16681944/how-to-reliably-unlink-a-unix-domain-socket-in-go-programming-language
-	err = commonerrors.Ignore(ConvertFileSystemError(syscall.Unlink(name)), commonerrors.ErrNotFound)
-	err = commonerrors.IgnoreCorrespondTo(err, "is a directory")
-	if err != nil {
+	unlinkErr := commonerrors.Ignore(ConvertFileSystemError(syscall.Unlink(name)), commonerrors.ErrNotFound)
+	unlinkErr = commonerrors.IgnoreCorrespondTo(unlinkErr, "is a directory")
+
+	removeErr := commonerrors.Ignore(ConvertFileSystemError(c.OsFs.Remove(name)), commonerrors.ErrNotFound)
+
+	if unlinkErr != nil && removeErr != nil {
+		// There is a behavioural difference on Mac vs Linux where performing an Unlink on a directory causes a EPERM which
+		// falsely gives the impression of a permissions issue, but directly using Remove works. So rather than fail on the
+		// first error this will only return an error if neither strategy works.
+		err = errors.Join(unlinkErr, removeErr)
 		return
 	}
 
-	err = commonerrors.Ignore(ConvertFileSystemError(c.OsFs.Remove(name)), commonerrors.ErrNotFound)
 	return
 }
 

--- a/utils/filesystem/extendedosfs.go
+++ b/utils/filesystem/extendedosfs.go
@@ -7,7 +7,6 @@ package filesystem
 
 import (
 	"context"
-	"errors"
 	"os"
 	"syscall"
 
@@ -34,7 +33,7 @@ func (c *ExtendedOsFs) Remove(name string) (err error) {
 		// There is a behavioural difference on Mac vs Linux where performing an Unlink on a directory causes a EPERM which
 		// falsely gives the impression of a permissions issue, but directly using Remove works. So rather than fail on the
 		// first error this will only return an error if neither strategy works.
-		err = errors.Join(unlinkErr, removeErr)
+		err = commonerrors.Join(unlinkErr, removeErr)
 		return
 	}
 


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

Fixes an issue on Mac where using `Unlink` on a directory results in an EPERM error, which prevents following on to the `Remove` which does work ok. 

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [x]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).

File delete
```
name = "node_modules/stale.txt"
err = nil
unlinkErr = nil
removeErr = nil
```

Dir delete
```
name = "node_modules"
err = nil
unlinkErr = error(*fmt.wrapError) *{msg: "conflict: operation not permitted", err: error(*errors.errorString) *{s: "conflict"}}
removeErr = nil
```