### PR TITLE
:sparkles: `[collection]` Added additional helpers to ease operation on collection

### DIFF
--- a/changes/20260601231830.feature
+++ b/changes/20260601231830.feature
@@ -1,0 +1,1 @@
+:sparkles: [reflection] Introduced a not empty helper

--- a/changes/20260601232922.doc
+++ b/changes/20260601232922.doc
@@ -1,0 +1,1 @@
+:book: [collection] Improve documentation

--- a/changes/20260602001604.feature
+++ b/changes/20260602001604.feature
@@ -1,0 +1,1 @@
+:sparkles: [collection] Added additional helpers to ease operation on collection

--- a/utils/collection/filter.go
+++ b/utils/collection/filter.go
@@ -13,18 +13,27 @@ import (
 // Predicate & filter types
 //
 
-// FilterFunc defines a function that evaluates a value and returns true
-// when the value satisfies the condition.
+// FilterFunc defines a function that evaluates a value and returns true when
+// the value satisfies the condition.
+//
+// Filter predicates are useful for selecting only the elements that should be
+// kept, such as enabled records, matching names, valid values, or items within
+// a threshold.
 type FilterFunc[E any] func(E) bool
 
-// FilterRefFunc defines a function that evaluates a pointer to a value
-// and returns true when the referenced value satisfies the condition.
+// FilterRefFunc defines a function that evaluates a pointer to a value and
+// returns true when the referenced value satisfies the condition.
+//
+// Reference-based predicates are useful when the predicate should be able to
+// work with optional values, share logic with other pointer-oriented helpers,
+// or avoid copying larger element values.
 type FilterRefFunc[E any] func(*E) bool
 
 // Predicate is an alias for FilterFunc to express boolean tests.
 type Predicate[E any] = FilterFunc[E]
 
-// PredicateRef is an alias for FilterRefFunc to express boolean tests on references.
+// PredicateRef is an alias for FilterRefFunc to express boolean tests on
+// references.
 type PredicateRef[E any] = FilterRefFunc[E]
 
 // toPredicateFunc adapts a PredicateRef (reference-based predicate) to
@@ -87,17 +96,37 @@ func StrictRefMatch[E comparable](a, b *E) (bool, error) { return field.Equal(a,
 // Rejection / Filtering
 //
 
-// Filter returns a new slice containing elements from s for which f returns true.
+// Filter returns a new slice containing elements from s for which f returns
+// true.
+//
+// This is useful when a collection should be narrowed down to only the items of
+// interest, for example active users, matching paths, or values that pass a
+// validation predicate.
+//
+// Reference documentation:
+//   - https://en.wikipedia.org/wiki/Filter_(higher-order_function)
+//   - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter
 func Filter[S ~[]E, E any](s S, f FilterFunc[E]) S {
 	return slices.Collect[E](FilterSequence[E](slices.Values(s), f))
 }
 
 // FilterRef behaves like Filter but accepts a reference-based predicate.
+//
+// This is useful when the predicate naturally works on pointers or when it is
+// shared with other APIs that already use PredicateRef.
 func FilterRef[S ~[]E, E any](s S, f FilterRefFunc[E]) S {
 	return Filter[S](s, toPredicateFunc(f))
 }
 
-// FilterSequence returns a sequence that yields only elements for which f returns true.
+// FilterSequence returns a sequence that yields only elements for which f
+// returns true.
+//
+// This is the lazy sequence-oriented counterpart to Filter and is useful when
+// composing iterator pipelines, avoiding intermediate slices, or processing
+// potentially large or streaming inputs incrementally.
+//
+// Reference documentation:
+//   - https://pkg.go.dev/iter
 func FilterSequence[E any](s iter.Seq[E], f Predicate[E]) (result iter.Seq[E]) {
 	return func(yield func(E) bool) {
 		for v := range s {
@@ -108,7 +137,11 @@ func FilterSequence[E any](s iter.Seq[E], f Predicate[E]) (result iter.Seq[E]) {
 	}
 }
 
-// FilterRefSequence behaves like FilterSequence but accepts a reference-based predicate.
+// FilterRefSequence behaves like FilterSequence but accepts a reference-based
+// predicate.
+//
+// This is useful when sequence processing should remain lazy while the
+// predicate logic is written against PredicateRef.
 func FilterRefSequence[E any](s iter.Seq[E], f PredicateRef[E]) (result iter.Seq[E]) {
 	return FilterSequence(s, toPredicateFunc(f))
 }
@@ -127,7 +160,11 @@ func RejectRef[S ~[]E, E any](s S, f FilterRefFunc[E]) S {
 	return Reject(s, toPredicateFunc(f))
 }
 
-// RejectSequence returns a sequence that yields elements for which f returns false.
+// RejectSequence returns a sequence that yields elements for which f returns
+// false.
+//
+// This is useful when the complement of a filter condition should be applied in
+// a lazy pipeline.
 func RejectSequence[E any](s iter.Seq[E], f FilterFunc[E]) iter.Seq[E] {
 	return FilterSequence(s, OppositeFunc[E](f))
 }

--- a/utils/collection/grouping.go
+++ b/utils/collection/grouping.go
@@ -1,0 +1,167 @@
+package collection
+
+import (
+	"iter"
+	"slices"
+
+	"github.com/ARM-software/golang-utils/utils/field"
+)
+
+// KeyFunc defines a function that maps an element to a comparable key.
+//
+// Key functions are useful when values need to be grouped, counted, or
+// deduplicated based on a derived identity such as an ID, category, or
+// normalised form.
+type KeyFunc[T1 any, T2 comparable] = MapFunc[T1, T2]
+
+// KeyRefFunc defines a function that maps a pointer to a value to a comparable
+// key.
+//
+// Reference-based key functions are useful when grouping or counting logic is
+// naturally written against optional or pointer-based values.
+type KeyRefFunc[T1 any, T2 comparable] func(*T1) T2
+
+func toKeyFunc[E any, K comparable](f KeyRefFunc[E, K]) KeyFunc[E, K] {
+	return func(e E) K {
+		return f(field.ToOptionalOrNilIfEmpty(e))
+	}
+}
+
+// CountBy counts how many elements in a slice satisfy the predicate.
+//
+// This is useful when a collection should be reduced to the number of matching
+// elements, for example, counting even values, enabled items, or values that
+// match a threshold.
+//
+// Reference documentation:
+//   - https://underscorejs.org/#countBy
+func CountBy[S ~[]E, E any](slice S, predicate Predicate[E]) int {
+	return CountBySequence(slices.Values(slice), predicate)
+}
+
+// CountByRef behaves like CountBy but accepts a reference-based predicate.
+func CountByRef[S ~[]E, E any](slice S, predicate PredicateRef[E]) int {
+	return CountBy(slice, toPredicateFunc(predicate))
+}
+
+// CountBySequence counts how many elements in a sequence satisfy predicate.
+//
+// This is useful when values are processed lazily through iterators rather than
+// from a prebuilt slice.
+func CountBySequence[E any](sequence iter.Seq[E], predicate Predicate[E]) int {
+	return ReducesSequence(sequence, 0, func(acc int, element E) int {
+		if predicate(element) {
+			return acc + 1
+		}
+		return acc
+	})
+}
+
+// CountByRefSequence behaves like CountBySequence but accepts a
+// reference-based predicate.
+func CountByRefSequence[E any](sequence iter.Seq[E], predicate PredicateRef[E]) int {
+	return CountBySequence(sequence, toPredicateFunc(predicate))
+}
+
+// GroupBy groups slice elements by the key returned by keyFunc.
+//
+// This is useful when a collection should be partitioned into buckets, such as
+// grouping users by role, strings by length, or values by status.
+//
+// Reference documentation:
+//   - https://underscorejs.org/#groupBy
+func GroupBy[S ~[]E, E any, K comparable](slice S, keyFunc KeyFunc[E, K]) map[K][]E {
+	return GroupBySequence(slices.Values(slice), keyFunc)
+}
+
+// GroupByRef behaves like GroupBy but accepts a reference-based key function.
+func GroupByRef[S ~[]E, E any, K comparable](slice S, keyFunc KeyRefFunc[E, K]) map[K][]E {
+	return GroupBy(slice, toKeyFunc(keyFunc))
+}
+
+// GroupBySequence groups sequence elements by the key returned by keyFunc.
+//
+// This is useful when grouping should happen during lazy iteration rather than
+// after collecting values into a slice.
+func GroupBySequence[E any, K comparable](sequence iter.Seq[E], keyFunc KeyFunc[E, K]) map[K][]E {
+	return ReducesSequence(sequence, map[K][]E{}, func(acc map[K][]E, element E) map[K][]E {
+		key := keyFunc(element)
+		acc[key] = append(acc[key], element)
+		return acc
+	})
+}
+
+// GroupByRefSequence behaves like GroupBySequence but accepts a reference-based
+// key function.
+func GroupByRefSequence[E any, K comparable](sequence iter.Seq[E], keyFunc KeyRefFunc[E, K]) map[K][]E {
+	return GroupBySequence(sequence, toKeyFunc(keyFunc))
+}
+
+// FrequenciesBy counts how often each derived key occurs in slice.
+//
+// This is useful for building histograms or frequency tables, for example
+// counting values by lowercase normalisation, status, or category.
+//
+// Reference documentation:
+//   - https://underscorejs.org/#countBy
+func FrequenciesBy[S ~[]E, E any, K comparable](slice S, keyFunc KeyFunc[E, K]) map[K]int {
+	return FrequenciesBySequence(slices.Values(slice), keyFunc)
+}
+
+// FrequenciesByRef behaves like FrequenciesBy but accepts a reference-based key
+// function.
+func FrequenciesByRef[S ~[]E, E any, K comparable](slice S, keyFunc KeyRefFunc[E, K]) map[K]int {
+	return FrequenciesBy(slice, toKeyFunc(keyFunc))
+}
+
+// FrequenciesBySequence counts how often each derived key occurs in a sequence.
+func FrequenciesBySequence[E any, K comparable](sequence iter.Seq[E], keyFunc KeyFunc[E, K]) map[K]int {
+	return ReducesSequence(sequence, map[K]int{}, func(acc map[K]int, element E) map[K]int {
+		key := keyFunc(element)
+		acc[key]++
+		return acc
+	})
+}
+
+// FrequenciesByRefSequence behaves like FrequenciesBySequence but accepts a
+// reference-based key function.
+func FrequenciesByRefSequence[E any, K comparable](sequence iter.Seq[E], keyFunc KeyRefFunc[E, K]) map[K]int {
+	return FrequenciesBySequence(sequence, toKeyFunc(keyFunc))
+}
+
+// FlatMap maps each element and concatenates the returned slices.
+//
+// This is useful when each input element expands into zero or more output
+// elements, such as splitting strings, flattening nested values, or projecting
+// structs into multiple derived values.
+//
+// Reference documentation:
+//   - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap
+func FlatMap[S ~[]E, E any, T any](slice S, mapper MapFunc[E, []T]) []T {
+	return FlatMapSequence(slices.Values(slice), mapper)
+}
+
+// FlatMapRef behaves like FlatMap but accepts a reference-based mapper.
+func FlatMapRef[S ~[]E, E any, T any](slice S, mapper MapRefFunc[E, []T]) []T {
+	return FlatMapRefSequence(slices.Values(slice), mapper)
+}
+
+// FlatMapSequence maps each sequence element and concatenates the returned
+// slices.
+func FlatMapSequence[E any, T any](sequence iter.Seq[E], mapper MapFunc[E, []T]) []T {
+	return ReducesSequence(sequence, []T{}, func(acc []T, element E) []T {
+		return append(acc, mapper(element)...)
+	})
+}
+
+// FlatMapRefSequence behaves like FlatMapSequence but accepts a reference-based
+// mapper.
+func FlatMapRefSequence[E any, T any](sequence iter.Seq[E], mapper MapRefFunc[E, []T]) []T {
+	return FlatMapSequence(sequence, func(element E) []T {
+		mapped := mapper(field.ToOptionalOrNilIfEmpty(element))
+		if mapped == nil {
+			return nil
+		}
+		return *mapped
+	})
+}

--- a/utils/collection/grouping_test.go
+++ b/utils/collection/grouping_test.go
@@ -55,16 +55,12 @@ func TestGroupBy(t *testing.T) {
 }
 
 func TestFrequenciesBy(t *testing.T) {
-	frequencies := FrequenciesBy([]string{"aa", "aA", "bb", "cc"}, func(element string) string {
-		return strings.ToLower(element)
-	})
+	frequencies := FrequenciesBy([]string{"aa", "aA", "bb", "cc"}, strings.ToLower)
 	assert.Equal(t, map[string]int{"aa": 2, "bb": 1, "cc": 1}, frequencies)
 	assert.Equal(t, frequencies, FrequenciesByRef([]string{"aa", "aA", "bb", "cc"}, func(element *string) string {
 		return strings.ToLower(*element)
 	}))
-	assert.Equal(t, frequencies, FrequenciesBySequence(slices.Values([]string{"aa", "aA", "bb", "cc"}), func(element string) string {
-		return strings.ToLower(element)
-	}))
+	assert.Equal(t, frequencies, FrequenciesBySequence(slices.Values([]string{"aa", "aA", "bb", "cc"}), strings.ToLower))
 	assert.Equal(t, frequencies, FrequenciesByRefSequence(slices.Values([]string{"aa", "aA", "bb", "cc"}), func(element *string) string {
 		return strings.ToLower(*element)
 	}))

--- a/utils/collection/grouping_test.go
+++ b/utils/collection/grouping_test.go
@@ -1,0 +1,90 @@
+package collection
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCountBy(t *testing.T) {
+	numbers := []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	count := CountBy(numbers, func(number int) bool {
+		return number%2 == 0
+	})
+	assert.Equal(t, 4, count)
+	assert.Equal(t, 4, CountByRef(numbers, func(number *int) bool {
+		return *number%2 == 0
+	}))
+	assert.Equal(t, 4, CountBySequence(slices.Values(numbers), func(number int) bool {
+		return number%2 == 0
+	}))
+	assert.Equal(t, 4, CountByRefSequence(slices.Values(numbers), func(number *int) bool {
+		return *number%2 == 0
+	}))
+}
+
+func TestGroupBy(t *testing.T) {
+	planets := []string{"Mercury", "Venus", "Earth", "Mars", "Jupiter", "Saturn", "Uranus", "Neptune"}
+	grouped := GroupBy(planets, func(planet string) int {
+		return len(planet)
+	})
+	require.Len(t, grouped, 4)
+	assert.ElementsMatch(t, []string{"Mercury", "Jupiter", "Neptune"}, grouped[7])
+	assert.ElementsMatch(t, []string{"Saturn", "Uranus"}, grouped[6])
+	assert.ElementsMatch(t, []string{"Venus", "Earth"}, grouped[5])
+	assert.ElementsMatch(t, []string{"Mars"}, grouped[4])
+
+	groupedSequence := GroupBySequence(slices.Values(planets), func(planet string) int {
+		return len(planet)
+	})
+	assert.Equal(t, grouped, groupedSequence)
+
+	groupedRef := GroupByRef(planets, func(planet *string) int {
+		return len(*planet)
+	})
+	assert.Equal(t, grouped, groupedRef)
+
+	groupedRefSequence := GroupByRefSequence(slices.Values(planets), func(planet *string) int {
+		return len(*planet)
+	})
+	assert.Equal(t, grouped, groupedRefSequence)
+}
+
+func TestFrequenciesBy(t *testing.T) {
+	frequencies := FrequenciesBy([]string{"aa", "aA", "bb", "cc"}, func(element string) string {
+		return strings.ToLower(element)
+	})
+	assert.Equal(t, map[string]int{"aa": 2, "bb": 1, "cc": 1}, frequencies)
+	assert.Equal(t, frequencies, FrequenciesByRef([]string{"aa", "aA", "bb", "cc"}, func(element *string) string {
+		return strings.ToLower(*element)
+	}))
+	assert.Equal(t, frequencies, FrequenciesBySequence(slices.Values([]string{"aa", "aA", "bb", "cc"}), func(element string) string {
+		return strings.ToLower(element)
+	}))
+	assert.Equal(t, frequencies, FrequenciesByRefSequence(slices.Values([]string{"aa", "aA", "bb", "cc"}), func(element *string) string {
+		return strings.ToLower(*element)
+	}))
+}
+
+func TestFlatMap(t *testing.T) {
+	numbers := []int{1, 2, 3}
+	flattened := FlatMap(numbers, func(number int) []string {
+		return []string{fmt.Sprintf("%d", number), fmt.Sprintf("%d", number)}
+	})
+	assert.Equal(t, []string{"1", "1", "2", "2", "3", "3"}, flattened)
+	assert.Equal(t, flattened, FlatMapRef(numbers, func(number *int) *[]string {
+		mapped := []string{fmt.Sprintf("%d", *number), fmt.Sprintf("%d", *number)}
+		return &mapped
+	}))
+	assert.Equal(t, flattened, FlatMapSequence(slices.Values(numbers), func(number int) []string {
+		return []string{fmt.Sprintf("%d", number), fmt.Sprintf("%d", number)}
+	}))
+	assert.Equal(t, flattened, FlatMapRefSequence(slices.Values(numbers), func(number *int) *[]string {
+		mapped := []string{fmt.Sprintf("%d", *number), fmt.Sprintf("%d", *number)}
+		return &mapped
+	}))
+}

--- a/utils/collection/mapping.go
+++ b/utils/collection/mapping.go
@@ -13,16 +13,25 @@ import (
 //
 
 // MapFunc defines a function that maps a value of type T1 to type T2.
+//
+// Mapping functions are useful for transforming collections from one shape into
+// another, such as extracting a field, converting one type to another, or
+// preparing values for serialisation or display.
 type MapFunc[T1, T2 any] func(T1) T2
 
 // MapRefFunc defines a mapping function that accepts a pointer to T1 and
 // returns a pointer to T2.
+//
+// Reference-based mappers are useful when the mapping logic naturally works on
+// pointers, when a value may be optional, or when larger values should not be
+// copied unnecessarily.
 type MapRefFunc[T1, T2 any] func(*T1) *T2
 
 // MapWithErrorFunc defines a mapping function that may return an error.
 type MapWithErrorFunc[T1, T2 any] func(T1) (T2, error)
 
-// MapRefWithErrorFunc defines a reference-based mapping function that may return an error.
+// MapRefWithErrorFunc defines a reference-based mapping function that may return
+// an error.
 type MapRefWithErrorFunc[T1, T2 any] func(*T1) (*T2, error)
 
 // IdentityMapFunc returns a mapping function that returns its input unchanged.
@@ -30,15 +39,25 @@ func IdentityMapFunc[T any]() MapFunc[T, T] {
 	return func(i T) T { return i }
 }
 
-// MapSequence maps each element of s using f and returns a sequence of mapped values.
+// MapSequence maps each element of s using f and returns a sequence of mapped
+// values.
+//
+// This is useful when data should be transformed lazily, for example while
+// streaming over iterators or when chaining other sequence operations.
+//
+// Reference documentation:
+//   - https://en.wikipedia.org/wiki/Map_(higher-order_function)
+//   - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map
 func MapSequence[T1 any, T2 any](s iter.Seq[T1], f MapFunc[T1, T2]) iter.Seq[T2] {
 	return MapSequenceWithError(s, func(t1 T1) (T2, error) {
 		return f(t1), nil
 	})
 }
 
-// MapSequenceWithError maps each element of s using f, which may return an error.
-// Mapping stops if f returns an error or if the consumer declines the yielded value.
+// MapSequenceWithError maps each element of s using f, which may return an
+// error.
+// Mapping stops if f returns an error or if the consumer declines the yielded
+// value.
 func MapSequenceWithError[T1 any, T2 any](s iter.Seq[T1], f MapWithErrorFunc[T1, T2]) iter.Seq[T2] {
 	return func(yield func(T2) bool) {
 		for v := range s {
@@ -50,15 +69,24 @@ func MapSequenceWithError[T1 any, T2 any](s iter.Seq[T1], f MapWithErrorFunc[T1,
 	}
 }
 
-// MapSequenceRef maps a sequence by applying a reference-based mapper to each element.
+// MapSequenceRef maps a sequence by applying a reference-based mapper to each
+// element.
+//
+// This is useful when values are consumed lazily and the mapping logic is
+// already written against pointers.
 func MapSequenceRef[T1 any, T2 any](s iter.Seq[T1], f MapRefFunc[T1, T2]) iter.Seq[T2] {
 	return MapSequenceRefWithError(s, func(t1 *T1) (*T2, error) {
 		return f(t1), nil
 	})
 }
 
-// MapSequenceRefWithError maps a sequence using a reference-based mapper which may return an error.
-// Mapping stops if the mapper returns an error, returns nil, or if the consumer declines the yielded value.
+// MapSequenceRefWithError maps a sequence using a reference-based mapper which
+// may return an error.
+// Mapping stops if the mapper returns an error, returns nil, or if the consumer
+// declines the yielded value.
+//
+// This is useful when lazy iteration and pointer-oriented mapping need to be
+// combined with validation or other error-producing transformations.
 func MapSequenceRefWithError[T1 any, T2 any](s iter.Seq[T1], f MapRefWithErrorFunc[T1, T2]) iter.Seq[T2] {
 	return func(yield func(T2) bool) {
 		for v := range s {
@@ -71,6 +99,10 @@ func MapSequenceRefWithError[T1 any, T2 any](s iter.Seq[T1], f MapRefWithErrorFu
 }
 
 // Map applies f to each element of s and returns a slice with the results.
+//
+// This is useful for eagerly transforming one slice into another, for example
+// converting IDs to strings, extracting names from structs, or normalising
+// values before further processing.
 func Map[T1 any, T2 any](s []T1, f MapFunc[T1, T2]) []T2 {
 	return slices.Collect[T2](MapSequence(slices.Values(s), f))
 }
@@ -92,13 +124,21 @@ func MapWithError[T1 any, T2 any](s []T1, f MapWithErrorFunc[T1, T2]) (result []
 	return
 }
 
-// MapRef applies a reference-based mapping function to s and returns the mapped slice.
+// MapRef applies a reference-based mapping function to s and returns the mapped
+// slice.
+//
+// This is useful when eager slice transformation should reuse logic written for
+// pointer-oriented mappers.
 func MapRef[T1 any, T2 any](s []T1, f MapRefFunc[T1, T2]) []T2 {
 	return slices.Collect[T2](MapSequenceRef(slices.Values(s), f))
 }
 
 // MapRefWithError applies a reference-based mapper that may return an error.
-// If the mapper returns nil or an error, processing stops and an error is returned.
+// If the mapper returns nil or an error, processing stops and an error is
+// returned.
+//
+// This is useful when eager slice transformation should stop as soon as an
+// invalid or missing mapped value is encountered.
 func MapRefWithError[T1 any, T2 any](s []T1, f MapRefWithErrorFunc[T1, T2]) (result []T2, err error) {
 	result = make([]T2, len(s))
 

--- a/utils/collection/random.go
+++ b/utils/collection/random.go
@@ -1,0 +1,68 @@
+package collection
+
+import (
+	cryptorand "crypto/rand"
+	"math/big"
+	"slices"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/reflection"
+	"github.com/ARM-software/golang-utils/utils/safecast"
+)
+
+// Random returns a random element from the slice.
+//
+// This is useful when one arbitrary element should be sampled from a slice,
+// such as choosing a test case, backend, worker, or candidate value.
+//
+// The first return value is the selected element.
+// The second return value reports whether an element could be selected.
+// If the slice is empty, Random returns the zero value of E and false.
+//
+// Reference documentation:
+//   - https://pkg.go.dev/crypto/rand
+func Random[S ~[]E, E any](slice S) (E, bool) {
+	if reflection.IsEmpty(slice) {
+		var zero E
+		return zero, false
+	}
+
+	idx, err := cryptoIntn(len(slice))
+	if err != nil {
+		var zero E
+		return zero, false
+	}
+
+	return slice[idx], true
+}
+
+// Shuffle returns a shuffled copy of the slice.
+//
+// This is useful when the same elements should be processed in a random order
+// without mutating the original slice.
+//
+// Reference documentation:
+//   - https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
+//   - https://pkg.go.dev/crypto/rand
+func Shuffle[S ~[]E, E any](slice S) S {
+	result := slices.Clone(slice)
+	for i := len(result) - 1; i > 0; i-- {
+		j, err := cryptoIntn(i + 1)
+		if err != nil {
+			return result
+		}
+		result[i], result[j] = result[j], result[i]
+	}
+	return result
+}
+
+func cryptoIntn(max int) (int, error) {
+	if max <= 0 {
+		return 0, commonerrors.UndefinedVariable("maximum random range")
+	}
+	value, err := cryptorand.Int(cryptorand.Reader, big.NewInt(int64(max)))
+	if err != nil {
+		return 0, err
+	}
+	return safecast.ToInt(value.Int64()), nil
+}

--- a/utils/collection/random_test.go
+++ b/utils/collection/random_test.go
@@ -1,0 +1,30 @@
+package collection
+
+import (
+	"testing"
+
+	"github.com/go-faker/faker/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRandom(t *testing.T) {
+	value, found := Random([]int(nil))
+	assert.False(t, found)
+	assert.Zero(t, value)
+
+	items := []string{faker.Word(), faker.Name(), faker.Word()}
+	randomItem, foundString := Random(items)
+	require.True(t, foundString)
+	assert.Contains(t, items, randomItem)
+}
+
+func TestShuffle(t *testing.T) {
+	items := []string{faker.Word(), faker.Name(), faker.Word(), faker.Name(), faker.Word()}
+	shuffled := Shuffle(items)
+	assert.ElementsMatch(t, items, shuffled)
+	assert.Equal(t, items, items)
+
+	empty := Shuffle([]int(nil))
+	assert.Nil(t, empty)
+}

--- a/utils/collection/reduce.go
+++ b/utils/collection/reduce.go
@@ -9,18 +9,42 @@ import (
 // Reduce utilities
 //
 
-// ReduceFunc defines a reducer that combines an accumulator and an element to produce a new accumulator.
+// ReduceFunc defines a reducer that combines an accumulator and an element to
+// produce a new accumulator.
+//
+// Reducers are useful for aggregating collections into a single result, such as
+// totals, counts, grouped values, flattened structures, or derived summary
+// objects.
 type ReduceFunc[T1, T2 any] func(T2, T1) T2
 
 // ReduceRefFunc defines a reducer that operates on references.
+//
+// Reference-based reducers are useful when the accumulator or elements are more
+// naturally handled as pointers, for example when building up mutable state or
+// sharing reducer logic with other pointer-oriented helpers.
 type ReduceRefFunc[T1, T2 any] func(*T2, *T1) *T2
 
 // Reduce folds over the slice s using f, starting with accumulator.
+//
+// This is useful when a collection needs to be collapsed into one value, for
+// example summing values, building a lookup map, or computing a derived result
+// from many elements.
+//
+// Reference documentation:
+//   - https://en.wikipedia.org/wiki/Fold_(higher-order_function)
+//   - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce
 func Reduce[T1, T2 any](s []T1, accumulator T2, f ReduceFunc[T1, T2]) T2 {
 	return ReducesSequence(slices.Values(s), accumulator, f)
 }
 
 // ReducesSequence folds over a sequence using f, starting with accumulator.
+//
+// This is the sequence-oriented counterpart to Reduce and is useful when values
+// are consumed lazily rather than from a prebuilt slice, such as values flowing
+// through iterators or other on-demand pipelines.
+//
+// Reference documentation:
+//   - https://pkg.go.dev/iter
 func ReducesSequence[T1, T2 any](s iter.Seq[T1], accumulator T2, f ReduceFunc[T1, T2]) T2 {
 	result := accumulator
 	for e := range s {

--- a/utils/collection/set.go
+++ b/utils/collection/set.go
@@ -5,6 +5,8 @@ import (
 	"slices"
 
 	mapset "github.com/deckarep/golang-set/v2"
+
+	"github.com/ARM-software/golang-utils/utils/field"
 )
 
 //
@@ -23,6 +25,46 @@ func UniqueEntries[T comparable](slice []T) []T {
 // The order of elements is not guaranteed.
 func Unique[T comparable](s iter.Seq[T]) []T {
 	return UniqueEntries(slices.Collect(s))
+}
+
+// UniqueBy returns the first occurrence of each unique derived key.
+//
+// This is useful when values should remain in input order while duplicates are
+// removed based on a derived property such as an ID, normalised string, or
+// computed category.
+//
+// Reference documentation:
+//   - https://underscorejs.org/#uniq
+func UniqueBy[S ~[]E, E any, K comparable](slice S, keyFunc KeyFunc[E, K]) S {
+	return UniqueBySequence(slices.Values(slice), keyFunc)
+}
+
+// UniqueByRef behaves like UniqueBy but accepts a reference-based key
+// function.
+func UniqueByRef[S ~[]E, E any, K comparable](slice S, keyFunc KeyRefFunc[E, K]) S {
+	return UniqueBy(slice, toKeyFunc(keyFunc))
+}
+
+// UniqueBySequence returns the first occurrence of each unique derived key from
+// a sequence.
+func UniqueBySequence[E any, K comparable](sequence iter.Seq[E], keyFunc KeyFunc[E, K]) []E {
+	seen := map[K]struct{}{}
+	return ReducesSequence(sequence, []E{}, func(acc []E, element E) []E {
+		key := keyFunc(element)
+		if _, found := seen[key]; found {
+			return acc
+		}
+		seen[key] = struct{}{}
+		return append(acc, element)
+	})
+}
+
+// UniqueByRefSequence behaves like UniqueBySequence but accepts a
+// reference-based key function.
+func UniqueByRefSequence[E any, K comparable](sequence iter.Seq[E], keyFunc KeyRefFunc[E, K]) []E {
+	return UniqueBySequence(sequence, func(element E) K {
+		return keyFunc(field.ToOptionalOrNilIfEmpty(element))
+	})
 }
 
 // Union returns the union of slice1 and slice2, containing only unique

--- a/utils/collection/set_test.go
+++ b/utils/collection/set_test.go
@@ -1,0 +1,49 @@
+package collection
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUniqueBy(t *testing.T) {
+	type planet struct {
+		Name   string
+		Radius int
+	}
+
+	neptune := planet{Name: "Neptune", Radius: 24622000}
+	mars := planet{Name: "Mars", Radius: 3389500}
+	sameRadiusAsMars := planet{Name: "Same Radius as Mars", Radius: 3389500}
+
+	planets := []planet{mars, neptune, sameRadiusAsMars}
+	uniquePlanets := UniqueBy(planets, func(planet planet) int {
+		return planet.Radius
+	})
+	require.Len(t, uniquePlanets, 2)
+	assert.Equal(t, mars, uniquePlanets[0])
+	assert.Equal(t, neptune, uniquePlanets[1])
+
+	uniquePlanetsRef := UniqueByRef(planets, func(planet *planet) int {
+		return planet.Radius
+	})
+	require.Len(t, uniquePlanetsRef, 2)
+	assert.Equal(t, mars, uniquePlanetsRef[0])
+	assert.Equal(t, neptune, uniquePlanetsRef[1])
+
+	uniquePlanetsSequence := UniqueBySequence(slices.Values(planets), func(planet planet) int {
+		return planet.Radius
+	})
+	require.Len(t, uniquePlanetsSequence, 2)
+	assert.Equal(t, mars, uniquePlanetsSequence[0])
+	assert.Equal(t, neptune, uniquePlanetsSequence[1])
+
+	uniquePlanetsRefSequence := UniqueByRefSequence(slices.Values(planets), func(planet *planet) int {
+		return planet.Radius
+	})
+	require.Len(t, uniquePlanetsRefSequence, 2)
+	assert.Equal(t, mars, uniquePlanetsRefSequence[0])
+	assert.Equal(t, neptune, uniquePlanetsRefSequence[1])
+}

--- a/utils/reflection/reflection.go
+++ b/utils/reflection/reflection.go
@@ -196,6 +196,11 @@ func IsEmpty(value any) bool {
 	return valueUtils.IsEmpty(value)
 }
 
+// IsNotEmpty checks whether a value is not empty. See IsEmpty for more details about what is considered empty.
+func IsNotEmpty(value any) bool {
+	return valueUtils.IsNotEmpty(value)
+}
+
 // IsNilInterface checks whether an interface value is nil even when it has been
 // passed around as `any`.
 func IsNilInterface(i any) bool {

--- a/utils/reflection/reflection_test.go
+++ b/utils/reflection/reflection_test.go
@@ -508,6 +508,7 @@ func TestIsEmpty(t *testing.T) {
 		test := tests[i]
 		t.Run(fmt.Sprintf("subtest #%v (%v)", i, test.value), func(t *testing.T) {
 			assert.Equal(t, test.isEmpty, IsEmpty(test.value))
+			assert.NotEqual(t, test.isEmpty, IsNotEmpty(test.value))
 			if test.isEmpty && !test.differsFromAssertEmpty {
 				assert.Empty(t, test.value)
 			} else {

--- a/utils/value/empty.go
+++ b/utils/value/empty.go
@@ -44,6 +44,11 @@ func IsEmpty(value any) bool {
 	}
 }
 
+// IsNotEmpty checks whether a value is not empty. See IsEmpty for more details about what is considered empty.
+func IsNotEmpty(value any) bool {
+	return !IsEmpty(value)
+}
+
 // IsNilInterface checks whether an interface value is nil even when it has been
 // passed around as `any`.
 func IsNilInterface(i any) bool {

--- a/utils/value/empty_test.go
+++ b/utils/value/empty_test.go
@@ -126,6 +126,7 @@ func TestIsEmpty(t *testing.T) {
 		test := tests[i]
 		t.Run(fmt.Sprintf("subtest #%v (%v)", i, test.value), func(t *testing.T) {
 			assert.Equal(t, test.isEmpty, IsEmpty(test.value))
+			assert.NotEqual(t, test.isEmpty, IsNotEmpty(test.value))
 			if test.isEmpty && !test.differsFromAssertEmpty {
 				assert.Empty(t, test.value)
 			} else {


### PR DESCRIPTION



<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

new utility helpers for common slice operations:

    randomisation: Random, Shuffle
    grouping/counting: GroupBy, CountBy, FrequenciesBy
    transformation: FlatMap
    keyed deduplication: UniqueBy



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
