### PR TITLE
:sparkles: Added a package to change string casing

### DIFF
--- a/changes/20260608105000.feature
+++ b/changes/20260608105000.feature
@@ -1,0 +1,1 @@
+:sparkles: Added a package to change string casing but handling [go initialisms](https://go.dev/wiki/CodeReviewComments#initialisms)

--- a/utils/go.mod
+++ b/utils/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	github.com/sttk/stringcase v0.3.0
 	github.com/zalando/go-keyring v0.2.8
 	go.uber.org/atomic v1.11.0
 	go.uber.org/goleak v1.3.0

--- a/utils/go.sum
+++ b/utils/go.sum
@@ -255,6 +255,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/sttk/stringcase v0.3.0 h1:O0F67PImqZPBAZKc/hAih2H1coeLGMVwXFBw+7z60uI=
+github.com/sttk/stringcase v0.3.0/go.mod h1:o1IEzL6qw8YmFeXvFMxy7cWnL2o6hZ8lggG3acmUxHs=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=

--- a/utils/strings/casing/case.go
+++ b/utils/strings/casing/case.go
@@ -1,0 +1,42 @@
+package casing
+
+import (
+	"github.com/ARM-software/golang-utils/utils/collection"
+	"github.com/sttk/stringcase"
+)
+
+// ToCamelCase converts value to camelCase and optionally applies a replacer to the resulting identifier. Only the first replacer is used.
+func ToCamelCase(value string, replacers ...*Replacer) string {
+	result := stringcase.CamelCase(value)
+	if replacer, ok := collection.First(replacers); ok && replacer != nil {
+		return replacer.Replace(result)
+	}
+	return result
+}
+
+// ToPascalCase converts value to PascalCase and optionally applies a replacer to the resulting identifier. Only the first replacer is used.
+func ToPascalCase(value string, replacers ...*Replacer) string {
+	result := stringcase.PascalCase(value)
+	if replacer, ok := collection.First(replacers); ok && replacer != nil {
+		return replacer.Replace(result)
+	}
+	return result
+}
+
+// ToSnakeCase converts value to snake_case and optionally applies a replacer to the identifier before the final case conversion. Only the first replacer is used.
+func ToSnakeCase(value string, replacers ...*Replacer) string {
+	result := value
+	if replacer, ok := collection.First(replacers); ok && replacer != nil {
+		result = replacer.Replace(stringcase.PascalCase(value))
+	}
+	return stringcase.SnakeCase(result)
+}
+
+// ToKebabCase converts value to kebab-case and optionally applies a replacer to the identifier before the final case conversion. Only the first replacer is used.
+func ToKebabCase(value string, replacers ...*Replacer) string {
+	result := value
+	if replacer, ok := collection.First(replacers); ok && replacer != nil {
+		result = replacer.Replace(stringcase.PascalCase(value))
+	}
+	return stringcase.KebabCase(result)
+}

--- a/utils/strings/casing/case.go
+++ b/utils/strings/casing/case.go
@@ -1,8 +1,9 @@
 package casing
 
 import (
-	"github.com/ARM-software/golang-utils/utils/collection"
 	"github.com/sttk/stringcase"
+
+	"github.com/ARM-software/golang-utils/utils/collection"
 )
 
 // ToCamelCase converts value to camelCase and optionally applies a replacer to the resulting identifier. Only the first replacer is used.

--- a/utils/strings/casing/case_test.go
+++ b/utils/strings/casing/case_test.go
@@ -1,0 +1,92 @@
+package casing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCaseHelpersWithOptionalReplacer(t *testing.T) {
+	r, err := NewReplacer(
+		Rule{Token: "Api", Replacement: "API"},
+		Rule{Token: "Id", Replacement: "ID", Exceptions: []string{"identifier"}},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "apiClient", ToCamelCase("api_client", r))
+	assert.Equal(t, "APIClient", ToPascalCase("api_client", r))
+	assert.Equal(t, "api_client", ToSnakeCase("api_client", r))
+	assert.Equal(t, "api-client", ToKebabCase("api_client", r))
+}
+
+func TestCaseHelpersWithoutReplacer(t *testing.T) {
+	assert.Equal(t, "sourceName", ToCamelCase("source_name"))
+	assert.Equal(t, "SourceName", ToPascalCase("source_name"))
+	assert.Equal(t, "source_name", ToSnakeCase("sourceName"))
+	assert.Equal(t, "source-name", ToKebabCase("sourceName"))
+
+	assert.Equal(t, "aiapi", ToSnakeCase("AIAPI"))
+	assert.Equal(t, "aiapi", ToKebabCase("AIAPI"))
+	assert.Equal(t, "httpapi_token", ToSnakeCase("HTTPAPIToken"))
+	assert.Equal(t, "httpapi-token", ToKebabCase("HTTPAPIToken"))
+	assert.Equal(t, "httpapiToken", ToCamelCase("HTTPAPIToken"))
+	assert.Equal(t, "HttpapiToken", ToPascalCase("HTTPAPIToken"))
+}
+
+func TestCaseHelpersWithoutReplacer_StrcaseInspiredCases(t *testing.T) {
+	// These cases are adapted from the broader casing corpus used by
+	// github.com/ettle/strcase to make sure this package behaves consistently on
+	// common acronym and mixed-token inputs, even though this package does not
+	// apply Go initialism rules unless explicitly configured through a Replacer.
+	assert.Equal(t, "Id", ToPascalCase("ID"))
+	assert.Equal(t, "id", ToCamelCase("ID"))
+	assert.Equal(t, "id", ToSnakeCase("ID"))
+
+	assert.Equal(t, "userId", ToCamelCase("userID"))
+	assert.Equal(t, "UserId", ToPascalCase("userID"))
+	assert.Equal(t, "user_id", ToSnakeCase("userID"))
+
+	assert.Equal(t, "jsonBlob", ToCamelCase("JSON_blob"))
+	assert.Equal(t, "JsonBlob", ToPascalCase("JSON_blob"))
+	assert.Equal(t, "json_blob", ToSnakeCase("JSON_blob"))
+
+	assert.Equal(t, "httpStatusCode", ToCamelCase("HTTPStatusCode"))
+	assert.Equal(t, "HttpStatusCode", ToPascalCase("HTTPStatusCode"))
+	assert.Equal(t, "http_status_code", ToSnakeCase("HTTPStatusCode"))
+
+	assert.Equal(t, "freeBsd", ToCamelCase("FreeBSD"))
+	assert.Equal(t, "FreeBsd", ToPascalCase("FreeBSD"))
+	assert.Equal(t, "free_bsd", ToSnakeCase("FreeBSD"))
+}
+
+func TestCaseHelpersWithOptionalReplacer_StrcaseInspiredInitialisms(t *testing.T) {
+	r, err := NewReplacer(
+		Rule{Token: "Api", Replacement: "API"},
+		Rule{Token: "Http", Replacement: "HTTP"},
+		Rule{Token: "Id", Replacement: "ID"},
+		Rule{Token: "Json", Replacement: "JSON"},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "userID", ToCamelCase("user_id", r))
+	assert.Equal(t, "UserID", ToPascalCase("user_id", r))
+	assert.Equal(t, "user_id", ToSnakeCase("UserID", r))
+
+	assert.Equal(t, "httpStatusCode", ToCamelCase("http_status_code", r))
+	assert.Equal(t, "HTTPStatusCode", ToPascalCase("http_status_code", r))
+	assert.Equal(t, "http_status_code", ToSnakeCase("HTTPStatusCode", r))
+
+	assert.Equal(t, "jsonBlob", ToCamelCase("json_blob", r))
+	assert.Equal(t, "JSONBlob", ToPascalCase("json_blob", r))
+	assert.Equal(t, "json_blob", ToSnakeCase("JSONBlob", r))
+}
+
+func TestCaseHelpersUseOnlyFirstReplacer(t *testing.T) {
+	first, err := NewReplacer(Rule{Token: "Api", Replacement: "API"})
+	require.NoError(t, err)
+	second, err := NewReplacer(Rule{Token: "Api", Replacement: "XXX"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "APIClient", ToPascalCase("api_client", first, second))
+}

--- a/utils/strings/casing/doc.go
+++ b/utils/strings/casing/doc.go
@@ -1,0 +1,46 @@
+// Package casing rewrites identifier-like strings according to declarative
+// token replacement rules.
+//
+// "Identifier-like strings" here means names that are structured as code or
+// configuration identifiers rather than arbitrary prose, for example:
+//   - camelCase names such as `apiClient` or `sourceName`
+//   - PascalCase names such as `ApiClient` or `SourceName`
+//   - mixed acronym-containing identifiers such as `HttpAPIClient`
+//
+// It is intended for cases where callers need to preserve the overall casing
+// shape of such identifiers while forcing specific words to use a canonical
+// replacement and exempting other whole words through an exception list.
+//
+// This differs from simpler alternatives such as:
+//   - `strings.Replacer`, which is useful for literal substring replacement but
+//     does not understand identifier word boundaries or case reconstruction
+//   - regexp-based rewriting, which can express some token patterns but becomes
+//     awkward when replacement depends on identifier-style word splitting,
+//     acronym policies, and explicit exception lists
+//
+// The package therefore combines identifier splitting with rule-based word
+// replacement, rather than treating the input as an arbitrary free-form string.
+//
+// Unlike libraries that automatically apply a built-in Go initialism list, this
+// package only applies that behaviour when explicitly requested. Callers can opt
+// into it by creating a replacer from [InitialismRules] or by reusing the
+// ready-made [InitialismReplacer]. This keeps the package predictable for
+// domain-specific casing policies while still providing built-in optional Go
+// initialism support when wanted.
+//
+// Typical uses include:
+//   - normalising known acronyms in generated identifiers
+//   - preserving exception words that should not be rewritten
+//   - applying a shared replacement policy across tools or generators
+//
+// Related references:
+//   - Go initialisms guidance in effective naming:
+//     https://go.dev/wiki/CodeReviewComments#initialisms
+//   - `ettle/strcase`, which includes a broad casing test corpus and built-in
+//     Go-initialism-aware conversions:
+//     https://github.com/ettle/strcase
+//
+// The case-conversion helpers in this package accept `...*Replacer` so callers
+// can use one common helper shape whether they want replacement or not. Only
+// the first replacer is used; passing more than one replacer is not supported.
+package casing

--- a/utils/strings/casing/initialisms.go
+++ b/utils/strings/casing/initialisms.go
@@ -1,0 +1,65 @@
+package casing
+
+// InitialismRules defines replacement rules for the common Go initialisms.
+//
+// This variable can be passed directly to [NewReplacer] to opt into built-in
+// Go-style initialism normalisation, for example:
+//
+//	r, err := NewReplacer(InitialismRules...)
+//
+// The list is based on the standard Go initialism guidance:
+// https://go.dev/wiki/CodeReviewComments#initialisms
+var InitialismRules = []Rule{
+	{Token: "Acl", Replacement: "ACL"},
+	{Token: "Api", Replacement: "API"},
+	{Token: "Ascii", Replacement: "ASCII"},
+	{Token: "Cpu", Replacement: "CPU"},
+	{Token: "Css", Replacement: "CSS"},
+	{Token: "Dns", Replacement: "DNS"},
+	{Token: "Eof", Replacement: "EOF"},
+	{Token: "Guid", Replacement: "GUID"},
+	{Token: "Html", Replacement: "HTML"},
+	{Token: "Http", Replacement: "HTTP"},
+	{Token: "Https", Replacement: "HTTPS"},
+	{Token: "Id", Replacement: "ID"},
+	{Token: "Ip", Replacement: "IP"},
+	{Token: "Json", Replacement: "JSON"},
+	{Token: "Lhs", Replacement: "LHS"},
+	{Token: "Qps", Replacement: "QPS"},
+	{Token: "Ram", Replacement: "RAM"},
+	{Token: "Rhs", Replacement: "RHS"},
+	{Token: "Rpc", Replacement: "RPC"},
+	{Token: "Sla", Replacement: "SLA"},
+	{Token: "Smtp", Replacement: "SMTP"},
+	{Token: "Sql", Replacement: "SQL"},
+	{Token: "Ssh", Replacement: "SSH"},
+	{Token: "Tcp", Replacement: "TCP"},
+	{Token: "Tls", Replacement: "TLS"},
+	{Token: "Ttl", Replacement: "TTL"},
+	{Token: "Udp", Replacement: "UDP"},
+	{Token: "Ui", Replacement: "UI"},
+	{Token: "Uid", Replacement: "UID"},
+	{Token: "Uuid", Replacement: "UUID"},
+	{Token: "Uri", Replacement: "URI"},
+	{Token: "Url", Replacement: "URL"},
+	{Token: "Utf8", Replacement: "UTF8"},
+	{Token: "Vm", Replacement: "VM"},
+	{Token: "Xml", Replacement: "XML"},
+	{Token: "Xmpp", Replacement: "XMPP"},
+	{Token: "Xsrf", Replacement: "XSRF"},
+	{Token: "Xss", Replacement: "XSS"},
+}
+
+// InitialismReplacer is a ready-to-use replacer built from [InitialismRules].
+//
+// This variable provides built-in optional Go initialism support without
+// requiring callers to construct a replacer explicitly.
+var InitialismReplacer = mustNewReplacer(InitialismRules...)
+
+func mustNewReplacer(rules ...Rule) *Replacer {
+	replacer, err := NewReplacer(rules...)
+	if err != nil {
+		panic(err)
+	}
+	return replacer
+}

--- a/utils/strings/casing/replacement.go
+++ b/utils/strings/casing/replacement.go
@@ -115,7 +115,7 @@ func (r *Replacer) WriteString(ctx context.Context, w io.Writer, s string) (n in
 }
 
 func splitCamelWords(value string) []string {
-	if value == "" {
+	if reflection.IsEmpty(value) {
 		return nil
 	}
 	words := strings.Split(stringcase.SnakeCase(value), "_")

--- a/utils/strings/casing/replacement.go
+++ b/utils/strings/casing/replacement.go
@@ -1,0 +1,174 @@
+package casing
+
+import (
+	"context"
+	"io"
+	"slices"
+	"strings"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/sttk/stringcase"
+
+	"github.com/ARM-software/golang-utils/utils/collection"
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/reflection"
+	"github.com/ARM-software/golang-utils/utils/safeio"
+)
+
+// Rule defines a token replacement rule for identifier-like strings.
+type Rule struct {
+	Token       string
+	Replacement string
+	Exceptions  []string
+}
+
+// Validate checks that the rule contains the required values.
+func (r *Rule) Validate() (err error) {
+	err = validation.ValidateStruct(r,
+		validation.Field(&r.Token, validation.Required),
+		validation.Field(&r.Replacement, validation.Required),
+	)
+	if err != nil {
+		err = commonerrors.WrapError(commonerrors.ErrInvalid, err, "invalid replacement rule")
+	}
+	return
+}
+
+type compiledRule struct {
+	Replacement string
+	Exceptions  mapset.Set[string]
+}
+
+// Replacer applies token replacement rules to identifier-like strings.
+//
+// A replacer works at identifier word boundaries rather than by performing raw
+// substring replacement. In practice, this means it splits names such as
+// `OpenAiApiKey`, `openAiApiKey`, or `HTTPApiToken` into logical words, looks
+// up each word against the configured rules, and then rebuilds the identifier
+// while preserving its overall case style.
+//
+// If a word matches a configured rule, the rule's replacement is used unless
+// that word is listed in the rule's exceptions. If a word does not match any
+// rule, or it is exempted by an exception, it is reconstructed according to the
+// identifier shape being processed:
+//   - all-uppercase words are preserved as-is
+//   - the first word of a camelCase identifier remains lower camel case
+//   - subsequent words are emitted in PascalCase
+//
+// This makes Replacer useful for normalising acronyms and canonical tokens such
+// as `API`, `HTTP`, `ID`, or `AI` across generated names, configuration keys,
+// and code identifiers without losing the surrounding naming convention.
+type Replacer struct {
+	rules map[string]compiledRule
+}
+
+// NewReplacer constructs a Replacer from the provided rules.
+func NewReplacer(rules ...Rule) (*Replacer, error) {
+	compiled := make(map[string]compiledRule, len(rules))
+	err := collection.Each(slices.Values(rules), func(rule Rule) error {
+		if err := rule.Validate(); err != nil {
+			return err
+		}
+
+		exceptions := mapset.NewSet[string]()
+		normalised := collection.Map(rule.Exceptions, func(exception string) string {
+			return strings.ToLower(strings.TrimSpace(exception))
+		})
+		_ = exceptions.Append(normalised...)
+
+		compiled[strings.ToLower(strings.TrimSpace(rule.Token))] = compiledRule{
+			Replacement: rule.Replacement,
+			Exceptions:  exceptions,
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &Replacer{rules: compiled}, nil
+}
+
+// Replace rewrites an identifier-like string according to the configured rules while preserving camelCase or PascalCase shape.
+func (r *Replacer) Replace(value string) string {
+	if r == nil || reflection.IsEmpty(r.rules) || reflection.IsEmpty(value) {
+		return value
+	}
+
+	parts := splitCamelWords(value)
+	if len(parts) == 0 {
+		return value
+	}
+	firstWordLowercase := strings.ToLower(string(value[0])) == string(value[0])
+
+	var builder strings.Builder
+	builder.Grow(len(value))
+	collection.ForEach(parts, func(part string) {
+		builder.WriteString(r.transformWord(part, builder.Len() == 0, firstWordLowercase))
+	})
+	return builder.String()
+}
+
+// WriteString rewrites s with Replace and writes the result to w using the repository's context-aware safe I/O helpers.
+func (r *Replacer) WriteString(ctx context.Context, w io.Writer, s string) (n int, err error) {
+	return safeio.WriteString(ctx, w, r.Replace(s))
+}
+
+func splitCamelWords(value string) []string {
+	if value == "" {
+		return nil
+	}
+	words := strings.Split(stringcase.SnakeCase(value), "_")
+	parts := make([]string, 0, len(words))
+	start := 0
+	_ = collection.Each(slices.Values(words), func(word string) error {
+		end := start + len(word)
+		if end > len(value) {
+			parts = words
+			return io.EOF
+		}
+		parts = append(parts, value[start:end])
+		start = end
+		return nil
+	})
+	return parts
+}
+
+// transformWord rewrites one logical word inside an identifier while trying to preserve the identifier's overall shape.
+//
+// The method first normalises word for case-insensitive rule lookup. If there
+// is no matching rule, or if the matching rule marks the word as an exception,
+// the original word is reconstructed according to the target identifier style:
+//   - all-uppercase words such as `API` are preserved as-is
+//   - the first word of a camelCase identifier is emitted in lower camel case
+//   - every other word is emitted in PascalCase
+//
+// If a rule applies, its configured replacement is used instead of rebuilding
+// the word, with the only adjustment being that the first word is lowercased
+// when the overall identifier should remain camelCase.
+func (r *Replacer) transformWord(word string, first, firstWordLowercase bool) string {
+	lower := strings.ToLower(word)
+	rule, found := r.rules[lower]
+	if !found {
+		if word == strings.ToUpper(word) {
+			return word
+		}
+		if first && firstWordLowercase {
+			return stringcase.CamelCase(lower)
+		}
+		return stringcase.PascalCase(lower)
+	}
+	if rule.Exceptions.Contains(lower) {
+		if word == strings.ToUpper(word) {
+			return word
+		}
+		if first && firstWordLowercase {
+			return stringcase.CamelCase(lower)
+		}
+		return stringcase.PascalCase(lower)
+	}
+	if first && firstWordLowercase {
+		return strings.ToLower(rule.Replacement)
+	}
+	return rule.Replacement
+}

--- a/utils/strings/casing/replacement_test.go
+++ b/utils/strings/casing/replacement_test.go
@@ -1,0 +1,79 @@
+package casing
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewReplacer(t *testing.T) {
+	r, err := NewReplacer(Rule{
+		Token:       "Api",
+		Replacement: "API",
+		Exceptions:  []string{" apiClient ", "apiClient"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	assert.Equal(t, "apiClient", r.Replace("apiClient"))
+}
+
+func TestNewReplacerRejectsInvalidRule(t *testing.T) {
+	_, err := NewReplacer(Rule{Token: ""})
+	require.Error(t, err)
+}
+
+func TestReplacerReplace(t *testing.T) {
+	r, err := NewReplacer(
+		Rule{Token: "Ai", Replacement: "AI"},
+		Rule{Token: "Api", Replacement: "API"},
+		Rule{Token: "Id", Replacement: "ID", Exceptions: []string{"identifier", "idempotent"}},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "APIClient", r.Replace("ApiClient"))
+	assert.Equal(t, "apiClient", r.Replace("apiClient"))
+	assert.Equal(t, "OpenAIAPIKey", r.Replace("OpenAiApiKey"))
+	assert.Equal(t, "openAIAPIKey", r.Replace("openAiApiKey"))
+	assert.Equal(t, "kemID", r.Replace("kemId"))
+	assert.Equal(t, "AdrienIdentifier", r.Replace("AdrienIdentifier"))
+	assert.Equal(t, "idempotentRetry", r.Replace("idempotentRetry"))
+	assert.Equal(t, "OpenAIAPIKey", r.Replace("OpenAIAPIKey"))
+	assert.Equal(t, "openAIAPIKey", r.Replace("openAIAPIKey"))
+	assert.Equal(t, "sourceName", r.Replace("sourceName"))
+	assert.Equal(t, "", r.Replace(""))
+
+	assert.Equal(t, "AIAPI", r.Replace("AIAPI"))
+	assert.Equal(t, "HTTPAPIToken", r.Replace("HTTPApiToken"))
+	assert.Equal(t, "HTTPAPIToken", r.Replace("HTTPAPIToken"))
+}
+
+func TestReplacerWriteString(t *testing.T) {
+	r, err := NewReplacer(Rule{Token: "Api", Replacement: "API"})
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	n, err := r.WriteString(context.Background(), &buf, "ApiClient")
+	require.NoError(t, err)
+	assert.Equal(t, len("APIClient"), n)
+	assert.Equal(t, "APIClient", buf.String())
+}
+
+func TestInitialismRules(t *testing.T) {
+	r, err := NewReplacer(InitialismRules...)
+	require.NoError(t, err)
+
+	assert.Equal(t, "UserID", r.Replace("UserId"))
+	assert.Equal(t, "userID", r.Replace("userId"))
+	assert.Equal(t, "HTTPAPIToken", r.Replace("HttpApiToken"))
+	assert.Equal(t, "JSONBlob", r.Replace("JsonBlob"))
+}
+
+func TestInitialismReplacer(t *testing.T) {
+	require.NotNil(t, InitialismReplacer)
+	assert.Equal(t, "UserID", InitialismReplacer.Replace("UserId"))
+	assert.Equal(t, "userID", InitialismReplacer.Replace("userId"))
+	assert.Equal(t, "HTTPAPIToken", InitialismReplacer.Replace("HttpApiToken"))
+}


### PR DESCRIPTION
This is so that https://go.dev/wiki/CodeReviewComments#initialisms are correctly handled