### PR TITLE
:bug: [jsonschema] Default schema options now keep `filesystem.NoLimits()` without failing validation

### DIFF
--- a/changes/202608062145.bugfix
+++ b/changes/202608062145.bugfix
@@ -1,0 +1,1 @@
+:bug: [jsonschema] Default schema options now keep `filesystem.NoLimits()` while schema validation only requires non-nil limits, so no-limit schemas no longer fail with missing `Limits`.

--- a/changes/202608071730.feature
+++ b/changes/202608071730.feature
@@ -1,0 +1,1 @@
+:bug: [validation] Replace safe library uses of raw ozzo `validation.Required` with the shared state-oriented `utils/validation.Required`, while keeping intentional non-empty or non-zero cases on ozzo or legacy semantics so zero-valued but present fields are validated consistently.

--- a/utils/cache/filecache/config.go
+++ b/utils/cache/filecache/config.go
@@ -6,6 +6,7 @@ import (
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 
 	configUtils "github.com/ARM-software/golang-utils/utils/config"
+	validationRules "github.com/ARM-software/golang-utils/utils/validation"
 )
 
 type FileCacheConfig struct {
@@ -23,7 +24,7 @@ func (cfg *FileCacheConfig) Validate() error {
 	}
 
 	return validation.ValidateStruct(cfg,
-		validation.Field(&cfg.CachePath, validation.Required),
+		validation.Field(&cfg.CachePath, validationRules.Required),
 		validation.Field(&cfg.GarbageCollectionPeriod, validation.Required),
 		validation.Field(&cfg.TTL, validation.Required),
 	)

--- a/utils/config/service_configuration.go
+++ b/utils/config/service_configuration.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ARM-software/golang-utils/utils/keyring"
 	"github.com/ARM-software/golang-utils/utils/reflection"
 	"github.com/ARM-software/golang-utils/utils/serialization/maps" //nolint:misspell
+	validationRules "github.com/ARM-software/golang-utils/utils/validation"
 )
 
 const (
@@ -182,7 +183,7 @@ type LoadingOptions struct {
 
 func (o *LoadingOptions) Validate() (err error) {
 	return WrapValidationError(nil, validation.ValidateStruct(o,
-		validation.Field(&o.viperSession, validation.Required),
+		validation.Field(&o.viperSession, validationRules.Required),
 	))
 }
 

--- a/utils/encryption/aesrsa/payload.go
+++ b/utils/encryption/aesrsa/payload.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/config"
+	validationRules "github.com/ARM-software/golang-utils/utils/validation"
 )
 
 type HybridAESRSAEncryptedPayload struct {
@@ -26,9 +27,9 @@ func (p *HybridAESRSAEncryptedPayload) Validate() (err error) {
 	}
 
 	return validation.ValidateStruct(p,
-		validation.Field(&p.CipherText, validation.Required),
-		validation.Field(&p.EncryptedKey, validation.Required),
-		validation.Field(&p.Nonce, validation.Required),
+		validation.Field(&p.CipherText, validationRules.Required),
+		validation.Field(&p.EncryptedKey, validationRules.Required),
+		validation.Field(&p.Nonce, validationRules.Required),
 	)
 }
 

--- a/utils/environment/envvar.go
+++ b/utils/environment/envvar.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/platform"
+	validationRules "github.com/ARM-software/golang-utils/utils/validation"
 )
 
 var (
@@ -67,7 +68,7 @@ func (e *EnvVar) String() string {
 }
 
 func (e *EnvVar) Validate() (err error) {
-	err = validation.Validate(e.GetKey(), validation.Required, IsEnvironmentVariableKey)
+	err = validation.Validate(e.GetKey(), validationRules.Required, IsEnvironmentVariableKey)
 	if err != nil {
 		err = commonerrors.WrapErrorf(commonerrors.ErrInvalid, err, "environment variable name `%v` is not valid", e.GetKey())
 		return

--- a/utils/environment/envvar_test.go
+++ b/utils/environment/envvar_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
 	"github.com/ARM-software/golang-utils/utils/platform"
+	validationRules "github.com/ARM-software/golang-utils/utils/validation"
 )
 
 func TestEnvVar_Validate(t *testing.T) {
@@ -73,20 +74,20 @@ func TestEnvVar_Validate(t *testing.T) {
 			key:         faker.Word(),
 			name:        "variable value compliant with one rule",
 			value:       faker.Sentence(),
-			valueRules:  []validation.Rule{validation.Required},
+			valueRules:  []validation.Rule{validationRules.Required},
 			expectError: false,
 		},
 		{
 			key:         faker.Word(),
 			name:        "variable value compliant with several rules",
 			value:       faker.Word(),
-			valueRules:  []validation.Rule{validation.Required, is.Alphanumeric},
+			valueRules:  []validation.Rule{validationRules.Required, is.Alphanumeric},
 			expectError: false,
 		},
 		{
 			key:         faker.Word(),
 			name:        "non compliant variable value",
-			valueRules:  []validation.Rule{validation.Required},
+			valueRules:  []validation.Rule{validationRules.Required},
 			expectError: true,
 		},
 	}

--- a/utils/filesystem/limits_test.go
+++ b/utils/filesystem/limits_test.go
@@ -3,13 +3,17 @@ package filesystem
 import (
 	"testing"
 
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	validationRules "github.com/ARM-software/golang-utils/utils/validation"
 )
 
 func TestNewLimits(t *testing.T) {
 	require.NoError(t, NoLimits().Validate())      //nolint:typecheck
 	require.NoError(t, DefaultLimits().Validate()) //nolint:typecheck
+	require.NoError(t, validation.Validate(NoLimits(), validationRules.Required))
 	assert.True(t, DefaultLimits().Apply())
 	assert.False(t, NoLimits().Apply())
 }

--- a/utils/filesystem/rules.go
+++ b/utils/filesystem/rules.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ARM-software/golang-utils/utils/collection"
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/reflection"
+	validationRules "github.com/ARM-software/golang-utils/utils/validation"
 )
 
 type filesystemValidationRule struct {
@@ -18,7 +19,7 @@ type filesystemValidationRule struct {
 }
 
 func (r *filesystemValidationRule) Validate(value any) error {
-	err := validation.Required.When(r.condition).Validate(value)
+	err := validation.When(r.condition, validationRules.Required).Validate(value)
 	if err != nil {
 		return commonerrors.WrapErrorf(commonerrors.ErrUndefined, err, "missing value")
 	}

--- a/utils/git/config.go
+++ b/utils/git/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/config"
 	"github.com/ARM-software/golang-utils/utils/reflection"
+	validationRules "github.com/ARM-software/golang-utils/utils/validation"
 )
 
 // SSHAuthConfig holds SSH-specific authentication configuration.
@@ -53,7 +54,7 @@ func (s *SSHAuthConfig) Validate() error {
 	return validation.ValidateStruct(s,
 		// PrivateKeyPath is required when SSH is configured without the agent
 		validation.Field(&s.PrivateKeyPath,
-			validation.When(s.isConfigured() && !s.UseAgent, validation.Required),
+			validation.When(s.isConfigured() && !s.UseAgent, validationRules.Required),
 		),
 		// KnownHostsFile and UseInsecureHostKey are mutually exclusive
 		validation.Field(&s.KnownHostsFile,
@@ -180,7 +181,7 @@ func (c *GitActionConfig) Validate() error {
 		return err
 	}
 	return validation.ValidateStruct(c,
-		validation.Field(&c.URL, validation.Required),
+		validation.Field(&c.URL, validationRules.Required),
 	)
 }
 

--- a/utils/http/configuration.go
+++ b/utils/http/configuration.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-cleanhttp"
 
 	"github.com/ARM-software/golang-utils/utils/config"
+	validationRules "github.com/ARM-software/golang-utils/utils/validation"
 )
 
 // HTTPClientConfiguration defines the client configuration. It can be used to tweak low level transport
@@ -62,7 +63,7 @@ func (cfg *HTTPClientConfiguration) Validate() error {
 	return validation.ValidateStruct(cfg,
 		validation.Field(&cfg.MaxIdleConns, validation.Min(0)),
 		validation.Field(&cfg.MaxIdleConnsPerHost, validation.Max(cfg.MaxIdleConns)),
-		validation.Field(&cfg.IdleConnTimeout, validation.Required),
+		validation.Field(&cfg.IdleConnTimeout, validationRules.Required),
 		validation.Field(&cfg.RetryPolicy, validation.Required),
 	)
 

--- a/utils/http/request.go
+++ b/utils/http/request.go
@@ -11,6 +11,7 @@ import (
 	configUtils "github.com/ARM-software/golang-utils/utils/config"
 	"github.com/ARM-software/golang-utils/utils/http/schemes"
 	"github.com/ARM-software/golang-utils/utils/reflection"
+	validationRules "github.com/ARM-software/golang-utils/utils/validation"
 )
 
 const (
@@ -71,8 +72,8 @@ func (cfg *Auth) Validate() (err error) {
 		return
 	}
 	return validation.ValidateStruct(cfg,
-		validation.Field(&cfg.Scheme, validation.When(cfg.Enforced, validation.Required, validation.In(inAuthSchemes...))),
-		validation.Field(&cfg.AccessToken, validation.Required.When(cfg.Enforced)),
+		validation.Field(&cfg.Scheme, validation.When(cfg.Enforced, validationRules.Required, validation.In(inAuthSchemes...))),
+		validation.Field(&cfg.AccessToken, validation.When(cfg.Enforced, validationRules.Required)),
 	)
 }
 
@@ -116,7 +117,7 @@ func (cfg *Target) Validate() (err error) {
 	}
 
 	return validation.ValidateStruct(cfg,
-		validation.Field(&cfg.Host, validation.Required, is.URL),
+		validation.Field(&cfg.Host, validationRules.Required, is.URL),
 		validation.Field(&cfg.Port, is.UTFNumeric, is.Port),
 	)
 }
@@ -136,8 +137,8 @@ func (cfg *RequestConfiguration) Validate() (err error) {
 	}
 
 	return validation.ValidateStruct(cfg,
-		validation.Field(&cfg.Host, validation.Required),
-		validation.Field(&cfg.UserAgent, validation.Required),
+		validation.Field(&cfg.Host, validationRules.Required),
+		validation.Field(&cfg.UserAgent, validationRules.Required),
 		validation.Field(&cfg.Authorisation, validation.Required),
 		validation.Field(&cfg.Retries, validation.Required),
 	)

--- a/utils/platform/os.go
+++ b/utils/platform/os.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/safecast"
+	validationRules "github.com/ARM-software/golang-utils/utils/validation"
 )
 
 var (
@@ -53,7 +54,7 @@ const (
 )
 
 func isWindowsVarName(value string) bool {
-	if validation.Required.Validate(value) != nil {
+	if validationRules.Required.Validate(value) != nil {
 		return false
 	}
 	regex := regexp.MustCompile(WindowsVariableNameRegexString)
@@ -61,7 +62,7 @@ func isWindowsVarName(value string) bool {
 }
 
 func isUnixVarName(value string) bool {
-	if validation.Required.Validate(value) != nil {
+	if validationRules.Required.Validate(value) != nil {
 		return false
 	}
 	regex := regexp.MustCompile(UnixVariableNameRegexString)

--- a/utils/serialization/frontmatter/format.go
+++ b/utils/serialization/frontmatter/format.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/config"
 	"github.com/ARM-software/golang-utils/utils/reflection"
+	validationRules "github.com/ARM-software/golang-utils/utils/validation"
 )
 
 // Format describes how a front matter block is detected and extracted.
@@ -78,8 +79,8 @@ func (f *Format) Validate() error {
 	err := config.ValidateEmbedded(f)
 	if err == nil {
 		err = validation.ValidateStruct(f,
-			validation.Field(&f.Start, validation.Required),
-			validation.Field(&f.End, validation.Required),
+			validation.Field(&f.Start, validationRules.Required),
+			validation.Field(&f.End, validationRules.Required),
 		)
 	}
 

--- a/utils/sharedcache/config.go
+++ b/utils/sharedcache/config.go
@@ -6,6 +6,7 @@ import (
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 
 	configUtils "github.com/ARM-software/golang-utils/utils/config"
+	validationRules "github.com/ARM-software/golang-utils/utils/validation"
 )
 
 type Configuration struct {
@@ -23,7 +24,7 @@ func (cfg *Configuration) Validate() error {
 	}
 
 	return validation.ValidateStruct(cfg,
-		validation.Field(&cfg.RemoteStoragePath, validation.Required),
+		validation.Field(&cfg.RemoteStoragePath, validationRules.Required),
 	)
 }
 

--- a/utils/strings/casing/replacement.go
+++ b/utils/strings/casing/replacement.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/reflection"
 	"github.com/ARM-software/golang-utils/utils/safeio"
+	validationRules "github.com/ARM-software/golang-utils/utils/validation"
 )
 
 var (
@@ -74,8 +75,8 @@ func (r Rule) Merge(other *Rule) Rule {
 // Validate checks that the rule contains the required values.
 func (r *Rule) Validate() (err error) {
 	err = validation.ValidateStruct(r,
-		validation.Field(&r.Token, validation.Required),
-		validation.Field(&r.Replacement, validation.Required),
+		validation.Field(&r.Token, validationRules.Required),
+		validation.Field(&r.Replacement, validationRules.Required),
 	)
 	if err != nil {
 		err = commonerrors.WrapError(commonerrors.ErrInvalid, err, "invalid replacement rule")

--- a/utils/validation/jsonschema/validation.go
+++ b/utils/validation/jsonschema/validation.go
@@ -90,7 +90,13 @@ func (s *Schema) Validate() error {
 			validation.Field(&s.LocalPath, validation.Required),
 			validation.Field(&s.ID, validation.Required),
 			validation.Field(&s.Filesystem, validation.Required),
-			validation.Field(&s.Limits, validation.Required),
+			// Ensure filesystem.NoLimits() remains valid while still rejecting a nil limits interface.
+			validation.Field(&s.Limits, validation.By(func(_ any) error {
+				if s.Limits == nil {
+					return validation.ErrRequired
+				}
+				return nil
+			})),
 		)
 	}
 

--- a/utils/validation/jsonschema/validation.go
+++ b/utils/validation/jsonschema/validation.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ARM-software/golang-utils/utils/reflection"
 	"github.com/ARM-software/golang-utils/utils/serialization/json" //nolint:misspell
 	"github.com/ARM-software/golang-utils/utils/serialization/yaml" //nolint:misspell
+	validationRules "github.com/ARM-software/golang-utils/utils/validation"
 )
 
 // Schema describes a schema file that can be loaded and registered for
@@ -86,17 +87,11 @@ func (s *Schema) Validate() error {
 	err := config.ValidateEmbedded(s)
 	if err == nil {
 		err = validation.ValidateStruct(s,
-			validation.Field(&s.Title, validation.Required),
-			validation.Field(&s.LocalPath, validation.Required),
-			validation.Field(&s.ID, validation.Required),
-			validation.Field(&s.Filesystem, validation.Required),
-			// Ensure filesystem.NoLimits() remains valid while still rejecting a nil limits interface.
-			validation.Field(&s.Limits, validation.By(func(_ any) error {
-				if s.Limits == nil {
-					return validation.ErrRequired
-				}
-				return nil
-			})),
+			validation.Field(&s.Title, validationRules.Required),
+			validation.Field(&s.LocalPath, validationRules.Required),
+			validation.Field(&s.ID, validationRules.Required),
+			validation.Field(&s.Filesystem, validationRules.Required),
+			validation.Field(&s.Limits, validationRules.Required),
 		)
 	}
 
@@ -122,7 +117,7 @@ func (s *SchemaSpec) Validate() error {
 		return commonerrors.UndefinedVariable("schema specification")
 	}
 	err := validation.ValidateStruct(s,
-		validation.Field(&s.ID, validation.Required),
+		validation.Field(&s.ID, validationRules.Required),
 		validation.Field(&s.Specification, validation.Required),
 	)
 	if err != nil {

--- a/utils/validation/jsonschema/validation_test.go
+++ b/utils/validation/jsonschema/validation_test.go
@@ -90,6 +90,13 @@ func newCompoundSchemas(t *testing.T, fs filesystem.FS) []Schema {
 
 func TestSchemaValidate(t *testing.T) {
 	require.NoError(t, newValidSchema(t, filesystem.GetGlobalFileSystem()).Validate())
+	require.NoError(t, (&Schema{
+		Title:      "person",
+		LocalPath:  path.Join("testdata", "person.schema.json"),
+		ID:         path.Join("testdata", "person.schema.json"),
+		Filesystem: filesystem.GetGlobalFileSystem(),
+		Limits:     filesystem.NoLimits(),
+	}).Validate())
 
 	var nilSchema *Schema
 	err := nilSchema.Validate()
@@ -353,6 +360,18 @@ func TestValidateRawYAMLAgainstSchemaOptions(t *testing.T) {
 		WithFilesystem(filesystem.GetGlobalFileSystem()),
 	)
 	require.NoError(t, err)
+}
+
+func TestDefaultSchemaSetsDefaultLimits(t *testing.T) {
+	schema := DefaultSchema()
+	require.NotNil(t, schema)
+	require.NotNil(t, schema.Limits)
+	assert.False(t, schema.Limits.Apply())
+	assert.Equal(t, filesystem.NoLimits().GetMaxFileSize(), schema.Limits.GetMaxFileSize())
+	assert.Equal(t, filesystem.NoLimits().GetMaxTotalSize(), schema.Limits.GetMaxTotalSize())
+	assert.Equal(t, filesystem.NoLimits().GetMaxFileCount(), schema.Limits.GetMaxFileCount())
+	assert.Equal(t, filesystem.NoLimits().GetMaxDepth(), schema.Limits.GetMaxDepth())
+	assert.Equal(t, filesystem.NoLimits().ApplyRecursively(), schema.Limits.ApplyRecursively())
 }
 
 func TestValidateRawYAMLAgainstSchemaOptions_IgnoreYAMLAliases(t *testing.T) {


### PR DESCRIPTION
This is to solve the issue with validation while defaulting to NoLimits

I extended the PR to use our in-house validation.Required so that the change of behaviour in https://github.com/go-ozzo/ozzo-validation/releases#release-v4.4.0 does not affect our library dependencies such as services