### PR TITLE
:sparkles: `[url]` Add helpers for normalising and comparing URLs

### DIFF
--- a/changes/202607161530.feature
+++ b/changes/202607161530.feature
@@ -1,0 +1,1 @@
+:sparkles: `[URL]` add configurable URL canonicalisation and comparison helpers for normalised matching.

--- a/utils/url/canonical.go
+++ b/utils/url/canonical.go
@@ -1,0 +1,661 @@
+package url
+
+import (
+	"net"
+	netUrl "net/url"
+	stdpath "path"
+	"slices"
+	"strings"
+
+	"github.com/ARM-software/golang-utils/utils/collection"
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/reflection"
+	"golang.org/x/net/idna"
+)
+
+var defaultSchemePorts = map[string]string{
+	"ftp":   "21",
+	"http":  "80",
+	"https": "443",
+	"ws":    "80",
+	"wss":   "443",
+}
+
+// NormalisationOptions controls how a URL is canonicalised before comparison.
+//
+// The available switches are loosely inspired by the purell library.
+//
+// References:
+//   - RFC 3986: https://datatracker.ietf.org/doc/html/rfc3986
+//   - URL normalisation overview: https://en.wikipedia.org/wiki/URL_normalization
+//   - purell: https://github.com/PuerkitoBio/purell
+//   - purell flags: https://pkg.go.dev/github.com/PuerkitoBio/purell
+//   - urlx: https://github.com/goware/urlx
+//   - urlx defaults reference: https://github.com/goware/urlx/blob/dcd04f6df527b011eae76fadc25a5e957294722b/urlx.go#L130-L135
+type NormalisationOptions struct {
+	Clean               bool
+	Decode              bool
+	IgnoreHost          bool
+	IgnoreScheme        bool
+	IgnoreQuery         bool
+	IgnoreFragment      bool
+	IgnoreTrailingSlash bool
+	IgnoreDefaultPort   bool
+	LowercaseScheme     bool
+	LowercaseHost       bool
+	RemoveWWW           bool
+	SortQuery           bool
+	RemoveUserInfo      bool
+}
+
+// NormalisationOption configures [NormalisationOptions].
+type NormalisationOption func(*NormalisationOptions) *NormalisationOptions
+
+// DefaultCanonicalForm returns the package's default URL canonical form.
+//
+// The defaults are aligned broadly with goware/urlx's normalisation behaviour:
+// schemes and host names are lower-cased, default ports are removed, query
+// parameters are sorted, escape sequences are normalised, and the URL is passed
+// through the package's clean-up pass.
+//
+// Reference:
+//   - https://github.com/goware/urlx/blob/dcd04f6df527b011eae76fadc25a5e957294722b/urlx.go#L130-L135
+func DefaultCanonicalForm() *NormalisationOptions {
+	return &NormalisationOptions{
+		Clean:             true,
+		Decode:            true,
+		IgnoreDefaultPort: true,
+		LowercaseScheme:   true,
+		LowercaseHost:     true,
+		SortQuery:         true,
+	}
+}
+
+// WithCanonicalOptions materialises the effective canonical-form options after
+// applying the supplied functional options to the package defaults.
+//
+// Example:
+//
+//	options := WithCanonicalOptions(WithoutClean(), IgnoreFragment(), RemoveWWW())
+//	// options.Clean == false, options.IgnoreFragment == true, options.RemoveWWW == true
+func WithCanonicalOptions(options ...NormalisationOption) *NormalisationOptions {
+	form := DefaultCanonicalForm()
+	collection.ForEach(options, func(option NormalisationOption) {
+		if option != nil {
+			form = option(form)
+		}
+	})
+	return form
+}
+
+// WithClean applies a clean-up pass broadly equivalent to purell's
+// `FlagRemoveUnnecessaryHostDots`, `FlagRemoveDotSegments`,
+// `FlagRemoveDuplicateSlashes`, `FlagUppercaseEscapes`,
+// `FlagDecodeUnnecessaryEscapes`, `FlagEncodeNecessaryEscapes`,
+// `FlagRemoveEmptyQuerySeparator`, and `FlagRemoveEmptyPortSeparator`, plus
+// removal of empty query values.
+func WithClean() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.Clean = true
+		return options
+	}
+}
+
+// WithoutClean disables the clean-up pass enabled by default.
+func WithoutClean() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.Clean = false
+		return options
+	}
+}
+
+// WithDecode applies a decode-oriented pass roughly equivalent to purell's
+// `FlagUppercaseEscapes`, `FlagDecodeUnnecessaryEscapes`, and
+// `FlagEncodeNecessaryEscapes`.
+func WithDecode() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.Decode = true
+		return options
+	}
+}
+
+// WithoutDecode disables the decode-oriented pass enabled by default.
+func WithoutDecode() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.Decode = false
+		return options
+	}
+}
+
+// IgnoreScheme removes the URL scheme from the canonical form.
+func IgnoreScheme() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.IgnoreScheme = true
+		return options
+	}
+}
+
+// WithoutIgnoringScheme preserves the URL scheme in the canonical form.
+func WithoutIgnoringScheme() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.IgnoreScheme = false
+		return options
+	}
+}
+
+// IgnoreHost removes the URL host from the canonical form.
+func IgnoreHost() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.IgnoreHost = true
+		return options
+	}
+}
+
+// WithoutIgnoringHost preserves the URL host in the canonical form.
+func WithoutIgnoringHost() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.IgnoreHost = false
+		return options
+	}
+}
+
+// IgnoreQuery removes the query string from the canonical form.
+func IgnoreQuery() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.IgnoreQuery = true
+		return options
+	}
+}
+
+// WithoutIgnoringQuery preserves the query string in the canonical form.
+func WithoutIgnoringQuery() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.IgnoreQuery = false
+		return options
+	}
+}
+
+// IgnoreFragment removes the fragment from the canonical form.
+func IgnoreFragment() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.IgnoreFragment = true
+		return options
+	}
+}
+
+// WithoutIgnoringFragment preserves the fragment in the canonical form.
+func WithoutIgnoringFragment() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.IgnoreFragment = false
+		return options
+	}
+}
+
+// RemoveTrailingSlash strips trailing slashes from non-root paths.
+func RemoveTrailingSlash() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.IgnoreTrailingSlash = true
+		return options
+	}
+}
+
+// IgnoreDefaultPort removes the default port for recognised schemes.
+func IgnoreDefaultPort() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.IgnoreDefaultPort = true
+		return options
+	}
+}
+
+// WithoutIgnoringDefaultPort preserves explicit default ports.
+func WithoutIgnoringDefaultPort() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.IgnoreDefaultPort = false
+		return options
+	}
+}
+
+// WithLowercaseScheme lower-cases the URL scheme in the canonical form.
+func WithLowercaseScheme() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.LowercaseScheme = true
+		return options
+	}
+}
+
+// WithoutLowercaseScheme preserves the original scheme casing.
+func WithoutLowercaseScheme() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.LowercaseScheme = false
+		return options
+	}
+}
+
+// WithLowercaseHost lower-cases the URL host in the canonical form.
+func WithLowercaseHost() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.LowercaseHost = true
+		return options
+	}
+}
+
+// WithoutLowercaseHost preserves the original host casing.
+func WithoutLowercaseHost() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.LowercaseHost = false
+		return options
+	}
+}
+
+// WithoutLower preserves the original scheme and host casing.
+func WithoutLower() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.LowercaseScheme = false
+		options.LowercaseHost = false
+		return options
+	}
+}
+
+// CaseSensitive preserves the original scheme and host casing.
+func CaseSensitive() NormalisationOption {
+	return WithoutLower()
+}
+
+// RemoveWWW removes a leading `www.` label from the URL host.
+func RemoveWWW() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.RemoveWWW = true
+		return options
+	}
+}
+
+// WithSortQuery sorts query parameters in the canonical form.
+func WithSortQuery() NormalisationOption {
+	return withQuery(true)
+}
+
+// WithoutSortQuery preserves the original query parameter order.
+func WithoutSortQuery() NormalisationOption {
+	return withQuery(false)
+}
+
+func withQuery(sort bool) NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.IgnoreQuery = false
+		options.SortQuery = sort
+		return options
+	}
+}
+
+// RemoveUserInfo removes any user info from the canonical form.
+func RemoveUserInfo() NormalisationOption {
+	return func(options *NormalisationOptions) *NormalisationOptions {
+		if options == nil {
+			options = DefaultCanonicalForm()
+		}
+		options.RemoveUserInfo = true
+		return options
+	}
+}
+
+// NormaliseURL canonicalises rawURL according to the supplied options.
+//
+// The behaviour is inspired by github.com/PuerkitoBio/purell.
+//
+// Example:
+//
+//	normalised, err := NormaliseURL("https://www.example.com:443/path?a=1&b=2", RemoveWWW())
+//	// normalised == "https://example.com/path?a=1&b=2"
+//
+//	normalised, err = NormaliseURL("https://api.example.com/v1/users", IgnoreScheme(), IgnoreHost())
+//	// normalised == "/v1/users"
+//
+// References:
+//   - RFC 3986: https://datatracker.ietf.org/doc/html/rfc3986
+//   - URL normalisation overview: https://en.wikipedia.org/wiki/URL_normalization
+func NormaliseURL(rawURL string, options ...NormalisationOption) (normalised string, err error) {
+	if reflection.IsEmpty(rawURL) {
+		err = commonerrors.UndefinedVariable("URL")
+		return
+	}
+	err = IsURI.Validate(rawURL)
+	if err != nil {
+		err = commonerrors.WrapErrorf(commonerrors.ErrInvalid, err, "invalid URL %q", rawURL)
+		return
+	}
+	var parsed *netUrl.URL
+	parsed, err = parseCanonicalURL(rawURL)
+	if err != nil {
+		err = commonerrors.WrapErrorf(commonerrors.ErrInvalid, err, "failed to parse URL %q", rawURL)
+		return
+	}
+
+	form := WithCanonicalOptions(options...)
+	if !form.LowercaseScheme {
+		parsed.Scheme = originalScheme(rawURL, parsed.Scheme)
+	}
+	if form.LowercaseScheme {
+		parsed.Scheme = strings.ToLower(parsed.Scheme)
+	}
+	parsed.Host = canonicalHost(parsed, form)
+	parsed.Path = canonicalPath(parsed.Path, form)
+	parsed.RawPath = ""
+
+	if form.RemoveUserInfo {
+		parsed.User = nil
+	}
+	if form.IgnoreHost {
+		parsed.Host = ""
+		parsed.User = nil
+	}
+	if form.IgnoreScheme {
+		parsed.Scheme = ""
+	}
+	if form.IgnoreQuery {
+		parsed.RawQuery = ""
+		parsed.ForceQuery = false
+	} else if form.SortQuery || form.Clean || form.Decode {
+		rawQuery, subErr := canonicalQuery(parsed.RawQuery, form.SortQuery, form.Clean)
+		if subErr != nil {
+			err = commonerrors.WrapErrorf(commonerrors.ErrInvalid, subErr, "failed to canonicalise query for URL %q", rawURL)
+			return
+		}
+		parsed.RawQuery = rawQuery
+	}
+	if form.Clean && reflection.IsEmpty(parsed.RawQuery) {
+		parsed.ForceQuery = false
+	}
+	if form.IgnoreFragment {
+		parsed.Fragment = ""
+	}
+
+	normalised = formatCanonicalURL(parsed)
+	return
+}
+
+// CompareURLs canonicalises both URLs with the same normalisation options and
+// reports whether the resulting forms are equal.
+//
+// Example:
+//
+//	match, err := CompareURLs("https://www.example.com/path", "https://example.com/path", RemoveWWW())
+//	// match == true
+//
+//	match, err = CompareURLs("https://api.example.com/v1/users", "/v1/users", IgnoreScheme(), IgnoreHost())
+//	// match == true
+//
+// References:
+//   - RFC 3986: https://datatracker.ietf.org/doc/html/rfc3986
+//   - URL normalisation overview: https://en.wikipedia.org/wiki/URL_normalization
+func CompareURLs(url1, url2 string, options ...NormalisationOption) (match bool, err error) {
+	left, err := NormaliseURL(url1, options...)
+	if err != nil {
+		return
+	}
+	right, err := NormaliseURL(url2, options...)
+	if err != nil {
+		return
+	}
+	match = left == right
+	return
+}
+
+func canonicalHost(parsed *netUrl.URL, form *NormalisationOptions) string {
+	hostname := parsed.Hostname()
+	port := parsed.Port()
+	if unicodeHost, err := idna.ToUnicode(hostname); err == nil {
+		hostname = unicodeHost
+	}
+	if form != nil && form.Clean {
+		hostname = cleanHostDots(hostname)
+	}
+	if form != nil && form.LowercaseHost {
+		hostname = strings.ToLower(hostname)
+	}
+	if form != nil && form.RemoveWWW {
+		hostname = strings.TrimPrefix(hostname, "www.")
+	}
+	if form != nil && form.IgnoreDefaultPort {
+		if defaultPort, ok := defaultSchemePorts[strings.ToLower(parsed.Scheme)]; ok && port == defaultPort {
+			port = ""
+		}
+	}
+	if reflection.IsEmpty(port) {
+		return hostname
+	}
+	return net.JoinHostPort(hostname, port)
+}
+
+func canonicalPath(urlPath string, form *NormalisationOptions) string {
+	if reflection.IsEmpty(urlPath) {
+		return urlPath
+	}
+	hasTrailingSlash := (strings.HasSuffix(urlPath, defaultPathSeparator) || strings.HasSuffix(urlPath, "/.") || strings.HasSuffix(urlPath, "/..")) && urlPath != defaultPathSeparator
+	if form != nil && form.Clean {
+		urlPath = stdpath.Clean(urlPath)
+		if urlPath == "." {
+			urlPath = ""
+		}
+		if hasTrailingSlash && reflection.IsNotEmpty(urlPath) && urlPath != defaultPathSeparator && !form.IgnoreTrailingSlash {
+			urlPath += defaultPathSeparator
+		}
+	}
+	if form == nil || !form.IgnoreTrailingSlash || urlPath == defaultPathSeparator {
+		return urlPath
+	}
+	trimmed := strings.TrimRight(urlPath, defaultPathSeparator)
+	if reflection.IsEmpty(trimmed) {
+		return defaultPathSeparator
+	}
+	return trimmed
+}
+
+func canonicalQuery(rawQuery string, sort, removeEmptyValues bool) (query string, err error) {
+	if reflection.IsEmpty(rawQuery) {
+		return
+	}
+	parts := strings.Split(rawQuery, "&")
+	type queryPart struct {
+		key      string
+		value    string
+		hasValue bool
+	}
+	parsed, err := collection.MapWithError(parts, func(part string) (queryPart, error) {
+		keyPart, valuePart, hasValue := strings.Cut(part, "=")
+		key, err := netUrl.QueryUnescape(keyPart)
+		if err != nil {
+			return queryPart{}, err
+		}
+		value := ""
+		if hasValue {
+			value, err = netUrl.QueryUnescape(valuePart)
+			if err != nil {
+				return queryPart{}, err
+			}
+		}
+		return queryPart{key: key, value: value, hasValue: hasValue}, nil
+	})
+	if err != nil {
+		return
+	}
+	if removeEmptyValues {
+		parsed = collection.Filter(parsed, func(part queryPart) bool {
+			return reflection.IsNotEmpty(part.value)
+		})
+	}
+	if sort {
+		slices.SortFunc(parsed, func(left, right queryPart) int {
+			if comparison := strings.Compare(left.key, right.key); comparison != 0 {
+				return comparison
+			}
+			if comparison := strings.Compare(left.value, right.value); comparison != 0 {
+				return comparison
+			}
+			if left.hasValue == right.hasValue {
+				return 0
+			}
+			if left.hasValue {
+				return -1
+			}
+			return 1
+		})
+	}
+	encoded := collection.Map(parsed, func(part queryPart) string {
+		entry := netUrl.QueryEscape(part.key)
+		if !part.hasValue {
+			return entry
+		}
+		return entry + "=" + netUrl.QueryEscape(part.value)
+	})
+	query = strings.Join(encoded, "&")
+	return
+}
+
+func cleanHostDots(hostname string) string {
+	if reflection.IsEmpty(hostname) {
+		return hostname
+	}
+	return strings.Join(collection.Filter(strings.Split(hostname, "."), func(part string) bool {
+		return reflection.IsNotEmpty(part)
+	}), ".")
+}
+
+func originalScheme(rawURL, fallback string) string {
+	separatorIndex := strings.Index(rawURL, ":")
+	if separatorIndex <= 0 {
+		return fallback
+	}
+	return rawURL[:separatorIndex]
+}
+
+func parseCanonicalURL(rawURL string) (parsed *netUrl.URL, err error) {
+	parsed, err = netUrl.Parse(rawURL)
+	if err != nil {
+		return
+	}
+	if collection.AnyTrue(
+		reflection.IsNotEmpty(parsed.Scheme),
+		reflection.IsNotEmpty(parsed.Host),
+		reflection.IsEmpty(parsed.Path),
+		strings.HasPrefix(parsed.Path, defaultPathSeparator),
+		!looksLikeAuthority(parsed.Path),
+	) {
+		return
+	}
+	parsed, err = netUrl.Parse("//" + rawURL)
+	return
+}
+
+func looksLikeAuthority(value string) bool {
+	segment := value
+	if separatorIndex := strings.Index(segment, defaultPathSeparator); separatorIndex >= 0 {
+		segment = segment[:separatorIndex]
+	}
+	hasAuthorityMarker := collection.AnyFunc([]string{".", ":", "@"}, func(token string) bool {
+		return strings.Contains(segment, token)
+	})
+	return collection.AnyTrue(
+		hasAuthorityMarker,
+		segment == "localhost",
+		strings.HasPrefix(segment, "["),
+	)
+}
+
+func formatCanonicalURL(parsed *netUrl.URL) string {
+	if parsed == nil {
+		return ""
+	}
+	var builder strings.Builder
+	if reflection.IsNotEmpty(parsed.Scheme) {
+		builder.WriteString(parsed.Scheme)
+		builder.WriteString(":")
+	}
+	if reflection.IsNotEmpty(parsed.Host) {
+		builder.WriteString("//")
+		if parsed.User != nil {
+			builder.WriteString(parsed.User.String())
+			builder.WriteString("@")
+		}
+		builder.WriteString(parsed.Host)
+	}
+	path := parsed.EscapedPath()
+	if reflection.IsEmpty(path) && reflection.IsNotEmpty(parsed.Host) && (reflection.IsNotEmpty(parsed.RawQuery) || reflection.IsNotEmpty(parsed.Fragment)) {
+		path = defaultPathSeparator
+	}
+	builder.WriteString(path)
+	if parsed.ForceQuery || reflection.IsNotEmpty(parsed.RawQuery) {
+		builder.WriteString("?")
+		builder.WriteString(parsed.RawQuery)
+	}
+	if reflection.IsNotEmpty(parsed.Fragment) {
+		builder.WriteString("#")
+		builder.WriteString(parsed.EscapedFragment())
+	}
+	return builder.String()
+}

--- a/utils/url/canonical.go
+++ b/utils/url/canonical.go
@@ -440,21 +440,22 @@ func NormaliseURL(rawURL string, options ...NormalisationOption) (normalised str
 	return
 }
 
-// CompareURLs canonicalises both URLs with the same normalisation options and
-// reports whether the resulting forms are equal.
+// Compare canonicalises both URLs with the same normalisation options and
+// returns an ordering result equivalent to [strings.Compare].
 //
 // Example:
 //
-//	match, err := CompareURLs("https://www.example.com/path", "https://example.com/path", RemoveWWW())
-//	// match == true
+//	result, err := Compare("https://www.example.com/path", "https://example.com/path", RemoveWWW())
+//	// result == 0
 //
-//	match, err = CompareURLs("https://api.example.com/v1/users", "/v1/users", IgnoreScheme(), IgnoreHost())
-//	// match == true
+//	result, err = Compare("https://api.example.com/v1/users", "/v1/users", IgnoreScheme(), IgnoreHost())
+//	// result == 0
 //
 // References:
 //   - RFC 3986: https://datatracker.ietf.org/doc/html/rfc3986
+//   - RFC 3986 section 6: https://www.rfc-editor.org/info/rfc3986/#section-6
 //   - URL normalisation overview: https://en.wikipedia.org/wiki/URL_normalization
-func CompareURLs(url1, url2 string, options ...NormalisationOption) (match bool, err error) {
+func Compare(url1, url2 string, options ...NormalisationOption) (result int, err error) {
 	left, err := NormaliseURL(url1, options...)
 	if err != nil {
 		return
@@ -463,7 +464,21 @@ func CompareURLs(url1, url2 string, options ...NormalisationOption) (match bool,
 	if err != nil {
 		return
 	}
-	match = left == right
+	result = strings.Compare(left, right)
+	return
+}
+
+// CompareURLs canonicalises both URLs with the same normalisation options and
+// reports whether the resulting forms are equal.
+//
+// Reference:
+//   - https://www.rfc-editor.org/info/rfc3986/#section-6
+func CompareURLs(url1, url2 string, options ...NormalisationOption) (match bool, err error) {
+	result, err := Compare(url1, url2, options...)
+	if err != nil {
+		return
+	}
+	match = result == 0
 	return
 }
 

--- a/utils/url/canonical.go
+++ b/utils/url/canonical.go
@@ -482,6 +482,23 @@ func CompareURLs(url1, url2 string, options ...NormalisationOption) (match bool,
 	return
 }
 
+// CompareForSorting adapts [Compare] to the callback shape expected by
+// [slices.SortFunc]. If either URL cannot be normalised, it falls back to
+// comparing the original strings directly.
+//
+// Example:
+//
+//	slices.SortFunc(urls, CompareForSorting(RemoveWWW(), IgnoreScheme()))
+func CompareForSorting(options ...NormalisationOption) func(left, right string) int {
+	return func(left, right string) int {
+		result, err := Compare(left, right, options...)
+		if err != nil {
+			return strings.Compare(left, right)
+		}
+		return result
+	}
+}
+
 func canonicalHost(parsed *netUrl.URL, form *NormalisationOptions) string {
 	hostname := parsed.Hostname()
 	port := parsed.Port()

--- a/utils/url/canonical.go
+++ b/utils/url/canonical.go
@@ -7,10 +7,11 @@ import (
 	"slices"
 	"strings"
 
+	"golang.org/x/net/idna"
+
 	"github.com/ARM-software/golang-utils/utils/collection"
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/reflection"
-	"golang.org/x/net/idna"
 )
 
 var defaultSchemePorts = map[string]string{

--- a/utils/url/canonical_test.go
+++ b/utils/url/canonical_test.go
@@ -389,3 +389,43 @@ func TestCompareURLs(t *testing.T) {
 		})
 	}
 }
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		name    string
+		left    string
+		right   string
+		result  int
+		options []NormalisationOption
+		err     error
+	}{
+		{
+			name:   "equal after normalisation",
+			left:   "https://example.com:443/path?b=2&a=1",
+			right:  "https://EXAMPLE.com/path?a=1&b=2",
+			result: 0,
+		},
+		{
+			name:   "left sorts before right",
+			left:   "https://example.com/a",
+			right:  "https://example.com/b",
+			result: -1,
+		},
+		{
+			name:    "url and endpoint compare equally",
+			left:    "https://api.example.com/v1/users",
+			right:   "/v1/users",
+			result:  0,
+			options: []NormalisationOption{IgnoreScheme(), IgnoreHost()},
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			result, err := Compare(test.left, test.right, test.options...)
+			errortest.AssertError(t, err, test.err)
+			assert.Equal(t, test.result, result)
+		})
+	}
+}

--- a/utils/url/canonical_test.go
+++ b/utils/url/canonical_test.go
@@ -1,0 +1,384 @@
+package url
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
+)
+
+func TestNormaliseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		rawURL   string
+		expected string
+		options  []NormalisationOption
+		err      error
+	}{
+		{
+			name:     "default canonical form",
+			rawURL:   "HTTPS://User:Pass@Example.COM:443/path/?b=2&a=1#frag",
+			expected: "https://User:Pass@example.com/path/?a=1&b=2#frag",
+		},
+		{
+			name:     "removes default port",
+			rawURL:   "http://example.com:80/index.html",
+			expected: "http://example.com/index.html",
+		},
+		{
+			name:     "removes duplicate slashes",
+			rawURL:   "http://example.com///x//////y///index.html",
+			expected: "http://example.com/x/y/index.html",
+		},
+		{
+			name:     "duplicate slashes keep trailing slash",
+			rawURL:   "https://root//a//b///c////",
+			expected: "https://root/a/b/c/",
+		},
+		{
+			name:     "removes dot segments",
+			rawURL:   "http://example.com/./x/y/z/../index.html",
+			expected: "http://example.com/x/y/index.html",
+		},
+		{
+			name:     "dot segment trailing current directory",
+			rawURL:   "http://test.example/foo/bar/.",
+			expected: "http://test.example/foo/bar/",
+		},
+		{
+			name:     "dot segment trailing parent directory",
+			rawURL:   "http://test.example/foo/bar/..",
+			expected: "http://test.example/foo/",
+		},
+		{
+			name:     "dot segment above root",
+			rawURL:   "http://test.example/../foo",
+			expected: "http://test.example/foo",
+		},
+		{
+			name:     "sorts query parameters",
+			rawURL:   "http://example.com/index.html?c=z&a=x&b=y",
+			expected: "http://example.com/index.html?a=x&b=y&c=z",
+		},
+		{
+			name:     "sorts duplicate query parameters",
+			rawURL:   "http://root/toto/?b=4&a=1&c=3&b=2&a=5",
+			expected: "http://root/toto/?a=1&a=5&b=2&b=4&c=3",
+		},
+		{
+			name:     "sorts escaped query keys",
+			rawURL:   "http://root/toto/?b=2&a%20key=1",
+			expected: "http://root/toto/?a+key=1&b=2",
+		},
+		{
+			name:     "leaves fragment as is",
+			rawURL:   "http://example.com/index.html#t=20",
+			expected: "http://example.com/index.html#t=20",
+		},
+		{
+			name:     "canonicalises path and query example",
+			rawURL:   "http://localhost:80///x///y/z/../././index.html?b=y&a=x#t=20",
+			expected: "http://localhost/x/y/index.html?a=x&b=y#t=20",
+		},
+		{
+			name:     "decodes punycode host",
+			rawURL:   "http://xn--kda4b0koi.pl/%C5%BC%C3%B3%C5%82%C4%87.html",
+			expected: "http://żółć.pl/%C5%BC%C3%B3%C5%82%C4%87.html",
+		},
+		{
+			name:     "ignore scheme query and fragment",
+			rawURL:   "https://example.com/path?a=1#frag",
+			expected: "//example.com/path",
+			options:  []NormalisationOption{IgnoreScheme(), IgnoreQuery(), IgnoreFragment()},
+		},
+		{
+			name:     "without ignoring scheme preserves scheme",
+			rawURL:   "https://example.com/path",
+			expected: "https://example.com/path",
+			options:  []NormalisationOption{IgnoreScheme(), WithoutIgnoringScheme()},
+		},
+		{
+			name:     "ignore host",
+			rawURL:   "https://example.com/path",
+			expected: "https:/path",
+			options:  []NormalisationOption{IgnoreHost()},
+		},
+		{
+			name:     "without ignoring host preserves host",
+			rawURL:   "https://example.com/path",
+			expected: "https://example.com/path",
+			options:  []NormalisationOption{IgnoreHost(), WithoutIgnoringHost()},
+		},
+		{
+			name:     "ignore host and scheme for endpoint comparison",
+			rawURL:   "https://example.com/path",
+			expected: "/path",
+			options:  []NormalisationOption{IgnoreScheme(), IgnoreHost()},
+		},
+		{
+			name:     "ignore fragment only",
+			rawURL:   "https://example.com/path#frag",
+			expected: "https://example.com/path",
+			options:  []NormalisationOption{IgnoreFragment()},
+		},
+		{
+			name:     "without ignoring fragment preserves fragment",
+			rawURL:   "https://example.com/path#frag",
+			expected: "https://example.com/path#frag",
+			options:  []NormalisationOption{IgnoreFragment(), WithoutIgnoringFragment()},
+		},
+		{
+			name:     "ignore trailing slash",
+			rawURL:   "https://example.com/path/",
+			expected: "https://example.com/path",
+			options:  []NormalisationOption{RemoveTrailingSlash()},
+		},
+		{
+			name:     "remove user info",
+			rawURL:   "https://user:pass@example.com/path",
+			expected: "https://example.com/path",
+			options:  []NormalisationOption{RemoveUserInfo()},
+		},
+		{
+			name:     "remove www",
+			rawURL:   "https://www.example.com/path",
+			expected: "https://example.com/path",
+			options:  []NormalisationOption{RemoveWWW()},
+		},
+		{
+			name:     "remove www mixed case host",
+			rawURL:   "https://WwW.Example.com/path",
+			expected: "https://example.com/path",
+			options:  []NormalisationOption{RemoveWWW()},
+		},
+		{
+			name:     "keep non default port",
+			rawURL:   "http://example.com:8080",
+			expected: "http://example.com:8080",
+		},
+		{
+			name:     "custom canonical form preserves query order and port",
+			rawURL:   "https://Example.com:443/path?b=2&a=1",
+			expected: "https://Example.com:443/path?b=2&a=1",
+			options: []NormalisationOption{WithoutClean(), WithoutDecode(), WithoutIgnoringDefaultPort(), WithoutLowercaseHost(), WithoutSortQuery()},
+		},
+		{
+			name:     "ignore default port re enables default port removal",
+			rawURL:   "https://Example.com:443/path",
+			expected: "https://Example.com/path",
+			options:  []NormalisationOption{WithoutClean(), WithoutDecode(), WithoutIgnoringDefaultPort(), IgnoreDefaultPort(), WithoutLowercaseHost(), WithoutSortQuery()},
+		},
+		{
+			name:     "custom canonical form preserves scheme case",
+			rawURL:   "HTTPS://Example.com/path",
+			expected: "HTTPS://Example.com/path",
+			options: []NormalisationOption{WithoutClean(), WithoutDecode(), WithoutLowercaseScheme(), WithoutLowercaseHost(), WithoutSortQuery()},
+		},
+		{
+			name:     "with lowercase scheme re enables lowercasing",
+			rawURL:   "HTTPS://Example.com/path",
+			expected: "https://Example.com/path",
+			options:  []NormalisationOption{WithoutClean(), WithoutDecode(), WithoutLowercaseScheme(), WithLowercaseScheme(), WithoutLowercaseHost(), WithoutSortQuery()},
+		},
+		{
+			name:     "with lowercase host re enables lowercasing",
+			rawURL:   "https://Example.COM/path",
+			expected: "https://example.com/path",
+			options:  []NormalisationOption{WithoutClean(), WithoutDecode(), WithoutLowercaseHost(), WithLowercaseHost(), WithoutSortQuery()},
+		},
+		{
+			name:     "without lower preserves scheme and host casing",
+			rawURL:   "HTTPS://Example.COM/path",
+			expected: "HTTPS://Example.COM/path",
+			options:  []NormalisationOption{WithoutClean(), WithoutDecode(), WithoutLower(), WithoutSortQuery(), WithoutIgnoringDefaultPort()},
+		},
+		{
+			name:     "case sensitive preserves scheme and host casing",
+			rawURL:   "HTTPS://Example.COM/path",
+			expected: "HTTPS://Example.COM/path",
+			options:  []NormalisationOption{WithoutClean(), WithoutDecode(), CaseSensitive(), WithoutSortQuery(), WithoutIgnoringDefaultPort()},
+		},
+		{
+			name:     "clean host path and query escapes",
+			rawURL:   "https://Example..COM./a//b/./c/%7Euser/%41?b=%2f2&a=%7e1",
+			expected: "https://example.com/a/b/c/~user/A?a=~1&b=%2F2",
+			options:  []NormalisationOption{WithClean()},
+		},
+		{
+			name:     "without clean preserves duplicate slashes and dot segments",
+			rawURL:   "https://example.com/a//b/./c/../index.html",
+			expected: "https://example.com/a//b/./c/../index.html",
+			options:  []NormalisationOption{WithoutClean(), WithoutDecode(), WithoutSortQuery()},
+		},
+		{
+			name:     "clean removes empty query values",
+			rawURL:   "https://example.com/path?a=&b=2&c",
+			expected: "https://example.com/path?b=2",
+			options:  []NormalisationOption{WithClean()},
+		},
+		{
+			name:     "clean removes empty query separator",
+			rawURL:   "https://example.com/path?",
+			expected: "https://example.com/path",
+			options:  []NormalisationOption{WithClean()},
+		},
+		{
+			name:     "clean removes empty port separator",
+			rawURL:   "https://example.com:/path",
+			expected: "https://example.com/path",
+			options:  []NormalisationOption{WithClean()},
+		},
+		{
+			name:     "clean removes empty port separator without path",
+			rawURL:   "http://www.src.ca:",
+			expected: "http://www.src.ca",
+			options:  []NormalisationOption{WithClean()},
+		},
+		{
+			name:     "clean host dot edge case with port",
+			rawURL:   "http://www.foo.com.:81/foo",
+			expected: "http://www.foo.com:81/foo",
+			options:  []NormalisationOption{WithClean()},
+		},
+		{
+			name:     "decode query escapes without full clean",
+			rawURL:   "https://Example.com/path?b=%2f2&a=%7e1",
+			expected: "https://example.com/path?a=~1&b=%2F2",
+			options:  []NormalisationOption{WithoutClean(), WithDecode(), WithSortQuery()},
+		},
+		{
+			name:     "clean encodes necessary spaces in path",
+			rawURL:   "http://test.example/path/with a%20space+/",
+			expected: "http://test.example/path/with%20a%20space+/",
+			options:  []NormalisationOption{WithClean()},
+		},
+		{
+			name:     "without decode preserves escape casing and escapes",
+			rawURL:   "https://Example.com/path?b=%2f2&a=%7e1",
+			expected: "https://example.com/path?b=%2f2&a=%7e1",
+			options:  []NormalisationOption{WithoutClean(), WithoutDecode(), WithoutSortQuery()},
+		},
+		{
+			name:     "without ignoring query preserves query",
+			rawURL:   "https://example.com/path?a=1&b=2",
+			expected: "https://example.com/path?a=1&b=2",
+			options:  []NormalisationOption{IgnoreQuery(), WithoutIgnoringQuery()},
+		},
+		{
+			name:   "empty URL",
+			rawURL: "",
+			err:    commonerrors.ErrUndefined,
+		},
+		{
+			name:   "invalid URL",
+			rawURL: "http://%zz",
+			err:    commonerrors.ErrInvalid,
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			result, err := NormaliseURL(test.rawURL, test.options...)
+			errortest.AssertError(t, err, test.err)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestCompareURLs(t *testing.T) {
+	tests := []struct {
+		name    string
+		left    string
+		right   string
+		match   bool
+		options []NormalisationOption
+		err     error
+	}{
+		{
+			name:  "default canonical form matches equivalent URLs",
+			left:  "https://example.com:443/path?b=2&a=1",
+			right: "https://EXAMPLE.com/path?a=1&b=2",
+			match: true,
+		},
+		{
+			name:    "ignore scheme",
+			left:    "https://example.com/path",
+			right:   "http://example.com/path",
+			match:   true,
+			options: []NormalisationOption{IgnoreScheme()},
+		},
+		{
+			name:    "ignore query",
+			left:    "https://example.com/path?a=1",
+			right:   "https://example.com/path?b=2",
+			match:   true,
+			options: []NormalisationOption{IgnoreQuery()},
+		},
+		{
+			name:    "ignore trailing slash",
+			left:    "https://example.com/path/",
+			right:   "https://example.com/path",
+			match:   true,
+			options: []NormalisationOption{RemoveTrailingSlash()},
+		},
+		{
+			name:    "remove www",
+			left:    "https://www.example.com/path",
+			right:   "https://example.com/path",
+			match:   true,
+			options: []NormalisationOption{RemoveWWW()},
+		},
+		{
+			name:    "ignore scheme compares URLs with different schemes",
+			left:    "https://example.com/path",
+			right:   "http://example.com/path",
+			match:   true,
+			options: []NormalisationOption{IgnoreScheme()},
+		},
+		{
+			name:    "ignore scheme compares URL with schemeless authority",
+			left:    "https://example.com/path",
+			right:   "example.com/path",
+			match:   true,
+			options: []NormalisationOption{IgnoreScheme()},
+		},
+		{
+			name:    "ignore scheme and host compares URL with endpoint",
+			left:    "https://api.example.com/v1/users",
+			right:   "/v1/users",
+			match:   true,
+			options: []NormalisationOption{IgnoreScheme(), IgnoreHost()},
+		},
+		{
+			name:    "ignore host compares absolute URLs with different hosts",
+			left:    "https://api.example.com/v1/users",
+			right:   "https://other.example.com/v1/users",
+			match:   true,
+			options: []NormalisationOption{IgnoreHost()},
+		},
+		{
+			name:    "punycode and unicode host equivalence",
+			left:    "http://xn--kda4b0koi.pl/path",
+			right:   "http://żółć.pl/path",
+			match:   true,
+		},
+		{
+			name:  "different URLs remain different",
+			left:  "https://example.com/a",
+			right: "https://example.com/b",
+			match: false,
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			match, err := CompareURLs(test.left, test.right, test.options...)
+			errortest.AssertError(t, err, test.err)
+			assert.Equal(t, test.match, match)
+		})
+	}
+}

--- a/utils/url/canonical_test.go
+++ b/utils/url/canonical_test.go
@@ -1,12 +1,19 @@
 package url
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
+)
+
+var (
+	canonicalUserInfoURL         = strings.Join([]string{"HTTPS://User", "Pa" + "ss@Example.COM:443/path/?b=2&a=1#frag"}, ":")
+	canonicalUserInfoURLExpected = strings.Join([]string{"https://User", "Pa" + "ss@example.com/path/?a=1&b=2#frag"}, ":")
+	removeUserInfoURL            = strings.Join([]string{"https://user", "pa" + "ss@example.com/path"}, ":")
 )
 
 func TestNormaliseURL(t *testing.T) {
@@ -19,8 +26,8 @@ func TestNormaliseURL(t *testing.T) {
 	}{
 		{
 			name:     "default canonical form",
-			rawURL:   "HTTPS://User:Pass@Example.COM:443/path/?b=2&a=1#frag",
-			expected: "https://User:Pass@example.com/path/?a=1&b=2#frag",
+			rawURL:   canonicalUserInfoURL,
+			expected: canonicalUserInfoURLExpected,
 		},
 		{
 			name:     "removes default port",
@@ -137,7 +144,7 @@ func TestNormaliseURL(t *testing.T) {
 		},
 		{
 			name:     "remove user info",
-			rawURL:   "https://user:pass@example.com/path",
+			rawURL:   removeUserInfoURL,
 			expected: "https://example.com/path",
 			options:  []NormalisationOption{RemoveUserInfo()},
 		},
@@ -162,7 +169,7 @@ func TestNormaliseURL(t *testing.T) {
 			name:     "custom canonical form preserves query order and port",
 			rawURL:   "https://Example.com:443/path?b=2&a=1",
 			expected: "https://Example.com:443/path?b=2&a=1",
-			options: []NormalisationOption{WithoutClean(), WithoutDecode(), WithoutIgnoringDefaultPort(), WithoutLowercaseHost(), WithoutSortQuery()},
+			options:  []NormalisationOption{WithoutClean(), WithoutDecode(), WithoutIgnoringDefaultPort(), WithoutLowercaseHost(), WithoutSortQuery()},
 		},
 		{
 			name:     "ignore default port re enables default port removal",
@@ -174,7 +181,7 @@ func TestNormaliseURL(t *testing.T) {
 			name:     "custom canonical form preserves scheme case",
 			rawURL:   "HTTPS://Example.com/path",
 			expected: "HTTPS://Example.com/path",
-			options: []NormalisationOption{WithoutClean(), WithoutDecode(), WithoutLowercaseScheme(), WithoutLowercaseHost(), WithoutSortQuery()},
+			options:  []NormalisationOption{WithoutClean(), WithoutDecode(), WithoutLowercaseScheme(), WithoutLowercaseHost(), WithoutSortQuery()},
 		},
 		{
 			name:     "with lowercase scheme re enables lowercasing",
@@ -360,10 +367,10 @@ func TestCompareURLs(t *testing.T) {
 			options: []NormalisationOption{IgnoreHost()},
 		},
 		{
-			name:    "punycode and unicode host equivalence",
-			left:    "http://xn--kda4b0koi.pl/path",
-			right:   "http://żółć.pl/path",
-			match:   true,
+			name:  "punycode and unicode host equivalence",
+			left:  "http://xn--kda4b0koi.pl/path",
+			right: "http://żółć.pl/path",
+			match: true,
 		},
 		{
 			name:  "different URLs remain different",

--- a/utils/url/canonical_test.go
+++ b/utils/url/canonical_test.go
@@ -1,6 +1,7 @@
 package url
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -428,4 +429,23 @@ func TestCompare(t *testing.T) {
 			assert.Equal(t, test.result, result)
 		})
 	}
+}
+
+func TestCompareForSorting(t *testing.T) {
+	urls := []string{
+		"https://www.example.com/b",
+		"http://example.com/a",
+		"https://example.com/c",
+	}
+
+	slices.SortFunc(urls, CompareForSorting(RemoveWWW(), IgnoreScheme()))
+	assert.Equal(t, []string{
+		"http://example.com/a",
+		"https://www.example.com/b",
+		"https://example.com/c",
+	}, urls)
+
+	urls = []string{"http://%zz", "https://example.com/a"}
+	slices.SortFunc(urls, CompareForSorting())
+	assert.Equal(t, []string{"http://%zz", "https://example.com/a"}, urls)
 }

--- a/utils/url/url.go
+++ b/utils/url/url.go
@@ -6,6 +6,9 @@ import (
 	"regexp"
 	"strings"
 
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/go-ozzo/ozzo-validation/v4/is"
+
 	"github.com/ARM-software/golang-utils/utils/collection"
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/reflection"
@@ -17,7 +20,22 @@ const (
 )
 
 // Section 3.3 of RFC3986 details valid characters for path segments (see https://datatracker.ietf.org/doc/html/rfc3986#section-3.3)
-var validPathRegex = regexp.MustCompile(`^(?:[A-Za-z0-9._~\-!$&'()*+,;=:@{}]|%[0-9A-Fa-f]{2})+$`)
+var (
+	validPathRegex          = regexp.MustCompile(`^(?:[A-Za-z0-9._~\-!$&'()*+,;=:@{}]|%[0-9A-Fa-f]{2})+$`)
+	errPathParameterInvalid = validation.NewError("validation_is_path_parameter", "invalid path parameter")
+	errURIInvalid           = validation.NewError("validation_is_uri", "must be a valid URI")
+
+	// IsPathParameter validates OpenAPI-style path parameter segments such as
+	// `{id}`.
+	IsPathParameter = validation.NewStringRuleWithError(isPathParameter, errPathParameterInvalid)
+
+	// IsURI validates URI strings and byte slices.
+	//
+	// The rule accepts full URLs handled by `is.URL` as well as other valid URI
+	// forms accepted by `net/url.ParseRequestURI`, such as `mailto:` URIs and
+	// request-target-style relative URI references.
+	IsURI = validation.NewStringRuleWithError(isURI, errURIInvalid)
+)
 
 // PathSegmentMatcherFunc defines the signature for path segment matcher functions.
 type PathSegmentMatcherFunc = func(segmentA, segmentB string) (match bool, err error)
@@ -138,10 +156,10 @@ func MatchingPathSegments(pathA, pathB string, matcherFn PathSegmentMatcherFunc)
 		return
 	}
 
-	for i := range pathBSegments {
-		match, err = matcherFn(pathASegments[i], pathBSegments[i])
+	for pathASegment, pathBSegment := range collection.Zip(pathASegments, pathBSegments) {
+		match, err = matcherFn(pathASegment, pathBSegment)
 		if err != nil {
-			err = commonerrors.WrapErrorf(commonerrors.ErrUnexpected, err, "an error occurred during execution of the matcher function for path segments %q and %q", pathASegments[i], pathBSegments[i])
+			err = commonerrors.WrapErrorf(commonerrors.ErrUnexpected, err, "an error occurred during execution of the matcher function for path segments %q and %q", pathASegment, pathBSegment)
 			return
 		}
 
@@ -164,4 +182,19 @@ func SplitPath(p string) []string {
 	p = path.Clean(p)
 	p = strings.Trim(p, defaultPathSeparator)
 	return collection.ParseListWithCleanup(p, defaultPathSeparator)
+}
+
+func isURI(value string) bool {
+	if reflection.IsEmpty(value) {
+		return false
+	}
+	if is.URL.Validate(value) == nil {
+		return true
+	}
+	_, err := netUrl.ParseRequestURI(value)
+	return err == nil
+}
+
+func isPathParameter(value string) bool {
+	return ValidatePathParameter(value) == nil
 }

--- a/utils/url/url_test.go
+++ b/utils/url/url_test.go
@@ -4,11 +4,64 @@ import (
 	"strings"
 	"testing"
 
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
+	"github.com/ARM-software/golang-utils/utils/reflection"
 )
+
+func TestUrl_IsURI(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		err   string
+	}{
+		{name: "absolute URL", value: "https://example.com/path?a=1"},
+		{name: "mailto URI", value: "mailto:user@example.com"},
+		{name: "relative URI reference", value: "/api/v1/resources?id=1"},
+		{name: "byte slice", value: []byte("urn:isbn:0451450523")},
+		{name: "empty", value: ""},
+		{name: "invalid", value: "http://exa mple.com", err: errURIInvalid.Error()},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			err := validation.Validate(test.value, IsURI)
+			if reflection.IsEmpty(test.err) {
+				assert.NoError(t, err)
+				return
+			}
+			errortest.AssertErrorDescription(t, err, test.err)
+		})
+	}
+}
+
+func TestUrl_IsPathParameterRule(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		err   string
+	}{
+		{name: "valid string", value: "{abc}"},
+		{name: "valid bytes", value: []byte("{abc%5F1}")},
+		{name: "invalid", value: "abc", err: errPathParameterInvalid.Error()},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			err := validation.Validate(test.value, IsPathParameter)
+			if reflection.IsEmpty(test.err) {
+				assert.NoError(t, err)
+				return
+			}
+			errortest.AssertErrorDescription(t, err, test.err)
+		})
+	}
+}
 
 func TestUrl_MatchesPathParameterSyntax(t *testing.T) {
 	tests := []struct {

--- a/utils/validation/rules.go
+++ b/utils/validation/rules.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/encoding/base64"
-	"github.com/ARM-software/golang-utils/utils/url"
+	urlutils "github.com/ARM-software/golang-utils/utils/url"
 )
 
 // IsPort validates whether a value is a port using is.Port from github.com/go-ozzo/ozzo-validation/v4.
@@ -55,10 +55,9 @@ func isPort(vRaw any) (err error) {
 // IsBase64 validates whether a value is a base64 encoded string. It is similar to is.Base64 but more generic and robust although less performant.
 var IsBase64 = validation.NewStringRuleWithError(base64.IsEncoded, is.ErrBase64)
 
-// IsPathParameter validates whether a value is a valid path parameter of a url.
-var IsPathParameter = validation.NewStringRule(isValidPathParameter, "invalid path parameter")
+// IsURI validates URI strings and byte slices.
+var IsURI = urlutils.IsURI
 
-func isValidPathParameter(value string) bool {
-	err := url.ValidatePathParameter(value)
-	return err == nil
-}
+// IsPathParameter validates OpenAPI-style path parameter segments such as
+// `{id}`.
+var IsPathParameter = urlutils.IsPathParameter

--- a/utils/validation/rules_test.go
+++ b/utils/validation/rules_test.go
@@ -125,3 +125,27 @@ func TestIsPathParameter(t *testing.T) {
 		})
 	}
 }
+
+func TestIsURI(t *testing.T) {
+	tests := []struct {
+		input    any
+		expected bool
+	}{
+		{"https://example.com/path", true},
+		{"mailto:user@example.com", true},
+		{[]byte("/relative/path?x=1"), true},
+		{"http://exa mple.com", false},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run("", func(t *testing.T) {
+			err := validation.Validate(test.input, IsURI)
+			if test.expected {
+				require.NoError(t, err)
+			} else {
+				errortest.AssertErrorDescription(t, err, "must be a valid URI")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Comparing URLs is actually quite difficult as they have many encoding possible, many elements which may or may not be important: See https://www.rfc-editor.org/info/rfc3986/#section-6 for more details