### PR TITLE
:bug: Ensure that there is an explicit check that a path is not a directory before unlinking

### DIFF
--- a/changes/20260529095325.bugfix
+++ b/changes/20260529095325.bugfix
@@ -1,0 +1,1 @@
+:bug: Ensure that there is an explicit check that a path is not a directory before unlinking

--- a/utils/filesystem/extendedosfs.go
+++ b/utils/filesystem/extendedosfs.go
@@ -22,14 +22,14 @@ type ExtendedOsFs struct {
 }
 
 func (c *ExtendedOsFs) Remove(name string) (err error) {
-	info, err := c.OsFs.Stat(name)
+	info, err := c.Stat(name)
 	if err != nil {
 		err = ConvertFileSystemError(err)
 		return
 	}
 
 	if !info.IsDir() {
-		// The following is to ensure sockets are correctly removed
+		// The following is to ensure sockets are correctly removed (must be unlinked/closed before reuse)
 		// https://stackoverflow.com/questions/16681944/how-to-reliably-unlink-a-unix-domain-socket-in-go-programming-language
 		err = commonerrors.Ignore(ConvertFileSystemError(syscall.Unlink(name)), commonerrors.ErrNotFound)
 		if err != nil {

--- a/utils/filesystem/extendedosfs.go
+++ b/utils/filesystem/extendedosfs.go
@@ -22,12 +22,19 @@ type ExtendedOsFs struct {
 }
 
 func (c *ExtendedOsFs) Remove(name string) (err error) {
-	// The following is to ensure sockets are correctly removed
-	// https://stackoverflow.com/questions/16681944/how-to-reliably-unlink-a-unix-domain-socket-in-go-programming-language
-	err = commonerrors.Ignore(ConvertFileSystemError(syscall.Unlink(name)), commonerrors.ErrNotFound)
-	err = commonerrors.IgnoreCorrespondTo(err, "is a directory")
+	info, err := c.OsFs.Stat(name)
 	if err != nil {
+		err = ConvertFileSystemError(err)
 		return
+	}
+
+	if !info.IsDir() {
+		// The following is to ensure sockets are correctly removed
+		// https://stackoverflow.com/questions/16681944/how-to-reliably-unlink-a-unix-domain-socket-in-go-programming-language
+		err = commonerrors.Ignore(ConvertFileSystemError(syscall.Unlink(name)), commonerrors.ErrNotFound)
+		if err != nil {
+			return
+		}
 	}
 
 	err = commonerrors.Ignore(ConvertFileSystemError(c.OsFs.Remove(name)), commonerrors.ErrNotFound)


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Ensure that there is an explicit check that a path is not a directory before unlinking.

The check for an error with `"is a directory"` (`EISDIR`) is not robust enough. On MacOS, the error is `ERPERM` which means that `Remove` fails tests on MacOS.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
