### PR TITLE
:sparkles: `[parallelisation]` add MapConcurrent, MapConcurrentRef, and MapConcurrentSequence helpers.

### DIFF
--- a/changes/20260707123000.feature
+++ b/changes/20260707123000.feature
@@ -1,0 +1,1 @@
+:sparkles: `[parallelisation]` add MapConcurrent, MapConcurrentRef, and MapConcurrentSequence helpers.

--- a/utils/parallelisation/mapping.go
+++ b/utils/parallelisation/mapping.go
@@ -1,0 +1,55 @@
+package parallelisation
+
+import (
+	"context"
+	"iter"
+	"slices"
+
+	"github.com/ARM-software/golang-utils/utils/collection"
+	"github.com/ARM-software/golang-utils/utils/field"
+)
+
+// MapConcurrent is similar to [collection.Map] but uses store options instead of
+// a dedicated worker-count parameter.
+//
+// Results are returned in input order. Use [Workers] to limit parallelism.
+func MapConcurrent[I any, O any](ctx context.Context, items []I, fn collection.MapFunc[I, O], options ...StoreOption) ([]O, error) {
+	return MapConcurrentSequence(ctx, slices.Values(items), fn, options...)
+
+}
+
+// MapConcurrentRef is similar to [collection.MapRef] but uses store options
+// instead of a dedicated worker-count parameter.
+//
+// Results are returned in input order. Nil mapped values are skipped.
+func MapConcurrentRef[I any, O any](ctx context.Context, items []I, fn collection.MapRefFunc[I, O], options ...StoreOption) ([]O, error) {
+	return TransformInOrder(ctx, slices.Values(items), func(fCtx context.Context, item I) (output O, success bool, err error) {
+		err = DetermineContextError(fCtx)
+		if err != nil {
+			return
+		}
+		mapped := fn(field.ToOptionalOrNilIfEmpty(item))
+		if mapped == nil {
+			return
+		}
+		output = *mapped
+		success = true
+		return
+	}, options...)
+}
+
+// MapConcurrentSequence is similar to [collection.MapSequence] but evaluates the
+// mapping work concurrently and returns the eagerly collected result slice.
+//
+// Results are returned in input order. Use [Workers] to limit parallelism.
+func MapConcurrentSequence[I any, O any](ctx context.Context, items iter.Seq[I], fn collection.MapFunc[I, O], options ...StoreOption) ([]O, error) {
+	return TransformInOrder(ctx, items, func(fCtx context.Context, item I) (output O, success bool, err error) {
+		err = DetermineContextError(fCtx)
+		if err != nil {
+			return
+		}
+		output = fn(item)
+		success = true
+		return
+	}, options...)
+}

--- a/utils/parallelisation/mapping_test.go
+++ b/utils/parallelisation/mapping_test.go
@@ -1,0 +1,73 @@
+package parallelisation
+
+import (
+	"context"
+	"iter"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
+)
+
+func TestMapConcurrent(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	ctx := context.Background()
+	mapped, err := MapConcurrent(ctx, []int{1, 2, 3}, func(v int) string {
+		return string(rune('0' + v))
+	}, Workers(2))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"1", "2", "3"}, mapped)
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = MapConcurrent(cancelledCtx, []int{1, 2, 3}, func(v int) int { return v })
+	errortest.AssertError(t, err, commonerrors.ErrCancelled)
+}
+
+func TestMapConcurrentRef(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	ctx := context.Background()
+	mapped, err := MapConcurrentRef(ctx, []int{1, 2, 3}, func(v *int) *string {
+		if v == nil {
+			return nil
+		}
+		result := string(rune('a' + *v - 1))
+		return &result
+	}, Workers(2))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"a", "b", "c"}, mapped)
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = MapConcurrentRef(cancelledCtx, []int{1, 2, 3}, func(v *int) *int { return v })
+	errortest.AssertError(t, err, commonerrors.ErrCancelled)
+}
+
+func TestMapConcurrentSequence(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	ctx := context.Background()
+	sequence := iter.Seq[int](func(yield func(int) bool) {
+		for _, value := range []int{1, 2, 3} {
+			if !yield(value) {
+				return
+			}
+		}
+	})
+	mapped, err := MapConcurrentSequence(ctx, sequence, func(v int) string {
+		return string(rune('0' + v))
+	}, Workers(2))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"1", "2", "3"}, mapped)
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = MapConcurrentSequence(cancelledCtx, sequence, func(v int) int { return v })
+	errortest.AssertError(t, err, commonerrors.ErrCancelled)
+}

--- a/utils/parallelisation/mapping_test.go
+++ b/utils/parallelisation/mapping_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
+	"github.com/ARM-software/golang-utils/utils/safecast"
 )
 
 func TestMapConcurrent(t *testing.T) {
@@ -18,7 +19,7 @@ func TestMapConcurrent(t *testing.T) {
 
 	ctx := context.Background()
 	mapped, err := MapConcurrent(ctx, []int{1, 2, 3}, func(v int) string {
-		return string(rune('0' + v))
+		return string(safecast.ToRune('0' + v))
 	}, Workers(2))
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"1", "2", "3"}, mapped)
@@ -37,7 +38,7 @@ func TestMapConcurrentRef(t *testing.T) {
 		if v == nil {
 			return nil
 		}
-		result := string(rune('a' + *v - 1))
+		result := string(safecast.ToRune('a' + *v - 1))
 		return &result
 	}, Workers(2))
 	require.NoError(t, err)
@@ -61,7 +62,7 @@ func TestMapConcurrentSequence(t *testing.T) {
 		}
 	})
 	mapped, err := MapConcurrentSequence(ctx, sequence, func(v int) string {
-		return string(rune('0' + v))
+		return string(safecast.ToRune('0' + v))
 	}, Workers(2))
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"1", "2", "3"}, mapped)

--- a/utils/safecast/cast.go
+++ b/utils/safecast/cast.go
@@ -218,6 +218,21 @@ func ToInt32Ref[C IConvertible](i *C) *int32 {
 	return CastRef(i, ToInt32[C])
 }
 
+// ToRune attempts to convert an [IConvertible] value to a rune.
+//
+// This helper clamps the input to the range of int32 before converting, so it
+// can be used in place of direct `int` to `rune` casts when overflow-safe
+// conversion is desired.
+func ToRune[C IConvertible](i C) rune {
+	return rune(ToInt32(i))
+}
+
+// ToRuneRef attempts to convert a reference to an [IConvertible] value to a
+// reference to a rune. A nil input returns nil.
+func ToRuneRef[C IConvertible](i *C) *rune {
+	return CastRef(i, ToRune[C])
+}
+
 // ToUint32 attempts to convert an [IConvertible] value to a uint32.
 // If the converted value falls outside the range of uint32,
 // the nearest boundary value is returned instead.

--- a/utils/safecast/cast.go
+++ b/utils/safecast/cast.go
@@ -224,7 +224,7 @@ func ToInt32Ref[C IConvertible](i *C) *int32 {
 // can be used in place of direct `int` to `rune` casts when overflow-safe
 // conversion is desired.
 func ToRune[C IConvertible](i C) rune {
-	return rune(ToInt32(i))
+	return ToInt32(i)
 }
 
 // ToRuneRef attempts to convert a reference to an [IConvertible] value to a

--- a/utils/safecast/cast_test.go
+++ b/utils/safecast/cast_test.go
@@ -11,6 +11,15 @@ import (
 	"github.com/ARM-software/golang-utils/utils/ptr"
 )
 
+func TestToRune(t *testing.T) {
+	assert.Equal(t, rune('a'), ToRune[int]('a'))
+	assert.Equal(t, rune(math.MaxInt32), ToRune[int64](math.MaxInt32+1))
+	assert.Equal(t, rune(math.MinInt32), ToRune[int64](math.MinInt32-1))
+	require.NotNil(t, ToRuneRef(ptr.To(65)))
+	assert.Equal(t, rune('A'), ptr.From(ToRuneRef(ptr.To(65))))
+	assert.Nil(t, ToRuneRef[int](nil))
+}
+
 type testCase[C1 IConvertible, C2 IConvertible] struct {
 	name         string
 	ctype        string


### PR DESCRIPTION
This is to make it more obvious how to do mapping with parallel processing