### PR TITLE
:bug: Ensure that different formats with the same start fence are treated as distinct formats

### DIFF
--- a/changes/20260602103158.bugfix
+++ b/changes/20260602103158.bugfix
@@ -1,0 +1,1 @@
+:bug: Ensure that different formats with the same start fence are treated as distinct formats

--- a/changes/20260602103158.bugfix
+++ b/changes/20260602103158.bugfix
@@ -1,1 +1,1 @@
-:bug: Ensure that different formats with the same start fence are treated as distinct formats
+:bug: `[frontmatter]` Ensure that different formats with the same start fence are treated as distinct formats

--- a/utils/serialization/frontmatter/parser.go
+++ b/utils/serialization/frontmatter/parser.go
@@ -14,8 +14,8 @@ import (
 
 // NewParser returns a parser for the supplied front matter formats.
 //
-// The formats are checked in order, and the first format whose opening
-// delimiter matches the start of the reader is used.
+// The formats are checked in order, with all formats sharing the detected
+// opening delimiter considered during the same parsing pass.
 func NewParser(formats ...*Format) (p IFrontMatterParser, err error) {
 	if reflection.IsEmpty(formats) {
 		err = commonerrors.UndefinedVariable("formats")
@@ -92,8 +92,14 @@ func (p *parser) Parse(ctx context.Context, r io.Reader) (frontmatter io.Reader,
 	if err != nil {
 		return
 	}
+
 	frontmatter = safeio.NewByteReader(ctx, content)
 	return
+}
+
+type candidateFormat struct {
+	format *Format
+	start  int
 }
 
 type extractor struct {
@@ -106,7 +112,7 @@ type extractor struct {
 }
 
 func (e *extractor) extract() ([]byte, error) {
-	format, found, err := e.detect()
+	candidates, found, err := e.detect()
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +120,7 @@ func (e *extractor) extract() ([]byte, error) {
 		return nil, commonerrors.New(commonerrors.ErrNotFound, "front matter not found")
 	}
 
-	found, err = e.capture(format)
+	start, end, found, err := e.capture(candidates)
 	if err != nil {
 		return nil, err
 	}
@@ -122,10 +128,13 @@ func (e *extractor) extract() ([]byte, error) {
 		return nil, commonerrors.New(commonerrors.ErrNotFound, "front matter not found")
 	}
 
-	return e.output.Bytes()[e.start:e.end], nil
+	e.start = start
+	e.end = end
+
+	return e.output.Bytes()[start:end], nil
 }
 
-func (e *extractor) detect() (*Format, bool, error) {
+func (e *extractor) detect() (candidates []*candidateFormat, found bool, err error) {
 	for {
 		read := e.read
 
@@ -148,54 +157,93 @@ func (e *extractor) detect() (*Format, bool, error) {
 			if format.Start != line {
 				continue
 			}
+
+			candidateStart := read
 			if !format.IncludeDelimitersWhenUnmarshalling {
-				read = e.read
+				candidateStart = e.read
 			}
-			e.start = read
-			return format, true, nil
+
+			candidates = append(candidates, &candidateFormat{format: format, start: candidateStart})
 		}
 
-		return nil, false, nil
+		if len(candidates) == 0 {
+			return nil, false, nil
+		}
+
+		return candidates, true, nil
 	}
 }
 
-func (e *extractor) capture(format *Format) (bool, error) {
+func (e *extractor) capture(candidates []*candidateFormat) (start int, end int, found bool, err error) {
 	for {
 		read := e.read
 
 		line, err := e.readLine()
 		if commonerrors.Ignore(err, commonerrors.ErrEOF) != nil {
-			return false, err
+			return 0, 0, false, err
 		}
 
-		if line != format.End {
+		matchingCandidates := matchingEndCandidates(candidates, line)
+		if len(matchingCandidates) == 0 {
 			if err != nil {
-				return false, nil
+				return 0, 0, false, nil
 			}
+
 			continue
 		}
 
-		if format.IncludeDelimitersWhenUnmarshalling {
-			read = e.read
-		}
-
-		if format.RequiresNewLine {
-			nextLine, nextErr := e.readLine()
-			nextEOF := commonerrors.Any(nextErr, commonerrors.ErrEOF)
-			if commonerrors.Ignore(nextErr, commonerrors.ErrEOF) != nil {
-				return false, nextErr
-			}
-			if nextLine != "" {
-				if nextEOF {
-					return false, nil
-				}
+		for _, candidate := range matchingCandidates {
+			if candidate.format.RequiresNewLine {
 				continue
 			}
+
+			candidateEnd := read
+			if candidate.format.IncludeDelimitersWhenUnmarshalling {
+				candidateEnd = e.read
+			}
+
+			return candidate.start, candidateEnd, true, nil
 		}
 
-		e.end = read
-		return true, nil
+		endAfterClosingLine := read
+		if matchingCandidates[0].format.IncludeDelimitersWhenUnmarshalling {
+			endAfterClosingLine = e.read
+		}
+
+		nextLine, nextErr := e.readLine()
+		nextEOF := commonerrors.Any(nextErr, commonerrors.ErrEOF)
+		if commonerrors.Ignore(nextErr, commonerrors.ErrEOF) != nil {
+			return 0, 0, false, nextErr
+		}
+
+		if nextLine != "" {
+			if nextEOF {
+				return 0, 0, false, nil
+			}
+
+			continue
+		}
+
+		candidate := matchingCandidates[0]
+		candidateEnd := endAfterClosingLine
+		if !candidate.format.IncludeDelimitersWhenUnmarshalling {
+			candidateEnd = read
+		}
+
+		return candidate.start, candidateEnd, true, nil
 	}
+}
+
+func matchingEndCandidates(candidates []*candidateFormat, line string) (matching []*candidateFormat) {
+	for _, candidate := range candidates {
+		if candidate.format.End != line {
+			continue
+		}
+
+		matching = append(matching, candidate)
+	}
+
+	return
 }
 
 func (e *extractor) readLine() (line string, err error) {

--- a/utils/serialization/frontmatter/parser_test.go
+++ b/utils/serialization/frontmatter/parser_test.go
@@ -231,6 +231,21 @@ func TestParseWithMultipleFormats(t *testing.T) {
 	assert.Equal(t, "title = \"Test\"\n", string(content))
 }
 
+func TestParseWithMultipleFormatsUsingSameOpeningFence(t *testing.T) {
+	yamlSeparatorFormat := NewFormat(WithStart("---"), WithEnd("---"))
+	yamlDocumentEndFormat := NewFormat(WithStart("---"), WithEnd("..."))
+
+	p, err := NewParser(yamlSeparatorFormat, yamlDocumentEndFormat)
+	require.NoError(t, err)
+
+	frontMatter, err := p.Parse(context.Background(), strings.NewReader("---\ntitle: Test\n...\nbody\n"))
+	require.NoError(t, err)
+
+	content, err := safeio.ReadAll(context.Background(), frontMatter)
+	require.NoError(t, err)
+	assert.Equal(t, "title: Test\n", string(content))
+}
+
 func TestParseYAMLExampleFilesInspiredByJxsonFrontMatter(t *testing.T) {
 	// Sources:
 	// - https://github.com/jxson/front-matter/blob/master/examples/yaml-seperator.md

--- a/utils/serialization/yaml/frontmatter/extractor.go
+++ b/utils/serialization/yaml/frontmatter/extractor.go
@@ -16,6 +16,14 @@ func NewYAMLFrontmatterFormat() *frontmatter.Format {
 	return frontmatter.NewFormat(frontmatter.WithStart("---"), frontmatter.WithEnd("---"))
 }
 
+// NewYAMLDocumentEndFrontmatterFormat returns the YAML front matter format that
+// uses the YAML document end marker.
+//
+// Source: https://yaml.org/spec/1.2.2/#912-document-markers
+func NewYAMLDocumentEndFrontmatterFormat() *frontmatter.Format {
+	return frontmatter.NewFormat(frontmatter.WithStart("---"), frontmatter.WithEnd("..."))
+}
+
 // NewYAML2FrontmatterFormat returns the alternative YAML front matter format
 // using `---yaml` as the opening delimiter.
 //
@@ -29,7 +37,7 @@ func NewYAML2FrontmatterFormat() *frontmatter.Format {
 // The extractor tries the known YAML front matter formats in order and returns
 // only the extracted front matter bytes.
 func ExtractYAMLFrontmatter(ctx context.Context, r io.Reader) (content []byte, err error) {
-	p, err := frontmatter.NewParser(NewYAMLFrontmatterFormat(), NewYAML2FrontmatterFormat())
+	p, err := frontmatter.NewParser(NewYAMLFrontmatterFormat(), NewYAMLDocumentEndFrontmatterFormat(), NewYAML2FrontmatterFormat())
 	if err != nil {
 		err = commonerrors.DescribeCircumstance(err, "cannot create a YAML frontmatter parser")
 		return

--- a/utils/serialization/yaml/frontmatter/extractor_test.go
+++ b/utils/serialization/yaml/frontmatter/extractor_test.go
@@ -26,6 +26,12 @@ func TestExtractYAMLFrontmatterInspiredBySimplematter(t *testing.T) {
 	assert.Equal(t, "hello: yaml\n", string(content))
 }
 
+func TestExtractYAMLFrontmatterWithDocumentEndMarker(t *testing.T) {
+	content, err := ExtractYAMLFrontmatter(context.Background(), strings.NewReader("---\nhello: yaml\n...\nRest of document\n"))
+	require.NoError(t, err)
+	assert.Equal(t, "hello: yaml\n", string(content))
+}
+
 func TestExtractYAMLFrontmatterCRLFInspiredBySimplematterAndPositFrontmatter(t *testing.T) {
 	// Sources:
 	// - https://github.com/remcohaszing/simplematter/blob/main/test/test.ts


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Ensure that different formats with the same start fence are treated as distinct formats

the old parser would:
1. see ---
2. pick the first --- format
3. look only for closing ---
4. hit EOF / fail
5. report not found if it had a different end

This will still fallback to one the first parser (like it did before) if you have formats that aren't compatible e.g.:

Start: "---", End: "---", include delimiters false
Start: "---", End: "---", include delimiters true

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
