### PR TITLE
:bug: `[casing]` fix the merging of rules rather than silently picking the latest defined

### DIFF
--- a/changes/20260608105500.feature
+++ b/changes/20260608105500.feature
@@ -1,0 +1,1 @@
+:sparkles: `[collection]` Added function composition helpers including `Combine`, `CombineRef`, `CombineWithError`, and `CombineRefWithError` for composing mapping functions right-to-left.

--- a/changes/20260608105600.feature
+++ b/changes/20260608105600.feature
@@ -1,0 +1,1 @@
+:sparkles: `[collection]` Added coalescing and merging helpers including `Coalesce`, `CoalesceRef`, `MergeBy`, and `MergeByRef` for compacting adjacent values and merging grouped values.

--- a/changes/20260618171355.bugfix
+++ b/changes/20260618171355.bugfix
@@ -1,0 +1,1 @@
+:bug: `[casing]` fix the merging of rules rather than silently picking the latest defined

--- a/utils/collection/coalesce.go
+++ b/utils/collection/coalesce.go
@@ -1,0 +1,58 @@
+package collection
+
+import (
+	"github.com/ARM-software/golang-utils/utils/field"
+	"github.com/ARM-software/golang-utils/utils/ptr"
+	"github.com/ARM-software/golang-utils/utils/reflection"
+)
+
+// Coalesce compacts items by merging adjacent compatible elements.
+//
+// Items are processed from left to right. Each new item is only considered for
+// merging with the last item already emitted in the output. If merge returns
+// ok=true, the last output item is replaced with the merged value; otherwise the
+// item is appended as a new output element.
+//
+// This is similar to Rust itertools::coalesce and is useful when neighbouring
+// values may collapse into a more compact representation.
+//
+// References:
+//   - https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.coalesce
+func Coalesce[T any](items []T, merge MergeFunc[T]) []T {
+	if reflection.IsEmpty(items) {
+		return []T{}
+	}
+
+	result := make([]T, 0, len(items))
+	ForEach(items, func(item T) {
+		last, found := Last(result)
+		if !found {
+			result = append(result, item)
+			return
+		}
+
+		merged, ok := merge(last, item)
+		if !ok {
+			result = append(result, item)
+			return
+		}
+
+		result[len(result)-1] = merged
+	})
+	return result
+}
+
+// CoalesceRef compacts items by merging adjacent compatible elements using a
+// reference-based merge function.
+func CoalesceRef[T any](items []T, merge MergeRefFunc[T]) []T {
+	return Coalesce(items, func(left, right T) (merged T, compatible bool) {
+		if merge == nil {
+			return merged, false
+		}
+		mergedRef, compatible := merge(field.ToOptional(left), field.ToOptional(right))
+		if !compatible || mergedRef == nil {
+			return merged, false
+		}
+		return ptr.From(mergedRef), true
+	})
+}

--- a/utils/collection/coalesce_test.go
+++ b/utils/collection/coalesce_test.go
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package collection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ARM-software/golang-utils/utils/field"
+)
+
+func TestCoalesceEmptySlice(t *testing.T) {
+	assert.Empty(t, Coalesce[int](nil, func(left, right int) (int, bool) { return 0, false }))
+	assert.Empty(t, Coalesce[int]([]int{}, func(left, right int) (int, bool) { return 0, false }))
+}
+
+func TestCoalesceSingleElement(t *testing.T) {
+	assert.Equal(t, []int{1}, Coalesce([]int{1}, func(left, right int) (int, bool) { return 0, false }))
+}
+
+func TestCoalesceNoMerges(t *testing.T) {
+	items := []int{1, 2, 3}
+	assert.Equal(t, items, Coalesce(items, func(left, right int) (int, bool) { return 0, false }))
+}
+
+func TestCoalesceRepeatedAdjacentMerges(t *testing.T) {
+	items := []int{1, 1, 1, 2}
+	result := Coalesce(items, func(left, right int) (int, bool) {
+		if left == right {
+			return left + right, true
+		}
+		return 0, false
+	})
+	assert.Equal(t, []int{2, 1, 2}, result)
+}
+
+func TestCoalesceNonAdjacentValuesAreNotMerged(t *testing.T) {
+	items := []int{1, 2, 1}
+	result := Coalesce(items, func(left, right int) (int, bool) {
+		if left == right {
+			return left + right, true
+		}
+		return 0, false
+	})
+	assert.Equal(t, []int{1, 2, 1}, result)
+}
+
+func TestCoalesceMergedResultCanMergeAgain(t *testing.T) {
+	items := []int{1, 1, 2}
+	result := Coalesce(items, func(left, right int) (int, bool) {
+		if left+right <= 4 {
+			return left + right, true
+		}
+		return 0, false
+	})
+	assert.Equal(t, []int{4}, result)
+}
+
+func TestCoalesceStructExample(t *testing.T) {
+	type token struct {
+		Kind string
+		Text string
+	}
+
+	items := []token{
+		{Kind: "id", Text: "foo"},
+		{Kind: "id", Text: "bar"},
+		{Kind: "op", Text: "+"},
+	}
+
+	result := Coalesce(items, func(left, right token) (token, bool) {
+		if left.Kind != right.Kind {
+			return token{}, false
+		}
+		return token{Kind: left.Kind, Text: left.Text + " " + right.Text}, true
+	})
+
+	assert.Equal(t, []token{{Kind: "id", Text: "foo bar"}, {Kind: "op", Text: "+"}}, result)
+}
+
+func TestCoalesceDoesNotModifyInput(t *testing.T) {
+	items := []int{1, 1, 2}
+	original := append([]int(nil), items...)
+	_ = Coalesce(items, func(left, right int) (int, bool) {
+		if left == right {
+			return left + right, true
+		}
+		return 0, false
+	})
+	assert.Equal(t, original, items)
+}
+
+func TestCoalesceRef(t *testing.T) {
+	items := []int{1, 1, 2}
+	result := CoalesceRef(items, func(left, right *int) (*int, bool) {
+		if field.OptionalInt(left, 0) != field.OptionalInt(right, 0) {
+			return nil, false
+		}
+		return field.ToOptional(field.OptionalInt(left, 0) + field.OptionalInt(right, 0)), true
+	})
+	assert.Equal(t, []int{4}, result)
+}

--- a/utils/collection/mapping.go
+++ b/utils/collection/mapping.go
@@ -39,6 +39,111 @@ func IdentityMapFunc[T any]() MapFunc[T, T] {
 	return func(i T) T { return i }
 }
 
+// Combine composes mapping functions of the same input/output type.
+//
+// Functions are applied from right to left, so
+// `Combine(f1, f2, f3)(value)` is equivalent to `f1(f2(f3(value)))`.
+// This corresponds to the composition `f1 o f2 o f3`.
+//
+// If no functions are supplied, the identity mapping is returned.
+//
+// Reference documentation:
+//   - https://en.wikipedia.org/wiki/Function_composition
+func Combine[T any](functions ...MapFunc[T, T]) MapFunc[T, T] {
+	return func(value T) T {
+		result := value
+		ForEach(Reverse(functions), func(f MapFunc[T, T]) {
+			if f != nil {
+				result = f(result)
+			}
+		})
+		return result
+	}
+}
+
+// CombineRef composes reference-based mapping functions of the same input/output type.
+//
+// Functions are applied from right to left, so
+// `CombineRef(f1, f2, f3)(value)` is equivalent to `f1(f2(f3(value)))`.
+// This corresponds to the composition `f1 o f2 o f3`.
+//
+// If no functions are supplied, the identity mapping is returned.
+//
+// Reference documentation:
+//   - https://en.wikipedia.org/wiki/Function_composition
+func CombineRef[T any](functions ...MapRefFunc[T, T]) MapRefFunc[T, T] {
+	return func(value *T) *T {
+		result := value
+		ForEach(Reverse(functions), func(f MapRefFunc[T, T]) {
+			if f != nil {
+				result = f(result)
+			}
+		})
+		return result
+	}
+}
+
+// CombineWithError composes error-returning mapping functions of the same input/output type.
+//
+// Functions are applied from right to left, so
+// `CombineWithError(f1, f2, f3)(value)` is equivalent to `f1(f2(f3(value)))`.
+// This corresponds to the composition `f1 o f2 o f3`.
+//
+// If any function returns an error, composition stops immediately and the error
+// is returned.
+//
+// If no functions are supplied, the identity mapping is returned.
+//
+// Reference documentation:
+//   - https://en.wikipedia.org/wiki/Function_composition
+func CombineWithError[T any](functions ...MapWithErrorFunc[T, T]) MapWithErrorFunc[T, T] {
+	return func(value T) (result T, err error) {
+		result = value
+		err = Each(slices.Values(Reverse(functions)), func(f MapWithErrorFunc[T, T]) error {
+			if f == nil {
+				return nil
+			}
+			result, err = f(result)
+			return err
+		})
+		if err != nil {
+			return result, err
+		}
+		return result, nil
+	}
+}
+
+// CombineRefWithError composes reference-based error-returning mapping functions
+// of the same input/output type.
+//
+// Functions are applied from right to left, so
+// `CombineRefWithError(f1, f2, f3)(value)` is equivalent to `f1(f2(f3(value)))`.
+// This corresponds to the composition `f1 o f2 o f3`.
+//
+// If any function returns an error, composition stops immediately and the error
+// is returned.
+//
+// If no functions are supplied, the identity mapping is returned.
+//
+// Reference documentation:
+//   - https://en.wikipedia.org/wiki/Function_composition
+func CombineRefWithError[T any](functions ...MapRefWithErrorFunc[T, T]) MapRefWithErrorFunc[T, T] {
+	return func(value *T) (result *T, err error) {
+		result = value
+		err = Each(slices.Values(Reverse(functions)), func(f MapRefWithErrorFunc[T, T]) error {
+			if f == nil {
+				return nil
+			}
+			result, err = f(result)
+			return err
+		})
+		if err != nil {
+			return result, err
+		}
+		return result, nil
+	}
+}
+
 // MapSequence maps each element of s using f and returns a sequence of mapped
 // values.
 //

--- a/utils/collection/merge.go
+++ b/utils/collection/merge.go
@@ -1,0 +1,63 @@
+package collection
+
+import (
+	"maps"
+	"slices"
+
+	"github.com/ARM-software/golang-utils/utils/field"
+	"github.com/ARM-software/golang-utils/utils/ptr"
+	"github.com/ARM-software/golang-utils/utils/reflection"
+)
+
+// MergeFunc combines two values of the same type into one.
+type MergeFunc[T any] func(e1, e2 T) (merged T, compatible bool)
+
+// MergeRefFunc combines two references to values of the same type into one.
+type MergeRefFunc[T any] func(e1, e2 *T) (merged *T, compatible bool)
+
+// MergeBy groups values by key and merges each group into one or more values.
+//
+// Within each group, values are coalesced from left to right using merge.
+//
+// Because grouping is map-based, the order of the returned groups is not
+// guaranteed.
+//
+// If items is nil, nil is returned. If items is empty, an empty slice is
+// returned. If keyFunc or merge is nil, a clone of items is returned unchanged.
+func MergeBy[T any, K comparable](items []T, keyFunc KeyFunc[T, K], merge MergeFunc[T]) (result []T) {
+	if reflection.IsEmpty(items) {
+		return []T{}
+	}
+	if keyFunc == nil || merge == nil {
+		return slices.Clone(items)
+	}
+
+	groups := GroupBy(items, keyFunc)
+	result = ReducesSequence(maps.Values(groups), make([]T, 0, len(groups)), func(acc []T, group []T) []T {
+		return append(acc, Coalesce(group, merge)...)
+	})
+	return result
+}
+
+// MergeByRef groups values by a reference-based key function and merges each
+// group using a reference-based merge function.
+func MergeByRef[T any, K comparable](items []T, keyFunc KeyRefFunc[T, K], merge MergeRefFunc[T]) (result []T) {
+	if keyFunc == nil || merge == nil {
+		if items == nil {
+			return nil
+		}
+		return slices.Clone(items)
+	}
+	return MergeBy(items,
+		func(item T) K {
+			return keyFunc(field.ToOptional(item))
+		},
+		func(left, right T) (merged T, compatible bool) {
+			mergedRef, compatible := merge(field.ToOptional(left), field.ToOptional(right))
+			if !compatible || mergedRef == nil {
+				return merged, false
+			}
+			return ptr.From(mergedRef), true
+		},
+	)
+}

--- a/utils/collection/merge_test.go
+++ b/utils/collection/merge_test.go
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package collection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ARM-software/golang-utils/utils/field"
+)
+
+func TestMergeBy(t *testing.T) {
+	items := []string{"a", "bb", "c", "dd"}
+	merged := MergeBy(items,
+		func(item string) int { return len(item) },
+		func(left, right string) (string, bool) { return left + "," + right, true },
+	)
+	assert.ElementsMatch(t, []string{"a,c", "bb,dd"}, merged)
+}
+
+func TestMergeByMergesGroups(t *testing.T) {
+	items := []int{2, 1, 4, 3}
+	merged := MergeBy(items,
+		func(item int) int { return item % 2 },
+		func(left, right int) (int, bool) { return left + right, true },
+	)
+	assert.ElementsMatch(t, []int{6, 4}, merged)
+}
+
+func TestMergeByEmpty(t *testing.T) {
+	merged := MergeBy[int, int](nil,
+		func(item int) int { return item },
+		func(left, right int) (int, bool) { return left + right, true },
+	)
+	assert.Empty(t, merged)
+
+	merged = MergeBy([]int{},
+		func(item int) int { return item },
+		func(left, right int) (int, bool) { return left + right, true },
+	)
+	assert.Empty(t, merged)
+}
+
+func TestMergeByNilFunctionsReturnClone(t *testing.T) {
+	items := []int{1, 2}
+	assert.Equal(t, items, MergeBy[int, int](items, nil, func(left, right int) (int, bool) { return left + right, true }))
+	assert.Equal(t, items, MergeBy[int, int](items, func(item int) int { return item }, nil))
+}
+
+func TestMergeByCanDeclineWithinGroup(t *testing.T) {
+	items := []string{"a", "c", "e"}
+	merged := MergeBy(items,
+		func(item string) int { return len(item) },
+		func(left, right string) (string, bool) {
+			if left+right == "ac" {
+				return left + "," + right, true
+			}
+			return "", false
+		},
+	)
+	assert.ElementsMatch(t, []string{"a,c", "e"}, merged)
+}
+
+func TestMergeByStruct(t *testing.T) {
+	type token struct {
+		Kind string
+		Text string
+	}
+
+	items := []token{
+		{Kind: "id", Text: "foo"},
+		{Kind: "op", Text: "+"},
+		{Kind: "id", Text: "bar"},
+	}
+
+	merged := MergeBy(items,
+		func(item token) string { return item.Kind },
+		func(left, right token) (token, bool) {
+			return token{Kind: left.Kind, Text: left.Text + " " + right.Text}, true
+		},
+	)
+	assert.ElementsMatch(t, []token{{Kind: "id", Text: "foo bar"}, {Kind: "op", Text: "+"}}, merged)
+}
+
+func TestMergeByRef(t *testing.T) {
+	items := []string{"a", "bb", "c", "dd"}
+	merged := MergeByRef(items,
+		func(item *string) int {
+			return len(field.OptionalString(item, ""))
+		},
+		func(left, right *string) (*string, bool) {
+			merged := field.OptionalString(left, "") + "," + field.OptionalString(right, "")
+			return field.ToOptional(merged), true
+		},
+	)
+	assert.ElementsMatch(t, []string{"a,c", "bb,dd"}, merged)
+}

--- a/utils/collection/operations_test.go
+++ b/utils/collection/operations_test.go
@@ -270,6 +270,74 @@ func TestMap(t *testing.T) {
 	assert.ElementsMatch(t, num, mappedInt)
 }
 
+func TestCombine(t *testing.T) {
+	combined := Combine(
+		func(v int) int { return v * 2 },
+		func(v int) int { return v + 3 },
+		func(v int) int { return v - 1 },
+	)
+	assert.Equal(t, 24, combined(10))
+
+	assert.Equal(t, 10, Combine[int]()(10))
+}
+
+func TestCombineRef(t *testing.T) {
+	combined := CombineRef(
+		func(v *int) *int {
+			n := field.OptionalInt(v, 0) * 2
+			return field.ToOptional(n)
+		},
+		func(v *int) *int {
+			n := field.OptionalInt(v, 0) + 3
+			return field.ToOptional(n)
+		},
+	)
+	assert.Equal(t, 26, field.OptionalInt(combined(field.ToOptional(10)), 0))
+}
+
+func TestCombineWithError(t *testing.T) {
+	combined := CombineWithError(
+		func(v int) (int, error) { return v * 2, nil },
+		func(v int) (int, error) { return v + 3, nil },
+		func(v int) (int, error) { return v - 1, nil },
+	)
+	result, err := combined(10)
+	require.NoError(t, err)
+	assert.Equal(t, 24, result)
+
+	combined = CombineWithError(
+		func(v int) (int, error) { return v * 2, nil },
+		func(v int) (int, error) { return 0, commonerrors.ErrUnexpected },
+	)
+	_, err = combined(10)
+	require.Error(t, err)
+	errortest.AssertError(t, err, commonerrors.ErrUnexpected)
+}
+
+func TestCombineRefWithError(t *testing.T) {
+	combined := CombineRefWithError(
+		func(v *int) (*int, error) {
+			n := field.OptionalInt(v, 0) * 2
+			return field.ToOptional(n), nil
+		},
+		func(v *int) (*int, error) {
+			n := field.OptionalInt(v, 0) + 3
+			return field.ToOptional(n), nil
+		},
+	)
+	result, err := combined(field.ToOptional(10))
+	require.NoError(t, err)
+	assert.Equal(t, 26, field.OptionalInt(result, 0))
+
+	combined = CombineRefWithError(
+		func(v *int) (*int, error) { return v, nil },
+		func(v *int) (*int, error) { return nil, commonerrors.ErrUnexpected },
+	)
+	_, err = combined(field.ToOptional(10))
+	require.Error(t, err)
+	errortest.AssertError(t, err, commonerrors.ErrUnexpected)
+}
+
 func TestReduce(t *testing.T) {
 	nums := []int{1, 2, 3, 4, 5}
 	sumOfNums := Reduce(nums, 0, func(acc, n int) int {

--- a/utils/strings/casing/replacement.go
+++ b/utils/strings/casing/replacement.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ARM-software/golang-utils/utils/collection"
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/ptr"
 	"github.com/ARM-software/golang-utils/utils/reflection"
 	"github.com/ARM-software/golang-utils/utils/safeio"
 )
@@ -21,6 +22,48 @@ type Rule struct {
 	Token       string
 	Replacement string
 	Exceptions  []string
+}
+
+// IsCompatible returns whether r and other describe the same replacement rule
+// and can therefore be merged safely.
+//
+// Rules are considered compatible when they target the same token and use the
+// same replacement after normalisation. Exception lists do not need to match.
+
+// If other is empty, the rules are treated as incompatible and false is
+// returned immediately.
+func (r Rule) IsCompatible(other *Rule) bool {
+	if reflection.IsEmpty(other) {
+		return false
+	}
+	return normaliseRuleToken(r.Token) == normaliseRuleToken(other.Token) && normaliseRuleReplacement(r.Replacement) == normaliseRuleReplacement(other.Replacement)
+}
+
+// Merge combines compatible rules into one rule.
+//
+// If the rules are not compatible, r is returned unchanged.
+//
+// When merged, exception lists are combined and deduplicated using the same
+// normalisation semantics as the replacer.
+
+// If other is empty, r is returned unchanged.
+func (r Rule) Merge(other *Rule) Rule {
+	if reflection.IsEmpty(other) {
+		return r
+	}
+	if !r.IsCompatible(other) {
+		return r
+	}
+
+	merged := r
+	if reflection.IsEmpty(merged.Token) {
+		merged.Token = strings.TrimSpace(other.Token)
+	}
+	if reflection.IsEmpty(merged.Replacement) {
+		merged.Replacement = strings.TrimSpace(other.Replacement)
+	}
+	merged.Exceptions = mergeRuleExceptions(r.Exceptions, other.Exceptions)
+	return merged
 }
 
 // Validate checks that the rule contains the required values.
@@ -65,8 +108,9 @@ type Replacer struct {
 
 // NewReplacer constructs a Replacer from the provided rules.
 func NewReplacer(rules ...Rule) (*Replacer, error) {
-	compiled := make(map[string]compiledRule, len(rules))
-	err := collection.Each(slices.Values(rules), func(rule Rule) error {
+	mergedRules := MergeRules(rules...)
+	compiled := make(map[string]compiledRule, len(mergedRules))
+	err := collection.Each(slices.Values(mergedRules), func(rule Rule) error {
 		if err := rule.Validate(); err != nil {
 			return err
 		}
@@ -87,6 +131,33 @@ func NewReplacer(rules ...Rule) (*Replacer, error) {
 		return nil, err
 	}
 	return &Replacer{rules: compiled}, nil
+}
+
+// MergeRules merges compatible duplicate rules and keeps the last conflicting
+// rule for a given token.
+//
+// Compatible rules share the same token and replacement and have their
+// exception lists combined. Conflicting rules do not cause an error; the later
+// rule replaces the earlier one.
+func MergeRules(rules ...Rule) []Rule {
+	merged := make([]Rule, 0, len(rules))
+	indexes := make(map[string]int, len(rules))
+
+	collection.ForEachRef(rules, func(rule *Rule) {
+		key := normaliseRuleToken(rule.Token)
+		if index, found := indexes[key]; found {
+			if merged[index].IsCompatible(rule) {
+				merged[index] = merged[index].Merge(rule)
+				return
+			}
+			merged[index] = ptr.From(rule)
+			return
+		}
+		indexes[key] = len(merged)
+		merged = append(merged, ptr.From(rule))
+	})
+
+	return merged
 }
 
 // Replace rewrites an identifier-like string according to the configured rules while preserving camelCase or PascalCase shape.
@@ -132,6 +203,24 @@ func splitCamelWords(value string) []string {
 		return nil
 	})
 	return parts
+}
+
+func normaliseRuleToken(token string) string {
+	return strings.ToLower(strings.TrimSpace(token))
+}
+
+func normaliseRuleReplacement(replacement string) string {
+	return strings.TrimSpace(replacement)
+}
+
+func mergeRuleExceptions(groups ...[]string) []string {
+	merged := make([]string, 0)
+	collection.ForEach(groups, func(exceptions []string) {
+		merged = append(merged, collection.Map(exceptions, func(exception string) string {
+			return strings.ToLower(strings.TrimSpace(exception))
+		})...)
+	})
+	return collection.Unique(slices.Values(merged))
 }
 
 // transformWord rewrites one logical word inside an identifier while trying to preserve the identifier's overall shape.

--- a/utils/strings/casing/replacement.go
+++ b/utils/strings/casing/replacement.go
@@ -12,9 +12,14 @@ import (
 
 	"github.com/ARM-software/golang-utils/utils/collection"
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
-	"github.com/ARM-software/golang-utils/utils/ptr"
 	"github.com/ARM-software/golang-utils/utils/reflection"
 	"github.com/ARM-software/golang-utils/utils/safeio"
+)
+
+var (
+	normaliseRuleTokenFunc       = collection.Combine(strings.ToLower, strings.TrimSpace)
+	normaliseRuleExceptionFunc   = collection.Combine(strings.ToLower, strings.TrimSpace)
+	normaliseRuleReplacementFunc = strings.TrimSpace
 )
 
 // Rule defines a token replacement rule for identifier-like strings.
@@ -36,7 +41,7 @@ func (r Rule) IsCompatible(other *Rule) bool {
 	if reflection.IsEmpty(other) {
 		return false
 	}
-	return normaliseRuleToken(r.Token) == normaliseRuleToken(other.Token) && normaliseRuleReplacement(r.Replacement) == normaliseRuleReplacement(other.Replacement)
+	return normaliseRuleTokenFunc(r.Token) == normaliseRuleTokenFunc(other.Token) && normaliseRuleReplacementFunc(r.Replacement) == normaliseRuleReplacementFunc(other.Replacement)
 }
 
 // Merge combines compatible rules into one rule.
@@ -60,7 +65,7 @@ func (r Rule) Merge(other *Rule) Rule {
 		merged.Token = strings.TrimSpace(other.Token)
 	}
 	if reflection.IsEmpty(merged.Replacement) {
-		merged.Replacement = strings.TrimSpace(other.Replacement)
+		merged.Replacement = normaliseRuleReplacementFunc(other.Replacement)
 	}
 	merged.Exceptions = mergeRuleExceptions(r.Exceptions, other.Exceptions)
 	return merged
@@ -116,12 +121,10 @@ func NewReplacer(rules ...Rule) (*Replacer, error) {
 		}
 
 		exceptions := mapset.NewSet[string]()
-		normalised := collection.Map(rule.Exceptions, func(exception string) string {
-			return strings.ToLower(strings.TrimSpace(exception))
-		})
+		normalised := collection.Map(rule.Exceptions, normaliseRuleExceptionFunc)
 		_ = exceptions.Append(normalised...)
 
-		compiled[strings.ToLower(strings.TrimSpace(rule.Token))] = compiledRule{
+		compiled[normaliseRuleTokenFunc(rule.Token)] = compiledRule{
 			Replacement: rule.Replacement,
 			Exceptions:  exceptions,
 		}
@@ -138,26 +141,20 @@ func NewReplacer(rules ...Rule) (*Replacer, error) {
 //
 // Compatible rules share the same token and replacement and have their
 // exception lists combined. Conflicting rules do not cause an error; the later
-// rule replaces the earlier one.
+// rule replaces the earlier one. The order of the returned rules is not
+// guaranteed.
 func MergeRules(rules ...Rule) []Rule {
-	merged := make([]Rule, 0, len(rules))
-	indexes := make(map[string]int, len(rules))
-
-	collection.ForEachRef(rules, func(rule *Rule) {
-		key := normaliseRuleToken(rule.Token)
-		if index, found := indexes[key]; found {
-			if merged[index].IsCompatible(rule) {
-				merged[index] = merged[index].Merge(rule)
-				return
+	return collection.MergeBy(rules,
+		func(rule Rule) string {
+			return normaliseRuleTokenFunc(rule.Token)
+		},
+		func(left, right Rule) (Rule, bool) {
+			if left.IsCompatible(&right) {
+				return left.Merge(&right), true
 			}
-			merged[index] = ptr.From(rule)
-			return
-		}
-		indexes[key] = len(merged)
-		merged = append(merged, ptr.From(rule))
-	})
-
-	return merged
+			return right, true
+		},
+	)
 }
 
 // Replace rewrites an identifier-like string according to the configured rules while preserving camelCase or PascalCase shape.
@@ -205,22 +202,12 @@ func splitCamelWords(value string) []string {
 	return parts
 }
 
-func normaliseRuleToken(token string) string {
-	return strings.ToLower(strings.TrimSpace(token))
-}
-
-func normaliseRuleReplacement(replacement string) string {
-	return strings.TrimSpace(replacement)
-}
-
 func mergeRuleExceptions(groups ...[]string) []string {
-	merged := make([]string, 0)
+	merged := mapset.NewSet[string]()
 	collection.ForEach(groups, func(exceptions []string) {
-		merged = append(merged, collection.Map(exceptions, func(exception string) string {
-			return strings.ToLower(strings.TrimSpace(exception))
-		})...)
+		merged.Append(collection.Map(exceptions, normaliseRuleExceptionFunc)...)
 	})
-	return collection.Unique(slices.Values(merged))
+	return merged.ToSlice()
 }
 
 // transformWord rewrites one logical word inside an identifier while trying to preserve the identifier's overall shape.

--- a/utils/strings/casing/replacement_test.go
+++ b/utils/strings/casing/replacement_test.go
@@ -39,7 +39,7 @@ func TestRuleMerge(t *testing.T) {
 
 	assert.Equal(t, "Api", merged.Token)
 	assert.Equal(t, "API", merged.Replacement)
-	assert.Equal(t, []string{"client", "request", "identifier"}, merged.Exceptions)
+	assert.ElementsMatch(t, []string{"client", "request", "identifier"}, merged.Exceptions)
 
 	assert.Equal(t, merged, merged.Merge(nil))
 }

--- a/utils/strings/casing/replacement_test.go
+++ b/utils/strings/casing/replacement_test.go
@@ -25,6 +25,58 @@ func TestNewReplacerRejectsInvalidRule(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestRuleIsCompatible(t *testing.T) {
+	assert.True(t, Rule{Token: "Api", Replacement: "API"}.IsCompatible(&Rule{Token: " api ", Replacement: "API"}))
+	assert.False(t, Rule{Token: "Api", Replacement: "API"}.IsCompatible(&Rule{Token: "Api", Replacement: "HTTP"}))
+	assert.False(t, Rule{Token: "Api", Replacement: "API"}.IsCompatible(&Rule{Token: "Http", Replacement: "API"}))
+	assert.False(t, Rule{Token: "Api", Replacement: "API"}.IsCompatible(nil))
+}
+
+func TestRuleMerge(t *testing.T) {
+	merged := Rule{Token: "Api", Replacement: "API", Exceptions: []string{"client", " request "}}.Merge(
+		&Rule{Token: "api", Replacement: "API", Exceptions: []string{"request", "identifier"}},
+	)
+
+	assert.Equal(t, "Api", merged.Token)
+	assert.Equal(t, "API", merged.Replacement)
+	assert.Equal(t, []string{"client", "request", "identifier"}, merged.Exceptions)
+
+	assert.Equal(t, merged, merged.Merge(nil))
+}
+
+func TestMergeRules(t *testing.T) {
+	merged := MergeRules(
+		Rule{Token: "Api", Replacement: "API", Exceptions: []string{"client"}},
+		Rule{Token: "api", Replacement: "API", Exceptions: []string{"identifier"}},
+		Rule{Token: "Api", Replacement: "HTTP"},
+	)
+
+	require.Len(t, merged, 1)
+	assert.Equal(t, Rule{Token: "Api", Replacement: "HTTP"}, merged[0])
+}
+
+func TestNewReplacerMergesCompatibleRules(t *testing.T) {
+	r, err := NewReplacer(
+		Rule{Token: "Api", Replacement: "API", Exceptions: []string{"client"}},
+		Rule{Token: "api", Replacement: "API", Exceptions: []string{"identifier"}},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "APIClient", r.Replace("ApiClient"))
+	assert.Equal(t, "APIIdentifier", r.Replace("ApiIdentifier"))
+	assert.Equal(t, "APIKey", r.Replace("ApiKey"))
+}
+
+func TestNewReplacerKeepsLastConflictingRule(t *testing.T) {
+	r, err := NewReplacer(
+		Rule{Token: "Api", Replacement: "API"},
+		Rule{Token: "Api", Replacement: "HTTP"},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "HTTPClient", r.Replace("ApiClient"))
+}
+
 func TestReplacerReplace(t *testing.T) {
 	r, err := NewReplacer(
 		Rule{Token: "Ai", Replacement: "AI"},


### PR DESCRIPTION
Make sure replacement rules are properly merged rather than silently ignored