### PR TITLE
:bug: `[collection]` Fixed collection sequence helpers so nil `iter.Seq` values no longer panic

### DIFF
--- a/changes/20260608103100.bugfix
+++ b/changes/20260608103100.bugfix
@@ -1,0 +1,1 @@
+Fixed collection sequence helpers so nil `iter.Seq` values no longer panic and instead behave like empty sequences.

--- a/utils/collection/conditions.go
+++ b/utils/collection/conditions.go
@@ -128,10 +128,7 @@ func Any(slice []bool) bool {
 
 // AnySequence returns true if there is at least one element of the slice which is true.
 func AnySequence(seq iter.Seq[bool]) bool {
-	if seq == nil {
-		return false
-	}
-	for e := range seq {
+	for e := range sequenceOrEmpty(seq) {
 		if e {
 			return true
 		}
@@ -147,7 +144,7 @@ func AnyTrue(values ...bool) bool {
 // AnyFalseSequence returns true if there is at least one element of the sequence which is false. If the sequence is empty, it also returns true.
 func AnyFalseSequence(eq iter.Seq[bool]) bool {
 	hasElements := false
-	for e := range eq {
+	for e := range sequenceOrEmpty(eq) {
 		hasElements = true
 		if !e {
 			return true

--- a/utils/collection/conditions.go
+++ b/utils/collection/conditions.go
@@ -128,7 +128,7 @@ func Any(slice []bool) bool {
 
 // AnySequence returns true if there is at least one element of the slice which is true.
 func AnySequence(seq iter.Seq[bool]) bool {
-	for e := range sequenceOrEmpty(seq) {
+	for e := range SequenceOrEmpty(seq) {
 		if e {
 			return true
 		}
@@ -144,7 +144,7 @@ func AnyTrue(values ...bool) bool {
 // AnyFalseSequence returns true if there is at least one element of the sequence which is false. If the sequence is empty, it also returns true.
 func AnyFalseSequence(eq iter.Seq[bool]) bool {
 	hasElements := false
-	for e := range sequenceOrEmpty(eq) {
+	for e := range SequenceOrEmpty(eq) {
 		hasElements = true
 		if !e {
 			return true

--- a/utils/collection/filter.go
+++ b/utils/collection/filter.go
@@ -129,7 +129,7 @@ func FilterRef[S ~[]E, E any](s S, f FilterRefFunc[E]) S {
 //   - https://pkg.go.dev/iter
 func FilterSequence[E any](s iter.Seq[E], f Predicate[E]) (result iter.Seq[E]) {
 	return func(yield func(E) bool) {
-		for v := range sequenceOrEmpty(s) {
+		for v := range SequenceOrEmpty(s) {
 			if f(v) && !yield(v) {
 				return
 			}

--- a/utils/collection/filter.go
+++ b/utils/collection/filter.go
@@ -129,7 +129,7 @@ func FilterRef[S ~[]E, E any](s S, f FilterRefFunc[E]) S {
 //   - https://pkg.go.dev/iter
 func FilterSequence[E any](s iter.Seq[E], f Predicate[E]) (result iter.Seq[E]) {
 	return func(yield func(E) bool) {
-		for v := range s {
+		for v := range sequenceOrEmpty(s) {
 			if f(v) && !yield(v) {
 				return
 			}

--- a/utils/collection/find.go
+++ b/utils/collection/find.go
@@ -30,7 +30,7 @@ func Find(slice *[]string, val string) (int, bool) {
 // match exists, it returns -1 and false.
 func FindInSequence[E any](elements iter.Seq[E], predicate Predicate[E]) (int, bool) {
 	idx := atomic.NewUint64(0)
-	for e := range sequenceOrEmpty(elements) {
+	for e := range SequenceOrEmpty(elements) {
 		if predicate(e) {
 			return safecast.ToInt(idx.Load()), true
 		}

--- a/utils/collection/find.go
+++ b/utils/collection/find.go
@@ -29,11 +29,8 @@ func Find(slice *[]string, val string) (int, bool) {
 // element and true when a match is found. If elements is nil or no
 // match exists, it returns -1 and false.
 func FindInSequence[E any](elements iter.Seq[E], predicate Predicate[E]) (int, bool) {
-	if elements == nil {
-		return -1, false
-	}
 	idx := atomic.NewUint64(0)
-	for e := range elements {
+	for e := range sequenceOrEmpty(elements) {
 		if predicate(e) {
 			return safecast.ToInt(idx.Load()), true
 		}

--- a/utils/collection/iterator.go
+++ b/utils/collection/iterator.go
@@ -25,11 +25,20 @@ type OperationWithoutErrorFunc[E any] func(E)
 type OperationWithoutErrorRefFunc[E any] func(*E)
 
 // EmptySequence returns a sequence that yields no values.
+//
+// This is useful when APIs need to return an `iter.Seq` but have nothing to
+// produce, or when a nil sequence should be normalised to a safe empty value so
+// callers can range over it without panicking.
 func EmptySequence[T any]() iter.Seq[T] {
 	return func(func(T) bool) {}
 }
 
-func sequenceOrEmpty[T any](s iter.Seq[T]) iter.Seq[T] {
+// SequenceOrEmpty returns s when it is non-nil, otherwise it returns an empty
+// sequence.
+//
+// This is useful when consuming code wants a guaranteed safe `iter.Seq` value
+// that can be ranged over without needing a separate nil check.
+func SequenceOrEmpty[T any](s iter.Seq[T]) iter.Seq[T] {
 	if s == nil {
 		return EmptySequence[T]()
 	}
@@ -65,7 +74,7 @@ func convertOperationWithoutError[E any](f OperationWithoutErrorFunc[E]) Operati
 // returns a non-EOF error, iteration stops and that error is returned.
 // If f returns EOF, the EOF is ignored and iteration ends without error.
 func Each[T any](s iter.Seq[T], f OperationFunc[T]) error {
-	for e := range sequenceOrEmpty(s) {
+	for e := range SequenceOrEmpty(s) {
 		err := f(e)
 		if err != nil {
 			err = commonerrors.Ignore(err, commonerrors.ErrEOF)

--- a/utils/collection/iterator.go
+++ b/utils/collection/iterator.go
@@ -24,6 +24,18 @@ type OperationWithoutErrorFunc[E any] func(E)
 // OperationWithoutErrorRefFunc defines an operation on a pointer that does not return an error.
 type OperationWithoutErrorRefFunc[E any] func(*E)
 
+// EmptySequence returns a sequence that yields no values.
+func EmptySequence[T any]() iter.Seq[T] {
+	return func(func(T) bool) {}
+}
+
+func sequenceOrEmpty[T any](s iter.Seq[T]) iter.Seq[T] {
+	if s == nil {
+		return EmptySequence[T]()
+	}
+	return s
+}
+
 // toOperationFunc adapts an OperationRefFunc to an OperationFunc by
 // converting the value to an optional reference.
 func toOperationFunc[E any](f OperationRefFunc[E]) OperationFunc[E] {
@@ -53,7 +65,7 @@ func convertOperationWithoutError[E any](f OperationWithoutErrorFunc[E]) Operati
 // returns a non-EOF error, iteration stops and that error is returned.
 // If f returns EOF, the EOF is ignored and iteration ends without error.
 func Each[T any](s iter.Seq[T], f OperationFunc[T]) error {
-	for e := range s {
+	for e := range sequenceOrEmpty(s) {
 		err := f(e)
 		if err != nil {
 			err = commonerrors.Ignore(err, commonerrors.ErrEOF)

--- a/utils/collection/mapping.go
+++ b/utils/collection/mapping.go
@@ -60,7 +60,7 @@ func MapSequence[T1 any, T2 any](s iter.Seq[T1], f MapFunc[T1, T2]) iter.Seq[T2]
 // value.
 func MapSequenceWithError[T1 any, T2 any](s iter.Seq[T1], f MapWithErrorFunc[T1, T2]) iter.Seq[T2] {
 	return func(yield func(T2) bool) {
-		for v := range sequenceOrEmpty(s) {
+		for v := range SequenceOrEmpty(s) {
 			mapped, err := f(v)
 			if err != nil || !yield(mapped) {
 				return
@@ -89,7 +89,7 @@ func MapSequenceRef[T1 any, T2 any](s iter.Seq[T1], f MapRefFunc[T1, T2]) iter.S
 // combined with validation or other error-producing transformations.
 func MapSequenceRefWithError[T1 any, T2 any](s iter.Seq[T1], f MapRefWithErrorFunc[T1, T2]) iter.Seq[T2] {
 	return func(yield func(T2) bool) {
-		for v := range sequenceOrEmpty(s) {
+		for v := range SequenceOrEmpty(s) {
 			mapped, err := f(field.ToOptionalOrNilIfEmpty(v))
 			if err != nil || mapped == nil || !yield(*mapped) {
 				return

--- a/utils/collection/mapping.go
+++ b/utils/collection/mapping.go
@@ -60,7 +60,7 @@ func MapSequence[T1 any, T2 any](s iter.Seq[T1], f MapFunc[T1, T2]) iter.Seq[T2]
 // value.
 func MapSequenceWithError[T1 any, T2 any](s iter.Seq[T1], f MapWithErrorFunc[T1, T2]) iter.Seq[T2] {
 	return func(yield func(T2) bool) {
-		for v := range s {
+		for v := range sequenceOrEmpty(s) {
 			mapped, err := f(v)
 			if err != nil || !yield(mapped) {
 				return
@@ -89,7 +89,7 @@ func MapSequenceRef[T1 any, T2 any](s iter.Seq[T1], f MapRefFunc[T1, T2]) iter.S
 // combined with validation or other error-producing transformations.
 func MapSequenceRefWithError[T1 any, T2 any](s iter.Seq[T1], f MapRefWithErrorFunc[T1, T2]) iter.Seq[T2] {
 	return func(yield func(T2) bool) {
-		for v := range s {
+		for v := range sequenceOrEmpty(s) {
 			mapped, err := f(field.ToOptionalOrNilIfEmpty(v))
 			if err != nil || mapped == nil || !yield(*mapped) {
 				return

--- a/utils/collection/queue/channel_queue.go
+++ b/utils/collection/queue/channel_queue.go
@@ -4,6 +4,7 @@ import (
 	"iter"
 	"slices"
 
+	"github.com/ARM-software/golang-utils/utils/collection"
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 )
 
@@ -38,6 +39,9 @@ func (q *ChanQueue[T]) Enqueue(values ...T) {
 // EnqueueSequence adds a sequence to the queue.
 // This blocks if the queue is full.
 func (q *ChanQueue[T]) EnqueueSequence(seq iter.Seq[T]) {
+	if seq == nil {
+		seq = collection.EmptySequence[T]()
+	}
 	for v := range seq {
 		q.ch <- v
 	}

--- a/utils/collection/queue/queue.go
+++ b/utils/collection/queue/queue.go
@@ -3,6 +3,8 @@ package queue
 import (
 	"iter"
 	"slices"
+
+	"github.com/ARM-software/golang-utils/utils/collection"
 )
 
 // NewQueue returns a Queue which is not thread safe
@@ -78,6 +80,9 @@ func (s *Queue[T]) Enqueue(value ...T) {
 }
 
 func (s *Queue[T]) EnqueueSequence(seq iter.Seq[T]) {
+	if seq == nil {
+		seq = collection.EmptySequence[T]()
+	}
 	for v := range seq {
 		s.enqueue(v)
 	}

--- a/utils/collection/queue/queue.go
+++ b/utils/collection/queue/queue.go
@@ -80,10 +80,7 @@ func (s *Queue[T]) Enqueue(value ...T) {
 }
 
 func (s *Queue[T]) EnqueueSequence(seq iter.Seq[T]) {
-	if seq == nil {
-		seq = collection.EmptySequence[T]()
-	}
-	for v := range seq {
+	for v := range collection.SequenceOrEmpty(seq) {
 		s.enqueue(v)
 	}
 }

--- a/utils/collection/range.go
+++ b/utils/collection/range.go
@@ -45,7 +45,7 @@ func RangeSequence[T safecast.IConvertible](start, stop T, step *T) iter.Seq[T] 
 func rangeSequence[T safecast.IConvertible](start, stop T, step *T) (it iter.Seq[T], length int) {
 	s := field.Optional[T](step, 1)
 	if s == 0 {
-		it = func(yield func(T) bool) {}
+		it = EmptySequence[T]()
 		return
 	}
 	length = determineRangeLength[T](start, stop, s)

--- a/utils/collection/reduce.go
+++ b/utils/collection/reduce.go
@@ -47,7 +47,7 @@ func Reduce[T1, T2 any](s []T1, accumulator T2, f ReduceFunc[T1, T2]) T2 {
 //   - https://pkg.go.dev/iter
 func ReducesSequence[T1, T2 any](s iter.Seq[T1], accumulator T2, f ReduceFunc[T1, T2]) T2 {
 	result := accumulator
-	for e := range s {
+	for e := range sequenceOrEmpty(s) {
 		result = f(result, e)
 	}
 	return result

--- a/utils/collection/reduce.go
+++ b/utils/collection/reduce.go
@@ -47,7 +47,7 @@ func Reduce[T1, T2 any](s []T1, accumulator T2, f ReduceFunc[T1, T2]) T2 {
 //   - https://pkg.go.dev/iter
 func ReducesSequence[T1, T2 any](s iter.Seq[T1], accumulator T2, f ReduceFunc[T1, T2]) T2 {
 	result := accumulator
-	for e := range sequenceOrEmpty(s) {
+	for e := range SequenceOrEmpty(s) {
 		result = f(result, e)
 	}
 	return result

--- a/utils/collection/sequence_test.go
+++ b/utils/collection/sequence_test.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package collection
+
+import (
+	"iter"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmptySequence(t *testing.T) {
+	assert.Empty(t, slices.Collect(EmptySequence[int]()))
+}
+
+func TestMapSequenceNil(t *testing.T) {
+	var seq iter.Seq[int]
+	assert.Empty(t, slices.Collect(MapSequence(seq, func(v int) int { return v + 1 })))
+}
+
+func TestFilterSequenceNil(t *testing.T) {
+	var seq iter.Seq[int]
+	assert.Empty(t, slices.Collect(FilterSequence(seq, func(v int) bool { return v%2 == 0 })))
+}
+
+func TestEachNilSequence(t *testing.T) {
+	var seq iter.Seq[int]
+	require.NoError(t, Each(seq, func(v int) error {
+		t.Fatalf("unexpected callback for value %d", v)
+		return nil
+	}))
+}
+
+func TestUniqueNilSequence(t *testing.T) {
+	var seq iter.Seq[int]
+	assert.Empty(t, Unique(seq))
+}

--- a/utils/collection/set.go
+++ b/utils/collection/set.go
@@ -24,7 +24,7 @@ func UniqueEntries[T comparable](slice []T) []T {
 // Unique returns the distinct values from the provided sequence.
 // The order of elements is not guaranteed.
 func Unique[T comparable](s iter.Seq[T]) []T {
-	return UniqueEntries(slices.Collect(s))
+	return UniqueEntries(slices.Collect(sequenceOrEmpty(s)))
 }
 
 // UniqueBy returns the first occurrence of each unique derived key.

--- a/utils/collection/set.go
+++ b/utils/collection/set.go
@@ -24,7 +24,7 @@ func UniqueEntries[T comparable](slice []T) []T {
 // Unique returns the distinct values from the provided sequence.
 // The order of elements is not guaranteed.
 func Unique[T comparable](s iter.Seq[T]) []T {
-	return UniqueEntries(slices.Collect(sequenceOrEmpty(s)))
+	return UniqueEntries(slices.Collect(SequenceOrEmpty(s)))
 }
 
 // UniqueBy returns the first occurrence of each unique derived key.

--- a/utils/collection/stack/stack.go
+++ b/utils/collection/stack/stack.go
@@ -75,10 +75,7 @@ func (s *Stack[T]) Push(value ...T) {
 }
 
 func (s *Stack[T]) PushSequence(seq iter.Seq[T]) {
-	if seq == nil {
-		seq = collection.EmptySequence[T]()
-	}
-	for v := range seq {
+	for v := range collection.SequenceOrEmpty(seq) {
 		s.push(v)
 	}
 }

--- a/utils/collection/stack/stack.go
+++ b/utils/collection/stack/stack.go
@@ -3,6 +3,8 @@ package stack
 import (
 	"iter"
 	"slices"
+
+	"github.com/ARM-software/golang-utils/utils/collection"
 )
 
 // NewStack returns a stack which is not thread safe
@@ -73,6 +75,9 @@ func (s *Stack[T]) Push(value ...T) {
 }
 
 func (s *Stack[T]) PushSequence(seq iter.Seq[T]) {
+	if seq == nil {
+		seq = collection.EmptySequence[T]()
+	}
 	for v := range seq {
 		s.push(v)
 	}


### PR DESCRIPTION

<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description
range on a nil sequence panics. This is to avoid this


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
