### PR TITLE
:bug: `[jsonschema]` Added support for ignoring YAML alias and anchor helper fields during schema validation when explicitly requested.

### DIFF
--- a/changes/20260608112000.bugfix
+++ b/changes/20260608112000.bugfix
@@ -1,0 +1,1 @@
+:bug: `[jsonschema]` Added support for ignoring YAML alias and anchor helper fields during schema validation when explicitly requested.

--- a/utils/validation/jsonschema/options.go
+++ b/utils/validation/jsonschema/options.go
@@ -126,3 +126,55 @@ func WithFileLimits(limits filesystem.ILimits) SchemaOption {
 		return schema
 	}
 }
+
+// IgnoreYAMLAliases enables removal of decoded object keys that follow the
+// `x-...` convention before validation.
+//
+// This is intended for YAML documents that use extension-like helper fields to
+// hold alias or anchor material which should be ignored once the document has
+// been decoded into plain objects for schema validation.
+//
+// Example:
+//
+//	schema := NewJSONSchemaFile(
+//		WithTitle("manifest"),
+//		WithLocalPath("schema.yaml"),
+//		IgnoreYAMLAliases(),
+//	)
+//
+// For example, a document may use helper fields only to define YAML anchors and
+// merges:
+//
+//	x-shared: &x-shared
+//	  count: 2
+//	name: Alice
+//	<<: *x-shared
+//
+// After YAML decoding, `name` and `count` are the real data to validate, but
+// the extra `x-shared` field may still be present in the decoded object. If the
+// JSON Schema does not allow that helper field, validation can fail even though
+// the effective manifest content is otherwise valid. Enabling this option strips
+// such helper fields before validation.
+//
+// The option always enables this behaviour; there is no boolean argument because
+// callers can simply omit the option when they do not want alias helper fields
+// removed.
+func IgnoreYAMLAliases() SchemaOption {
+	return WithStripXAliases(true)
+}
+
+// WithStripXAliases explicitly sets whether decoded `x-...` helper fields are
+// removed before validation.
+//
+// This is the general form of the option and is useful when schema options are
+// composed dynamically and the caller wants to control the setting explicitly.
+// `IgnoreYAMLAliases()` is the convenience form for simply enabling it.
+func WithStripXAliases(enabled bool) SchemaOption {
+	return func(schema *Schema) *Schema {
+		if schema == nil {
+			schema = DefaultSchema()
+		}
+		schema.StripXAliases = enabled
+		return schema
+	}
+}

--- a/utils/validation/jsonschema/validation.go
+++ b/utils/validation/jsonschema/validation.go
@@ -57,6 +57,25 @@ type Schema struct {
 	// Limits defines the filesystem read limits used when loading the schema
 	// file.
 	Limits filesystem.ILimits
+	// StripXAliases removes decoded object keys using the `x-...` convention
+	// before validation.
+	//
+	// This is useful for YAML manifests that carry helper fields such as
+	// `x-aliases`, `x-anchors`, or similar extension-like structures whose only
+	// purpose is to materialise YAML anchors, aliases, or merge-like expansion
+	// before validation. Those helper fields are not part of the actual schema,
+	// and if they are left in place they can cause otherwise valid documents to
+	// fail schema validation because the schema does not declare them.
+	StripXAliases bool
+}
+
+// ShouldStripAliases returns whether extension-style alias or anchor helper
+// fields should be removed before validation.
+func (s *Schema) ShouldStripAliases() bool {
+	if s == nil {
+		return false
+	}
+	return s.StripXAliases
 }
 
 // Validate checks that the schema definition contains the required fields

--- a/utils/validation/jsonschema/validation_test.go
+++ b/utils/validation/jsonschema/validation_test.go
@@ -355,6 +355,50 @@ func TestValidateRawYAMLAgainstSchemaOptions(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestValidateRawYAMLAgainstSchemaOptions_IgnoreYAMLAliases(t *testing.T) {
+	content := []byte(`x-shared: &x-shared
+  count: 2
+name: Alice
+<<: *x-shared
+`)
+
+	t.Run("fails without option", func(t *testing.T) {
+		err := ValidateRawYAMLAgainstSchemaOptions(
+			context.Background(),
+			content,
+			WithTitle("person"),
+			WithLocalPath(path.Join("testdata", "person.schema.json")),
+			WithFilesystem(filesystem.GetGlobalFileSystem()),
+		)
+		require.Error(t, err)
+		errortest.AssertError(t, err, commonerrors.ErrInvalid)
+	})
+
+	t.Run("passes with option", func(t *testing.T) {
+		err := ValidateRawYAMLAgainstSchemaOptions(
+			context.Background(),
+			content,
+			WithTitle("person"),
+			WithLocalPath(path.Join("testdata", "person.schema.json")),
+			WithFilesystem(filesystem.GetGlobalFileSystem()),
+			IgnoreYAMLAliases(),
+		)
+		require.NoError(t, err)
+	})
+}
+
+func TestValidateRawJSONAgainstSchemaOptions_StripsXAliasFields(t *testing.T) {
+	err := ValidateRawJSONAgainstSchemaOptions(
+		context.Background(),
+		[]byte(`{"x-shared":{"count":2},"name":"Alice","count":2}`),
+		WithTitle("person"),
+		WithLocalPath(path.Join("testdata", "person.schema.json")),
+		WithFilesystem(filesystem.GetGlobalFileSystem()),
+		IgnoreYAMLAliases(),
+	)
+	require.NoError(t, err)
+}
+
 func TestValidateRawYAMLAgainstSchema_InvalidContent(t *testing.T) {
 	err := ValidateRawYAMLAgainstSchema(context.Background(), []byte("count: two\n"), nil, *newValidSchema(t, filesystem.GetGlobalFileSystem()))
 	require.Error(t, err)

--- a/utils/validation/jsonschema/validator.go
+++ b/utils/validation/jsonschema/validator.go
@@ -3,20 +3,26 @@ package jsonschema
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
 
+	"github.com/ARM-software/golang-utils/utils/collection"
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/filesystem"
+	"github.com/ARM-software/golang-utils/utils/ptr"
 	jsonserialization "github.com/ARM-software/golang-utils/utils/serialization/json" //nolint:misspell
 	"github.com/ARM-software/golang-utils/utils/serialization/yaml"                   //nolint:misspell
 )
+
+const xAliasPrefix = "x-"
 
 type fileValidator struct {
 	schemaCreationFunc func(context.Context) (*jsonschema.Schema, error)
 	expectedExtensions []string
 	convertFunc        func([]byte) ([]byte, error)
+	stripXAliases      bool
 }
 
 func (c *fileValidator) ValidateFileWithLimits(ctx context.Context, filepath string, fileLimits filesystem.ILimits) error {
@@ -60,11 +66,35 @@ func (c *fileValidator) ValidateContent(ctx context.Context, a any) error {
 		}
 		a = decoded
 	}
+	if c.stripXAliases {
+		a = stripXAliasFields(a)
+	}
 	schema, err := c.schemaCreationFunc(ctx)
 	if err != nil {
 		return err
 	}
 	return validateAgainstSchema(schema, a)
+}
+
+func stripXAliasFields(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		cleaned := make(map[string]any, len(typed))
+		for key, nested := range typed {
+			if strings.HasPrefix(strings.TrimSpace(key), xAliasPrefix) {
+				continue
+			}
+			cleaned[key] = stripXAliasFields(nested)
+		}
+		return cleaned
+	case []any:
+		collection.ForEachRef(typed, func(item *any) {
+			*item = stripXAliasFields(ptr.Deref(item))
+		})
+		return typed
+	default:
+		return value
+	}
 }
 
 func (c *fileValidator) ValidateFile(ctx context.Context, filepath string) error {
@@ -104,6 +134,7 @@ func NewJSONFileValidator(schemaID *string, schema ...Schema) (v ISchemaValidato
 		schemaCreationFunc: newSchemaCreationFunc(schemaID, schema...),
 		expectedExtensions: jsonserialization.JSONExtensions,
 		convertFunc:        nil,
+		stripXAliases:      collection.AnyRefFunc(schema, func(s *Schema) bool { return s.ShouldStripAliases() }),
 	}
 	return
 }
@@ -127,6 +158,7 @@ func NewYAMLFileValidator(schemaID *string, schema ...Schema) (v ISchemaValidato
 		schemaCreationFunc: newSchemaCreationFunc(schemaID, schema...),
 		expectedExtensions: yaml.YAMLExtensions,
 		convertFunc:        yaml.ToJSON,
+		stripXAliases:      collection.AnyRefFunc(schema, func(s *Schema) bool { return s.ShouldStripAliases() }),
 	}
 	return
 }


### PR DESCRIPTION
an edge case with advanced yaml files has been encountered when yaml aliases are being used to reduce duplication. 