### PR TITLE
:bug: `[casing]` fix casing helpers so adjacent acronym runs like AESRSA are preserved in existing camelCase and PascalCase identifiers instead of collapsing to Aesrsa.

### DIFF
--- a/changes/20260708153417.bugfix
+++ b/changes/20260708153417.bugfix
@@ -1,0 +1,1 @@
+:bug: `[casing]` fix casing helpers so adjacent acronym runs like AESRSA are preserved in existing camelCase and PascalCase identifiers instead of collapsing to Aesrsa.

--- a/utils/strings/casing/case.go
+++ b/utils/strings/casing/case.go
@@ -1,9 +1,12 @@
 package casing
 
 import (
+	"unicode"
+
 	"github.com/sttk/stringcase"
 
 	"github.com/ARM-software/golang-utils/utils/collection"
+	"github.com/ARM-software/golang-utils/utils/reflection"
 )
 
 // ToCamelCase converts value to camelCase and optionally applies a replacer to the resulting identifier. Only the first replacer is used.
@@ -19,6 +22,9 @@ func ToCamelCase(value string, replacers ...*Replacer) string {
 func ToPascalCase(value string, replacers ...*Replacer) string {
 	result := stringcase.PascalCase(value)
 	if replacer, ok := collection.First(replacers); ok && replacer != nil {
+		if isIdentifierWithoutSeparators(value) {
+			return replacer.Replace(value)
+		}
 		return replacer.Replace(result)
 	}
 	return result
@@ -40,4 +46,13 @@ func ToKebabCase(value string, replacers ...*Replacer) string {
 		result = replacer.Replace(stringcase.PascalCase(value))
 	}
 	return stringcase.KebabCase(result)
+}
+
+func isIdentifierWithoutSeparators(value string) bool {
+	if reflection.IsEmpty(value) {
+		return false
+	}
+	return collection.AllFunc([]rune(value), func(r rune) bool {
+		return unicode.IsLetter(r) || unicode.IsDigit(r)
+	})
 }

--- a/utils/strings/casing/case_test.go
+++ b/utils/strings/casing/case_test.go
@@ -80,6 +80,16 @@ func TestCaseHelpersWithOptionalReplacer_StrcaseInspiredInitialisms(t *testing.T
 	assert.Equal(t, "jsonBlob", ToCamelCase("json_blob", r))
 	assert.Equal(t, "JSONBlob", ToPascalCase("json_blob", r))
 	assert.Equal(t, "json_blob", ToSnakeCase("JSONBlob", r))
+
+	acr, err := NewReplacer(
+		Rule{Token: "Aes", Replacement: "AES"},
+		Rule{Token: "Rsa", Replacement: "RSA"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "hybridAESRSAEncryptedPayload", ToCamelCase("hybridAESRSAEncryptedPayload", acr))
+	assert.Equal(t, "hybridAESRSAEncryptedPayload", ToCamelCase("hybridAesrsaEncryptedPayload", acr))
+	assert.Equal(t, "HybridAESRSAEncryptedPayload", ToPascalCase("HybridAESRSAEncryptedPayload", acr))
+	assert.Equal(t, "HybridAESRSAEncryptedPayload", ToPascalCase("HybridAesrsaEncryptedPayload", acr))
 }
 
 func TestCaseHelpersUseOnlyFirstReplacer(t *testing.T) {

--- a/utils/strings/casing/replacement.go
+++ b/utils/strings/casing/replacement.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"slices"
 	"strings"
+	"unicode"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	validation "github.com/go-ozzo/ozzo-validation/v4"
@@ -186,19 +187,19 @@ func splitCamelWords(value string) []string {
 	if reflection.IsEmpty(value) {
 		return nil
 	}
-	words := strings.Split(stringcase.SnakeCase(value), "_")
-	parts := make([]string, 0, len(words))
+	runes := []rune(value)
+	parts := make([]string, 0)
 	start := 0
-	_ = collection.Each(slices.Values(words), func(word string) error {
-		end := start + len(word)
-		if end > len(value) {
-			parts = words
-			return io.EOF
+	for i := 1; i < len(runes); i++ {
+		prev := runes[i-1]
+		curr := runes[i]
+		nextIsLower := i+1 < len(runes) && unicode.IsLower(runes[i+1])
+		if unicode.IsLower(prev) && unicode.IsUpper(curr) || unicode.IsDigit(prev) && unicode.IsUpper(curr) || unicode.IsUpper(prev) && unicode.IsUpper(curr) && nextIsLower {
+			parts = append(parts, string(runes[start:i]))
+			start = i
 		}
-		parts = append(parts, value[start:end])
-		start = end
-		return nil
-	})
+	}
+	parts = append(parts, string(runes[start:]))
 	return parts
 }
 
@@ -226,6 +227,9 @@ func (r *Replacer) transformWord(word string, first, firstWordLowercase bool) st
 	lower := strings.ToLower(word)
 	rule, found := r.rules[lower]
 	if !found {
+		if compound, ok := r.compoundReplacement(lower, first, firstWordLowercase); ok {
+			return compound
+		}
 		if word == strings.ToUpper(word) {
 			return word
 		}
@@ -247,4 +251,33 @@ func (r *Replacer) transformWord(word string, first, firstWordLowercase bool) st
 		return strings.ToLower(rule.Replacement)
 	}
 	return rule.Replacement
+}
+
+func (r *Replacer) compoundReplacement(lower string, first, firstWordLowercase bool) (string, bool) {
+	parts, ok := r.compoundReplacementParts(lower)
+	if !ok || len(parts) < 2 {
+		return "", false
+	}
+	if first && firstWordLowercase {
+		parts[0] = strings.ToLower(parts[0])
+	}
+	return strings.Join(parts, ""), true
+}
+
+func (r *Replacer) compoundReplacementParts(lower string) ([]string, bool) {
+	if lower == "" {
+		return nil, true
+	}
+	for token, rule := range r.rules {
+		if !strings.HasPrefix(lower, token) || rule.Exceptions.Contains(lower) {
+			continue
+		}
+		remainder := strings.TrimPrefix(lower, token)
+		tail, ok := r.compoundReplacementParts(remainder)
+		if !ok {
+			continue
+		}
+		return append([]string{rule.Replacement}, tail...), true
+	}
+	return nil, false
 }


### PR DESCRIPTION
This is a bug in the casing helpers as this edge case was not considered