### PR TITLE
:sparkles: [validation] Added when-rule helpers for not-equals, empty, and not-empty checks across property- and field-based validation.

### DIFF
--- a/changes/202608062230.feature
+++ b/changes/202608062230.feature
@@ -1,0 +1,1 @@
+:sparkles: [validation] Added when-rule helpers for not-equals, empty, and not-empty checks across property- and field-based validation.

--- a/changes/202608070910.feature
+++ b/changes/202608070910.feature
@@ -1,0 +1,1 @@
+:sparkles: [validation] Added non-recursive value-oriented helpers such as `WhenFieldEqualsValue`, `RequiredFieldsBy`, `FieldDependencyBy`, `MutuallyExclusiveFieldsBy`, and `ForbiddenFieldsBy` for clearer cross-field validation.

--- a/changes/202608071000.feature
+++ b/changes/202608071000.feature
@@ -1,0 +1,1 @@
+:sparkles: [validation] Added value-oriented field helpers because property-oriented rules are clearer for maps than structs, and struct `Validate()` implementations needed readable cross-field validation without recursive helper composition traps.

--- a/changes/202608071140.bugfix
+++ b/changes/202608071140.bugfix
@@ -1,0 +1,1 @@
+:bug: [validation] Added regression coverage pinning the current `validation.Required` behaviour for zero-valued structs so future ozzo upgrades do not silently change repository validation semantics.

--- a/changes/202608071215.feature
+++ b/changes/202608071215.feature
@@ -1,0 +1,1 @@
+:sparkles: `[validation]` Add state-oriented validation rules for zero, emptiness, nil, and legacy required semantics, including a struct-friendly `IsRequired` that preserves pre-v4.4 ozzo behaviour.

--- a/changes/202608071235.bugfix
+++ b/changes/202608071235.bugfix
@@ -1,0 +1,1 @@
+:bug: [validation] Added a state-style `Required` rule to avoid OpenAPI validation issues where valid zero values such as false and numeric zero were incorrectly excluded, while still rejecting nil values, empty strings, and zero `time.Time{}`. See `utils/validation/state_rules.go` for the `Required` definition.

--- a/utils/validation/json-schema-rules.go
+++ b/utils/validation/json-schema-rules.go
@@ -1301,7 +1301,7 @@ func ForbiddenFieldsBy(fields ...any) validation.Rule {
 // numbers represented as `float64(3)`.
 func XIntOrString() validation.Rule {
 	return validation.By(func(value any) error {
-		if validation.NotNil.Validate(value) != nil {
+		if isNilValue(value) {
 			return errIntOrString
 		}
 		candidate, _ := validation.Indirect(value)
@@ -1412,7 +1412,7 @@ func Not(rule validation.Rule) validation.Rule {
 //     https://spec.openapis.org/oas/v3.0.3.html#schema-object
 func Nullable(rule validation.Rule) validation.Rule {
 	return validation.By(func(value any) error {
-		if validation.Nil.Validate(value) == nil {
+		if isNilValue(value) {
 			return nil
 		}
 		if rule == nil {
@@ -1458,19 +1458,6 @@ func NoneOf(rules ...validation.Rule) validation.Rule {
 // Reference: https://json-schema.org/understanding-json-schema/reference/combining#oneof
 func OneOf(rules ...validation.Rule) validation.Rule {
 	return NewOneOfRule(rules...)
-}
-
-// NotEmpty validates that a value is not empty according to the repository's
-// reflection-based emptiness semantics.
-//
-// Example: `NotEmpty()` rejects `"   "`.
-func NotEmpty() validation.Rule {
-	return validation.By(func(value any) error {
-		if utilreflection.IsNotEmpty(value) {
-			return nil
-		}
-		return errNotEmpty
-	})
 }
 
 // LengthRule returns an ozzo length rule with optional minimum and maximum

--- a/utils/validation/json-schema-rules.go
+++ b/utils/validation/json-schema-rules.go
@@ -473,19 +473,91 @@ func RequiredItemKeys[T any, K comparable](keyFunc collection.KeyFunc[T, K], key
 //
 // Example:
 //
-//	cfg := &Config{}
-//	err := validation.Validate(cfg, RequiredPropertiesBy(&cfg.Name, &cfg.Enabled, &cfg.Mode))
+//	payload := map[string]any{"name": "alice", "enabled": true}
+//	err := validation.Validate(payload, RequiredPropertiesBy("name", "enabled", "mode"))
+//
+// This helper is best suited to property-oriented validation of maps or decoded
+// object content where the question is whether properties exist at all. For
+// struct validation where fields are always present but their values must be
+// non-empty, prefer [RequiredFieldsBy]. That is especially true when the struct
+// has its own `Validate()` method and the rule is composed inside that method.
 func RequiredPropertiesBy(keys ...any) validation.Rule {
+	return validation.By(func(value any) error {
+		return propertyRuleBy(value, "RequiredPropertiesBy", "RequiredFieldsBy", keys, func(replayableValue any, names []string) error {
+			return RequiredProperties(names...).Validate(replayableValue)
+		})
+	})
+}
+
+// RequiredFieldsBy resolves strings, `[]string`, or field references such as
+// `&cfg.Name` and validates that each resolved field value is non-empty.
+//
+// This is the value-oriented counterpart to [RequiredPropertiesBy]. It is useful
+// when the object shape is fixed (for example a struct) and the validation should
+// require actual values rather than mere property presence.
+//
+// Example:
+//
+//	cfg := &Config{}
+//	err := validation.Validate(cfg, RequiredFieldsBy(&cfg.Name, &cfg.Mode))
+//
+// This rejects `cfg` when either `cfg.Name` or `cfg.Mode` is empty, even though
+// those struct fields are always present on the object.
+func RequiredFieldsBy(fields ...any) validation.Rule {
+	return validation.By(func(value any) error {
+		return fieldValueRuleBy(value, fields, requireResolvedFields)
+	})
+}
+
+// FieldDependencyBy resolves field references on the validated value and
+// requires the dependent fields to be non-empty whenever the source field is
+// present.
+//
+// Example:
+//
+//	cfg := &Config{}
+//	err := validation.Validate(cfg, FieldDependencyBy(map[any][]any{&cfg.SummaryFile: {&cfg.Summary}}))
+//
+// This rejects `cfg` when `cfg.SummaryFile` is non-empty but `cfg.Summary` is
+// empty.
+func FieldDependencyBy(dependencies map[any][]any) validation.Rule {
 	return validation.By(func(value any) error {
 		replayableValue, err := replayableValidationValue(value)
 		if err != nil {
 			return err
 		}
-		normalisedKeys, err := propertyNamesForValue(replayableValue, keys...)
-		if err != nil {
+		props, isNil, err := objectProperties(replayableValue)
+		if err != nil || isNil {
 			return err
 		}
-		return RequiredProperties(normalisedKeys...).Validate(replayableValue)
+		validationErrors := validation.Errors{}
+		for field, dependentFields := range dependencies {
+			fieldName, err := propertyNameForValue(replayableValue, field)
+			if err != nil {
+				return err
+			}
+			actual, found := props.value(fieldName)
+			if !found || utilreflection.IsEmpty(actual) {
+				continue
+			}
+			dependentNames, err := propertyNamesForValue(replayableValue, dependentFields...)
+			if err != nil {
+				return err
+			}
+			if err := requireResolvedFields(props, dependentNames); err != nil {
+				if ve, ok := err.(validation.Errors); ok {
+					for key, value := range ve {
+						validationErrors[key] = value
+					}
+					continue
+				}
+				return err
+			}
+		}
+		if len(validationErrors) > 0 {
+			return validationErrors
+		}
+		return nil
 	})
 }
 
@@ -585,19 +657,24 @@ func DependentRequiredItemKeys[T any, K comparable](keyFunc collection.KeyFunc[T
 //
 // Example:
 //
-//	cfg := &Config{}
-//	err := validation.Validate(cfg, DependentRequiredBy(map[any]any{&cfg.Username: []any{&cfg.Password, &cfg.Scheme}}))
+//	payload := map[string]any{"username": "alice"}
+//	err := validation.Validate(payload, DependentRequiredBy(map[any]any{"username": []any{"password", "scheme"}}))
+//
+// This helper is best suited to property-oriented validation of maps or decoded
+// object content where dependencies are expressed in terms of property
+// existence. For struct validation where dependencies should be based on
+// non-empty field values, prefer [FieldDependencyBy]. That is especially true
+// when the struct has its own `Validate()` method and the rule is composed
+// inside that method.
 func DependentRequiredBy(dependencies map[any]any) validation.Rule {
 	return validation.By(func(value any) error {
-		replayableValue, err := replayableValidationValue(value)
-		if err != nil {
-			return err
-		}
-		normalised, err := propertyDependenciesForValue(replayableValue, dependencies)
-		if err != nil {
-			return err
-		}
-		return DependentRequired(normalised).Validate(replayableValue)
+		return propertyRuleBy(value, "DependentRequiredBy", "FieldDependencyBy", dependencySpecifiers(dependencies), func(replayableValue any, _ []string) error {
+			normalised, err := propertyDependenciesForValue(replayableValue, dependencies)
+			if err != nil {
+				return err
+			}
+			return DependentRequired(normalised).Validate(replayableValue)
+		})
 	})
 }
 
@@ -794,15 +871,9 @@ func AdditionalItemKeys[T any, K comparable](keyFunc collection.KeyFunc[T, K], k
 //	err := validation.Validate(cfg, AdditionalPropertiesBy(&cfg.Name, &cfg.Enabled, &cfg.Mode))
 func AdditionalPropertiesBy(keys ...any) validation.Rule {
 	return validation.By(func(value any) error {
-		replayableValue, err := replayableValidationValue(value)
-		if err != nil {
-			return err
-		}
-		normalisedKeys, err := propertyNamesForValue(replayableValue, keys...)
-		if err != nil {
-			return err
-		}
-		return AdditionalProperties(normalisedKeys...).Validate(replayableValue)
+		return propertyRuleBy(value, "", "", keys, func(replayableValue any, names []string) error {
+			return AdditionalProperties(names...).Validate(replayableValue)
+		})
 	})
 }
 
@@ -894,19 +965,29 @@ func MutuallyExclusiveItemKeys[T any, K comparable](keyFunc collection.KeyFunc[T
 //
 // Example:
 //
-//	cfg := &Config{}
-//	err := validation.Validate(cfg, MutuallyExclusiveWithBy(&cfg.Token, &cfg.Username, &cfg.APIKey))
+//	payload := map[string]any{"token": "abc", "apiKey": "def"}
+//	err := validation.Validate(payload, MutuallyExclusiveWithBy("token", "username", "apiKey"))
+//
+// This helper is best suited to property-oriented validation of maps or decoded
+// object content. For struct validation where exclusivity should be based on
+// non-empty field values, prefer [MutuallyExclusiveFieldsBy]. That is
+// especially true when the struct has its own `Validate()` method and the rule
+// is composed inside that method.
 func MutuallyExclusiveWithBy(keys ...any) validation.Rule {
 	return validation.By(func(value any) error {
-		replayableValue, err := replayableValidationValue(value)
-		if err != nil {
-			return err
-		}
-		normalisedKeys, err := propertyNamesForValue(replayableValue, keys...)
-		if err != nil {
-			return err
-		}
-		return MutuallyExclusiveWith(normalisedKeys...).Validate(replayableValue)
+		return propertyRuleBy(value, "MutuallyExclusiveWithBy", "MutuallyExclusiveFieldsBy", keys, func(replayableValue any, names []string) error {
+			return MutuallyExclusiveWith(names...).Validate(replayableValue)
+		})
+	})
+}
+
+// MutuallyExclusiveFieldsBy resolves field references on the validated value
+// and validates that at most one of the resolved field values is non-empty.
+func MutuallyExclusiveFieldsBy(fields ...any) validation.Rule {
+	return validation.By(func(value any) error {
+		return fieldValueRuleBy(value, fields, func(props *objectAccessor, names []string) error {
+			return checkResolvedFieldCardinality(props, names, -1, 1)
+		})
 	})
 }
 
@@ -951,15 +1032,19 @@ func AtMostOneItemKey[T any, K comparable](keyFunc collection.KeyFunc[T, K], key
 //	err := validation.Validate(cfg, AtMostOnePropertyBy(&cfg.Token, &cfg.Username, &cfg.APIKey))
 func AtMostOnePropertyBy(keys ...any) validation.Rule {
 	return validation.By(func(value any) error {
-		replayableValue, err := replayableValidationValue(value)
-		if err != nil {
-			return err
-		}
-		normalisedKeys, err := propertyNamesForValue(replayableValue, keys...)
-		if err != nil {
-			return err
-		}
-		return AtMostOneProperty(normalisedKeys...).Validate(replayableValue)
+		return propertyRuleBy(value, "AtMostOnePropertyBy", "MutuallyExclusiveFieldsBy", keys, func(replayableValue any, names []string) error {
+			return AtMostOneProperty(names...).Validate(replayableValue)
+		})
+	})
+}
+
+// OneOfFieldsBy resolves field references on the validated value and validates
+// that exactly one of the resolved field values is non-empty.
+func OneOfFieldsBy(fields ...any) validation.Rule {
+	return validation.By(func(value any) error {
+		return fieldValueRuleBy(value, fields, func(props *objectAccessor, names []string) error {
+			return checkResolvedFieldCardinality(props, names, 1, 1)
+		})
 	})
 }
 
@@ -1032,15 +1117,9 @@ func OneOfItemKeys[T any, K comparable](keyFunc collection.KeyFunc[T, K], keys .
 //	err := validation.Validate(cfg, OneOfPropertiesBy(&cfg.Token, &cfg.Username, &cfg.APIKey))
 func OneOfPropertiesBy(keys ...any) validation.Rule {
 	return validation.By(func(value any) error {
-		replayableValue, err := replayableValidationValue(value)
-		if err != nil {
-			return err
-		}
-		normalisedKeys, err := propertyNamesForValue(replayableValue, keys...)
-		if err != nil {
-			return err
-		}
-		return OneOfProperties(normalisedKeys...).Validate(replayableValue)
+		return propertyRuleBy(value, "OneOfPropertiesBy", "OneOfFieldsBy", keys, func(replayableValue any, names []string) error {
+			return OneOfProperties(names...).Validate(replayableValue)
+		})
 	})
 }
 
@@ -1112,15 +1191,19 @@ func AtLeastOneItemKey[T any, K comparable](keyFunc collection.KeyFunc[T, K], ke
 //	err := validation.Validate(cfg, AtLeastOnePropertyBy(&cfg.Token, &cfg.Username, &cfg.APIKey))
 func AtLeastOnePropertyBy(keys ...any) validation.Rule {
 	return validation.By(func(value any) error {
-		replayableValue, err := replayableValidationValue(value)
-		if err != nil {
-			return err
-		}
-		normalisedKeys, err := propertyNamesForValue(replayableValue, keys...)
-		if err != nil {
-			return err
-		}
-		return AtLeastOneProperty(normalisedKeys...).Validate(replayableValue)
+		return propertyRuleBy(value, "AtLeastOnePropertyBy", "AtLeastOneFieldBy", keys, func(replayableValue any, names []string) error {
+			return AtLeastOneProperty(names...).Validate(replayableValue)
+		})
+	})
+}
+
+// AtLeastOneFieldBy resolves field references on the validated value and
+// validates that at least one of the resolved field values is non-empty.
+func AtLeastOneFieldBy(fields ...any) validation.Rule {
+	return validation.By(func(value any) error {
+		return fieldValueRuleBy(value, fields, func(props *objectAccessor, names []string) error {
+			return checkResolvedFieldCardinality(props, names, 1, -1)
+		})
 	})
 }
 
@@ -1187,19 +1270,27 @@ func ForbiddenItemKeys[T any, K comparable](keyFunc collection.KeyFunc[T, K], ke
 //
 // Example:
 //
-//	cfg := &Config{}
-//	err := validation.Validate(cfg, ForbiddenPropertiesBy(&cfg.Debug, &cfg.InternalOnly))
+//	payload := map[string]any{"debug": true}
+//	err := validation.Validate(payload, ForbiddenPropertiesBy("debug", "internalOnly"))
+//
+// This helper is best suited to property-oriented validation of maps or decoded
+// object content. For struct validation where forbiddenness should be based on
+// non-empty field values, prefer [ForbiddenFieldsBy]. That is especially true
+// when the struct has its own `Validate()` method and the rule is composed
+// inside that method.
 func ForbiddenPropertiesBy(keys ...any) validation.Rule {
 	return validation.By(func(value any) error {
-		replayableValue, err := replayableValidationValue(value)
-		if err != nil {
-			return err
-		}
-		normalisedKeys, err := propertyNamesForValue(replayableValue, keys...)
-		if err != nil {
-			return err
-		}
-		return ForbiddenProperties(normalisedKeys...).Validate(replayableValue)
+		return propertyRuleBy(value, "ForbiddenPropertiesBy", "ForbiddenFieldsBy", keys, func(replayableValue any, names []string) error {
+			return ForbiddenProperties(names...).Validate(replayableValue)
+		})
+	})
+}
+
+// ForbiddenFieldsBy resolves field references on the validated value and
+// validates that all resolved field values are empty.
+func ForbiddenFieldsBy(fields ...any) validation.Rule {
+	return validation.By(func(value any) error {
+		return fieldValueRuleBy(value, fields, forbidResolvedFields)
 	})
 }
 

--- a/utils/validation/json-schema-rules.go
+++ b/utils/validation/json-schema-rules.go
@@ -49,7 +49,6 @@ var (
 	errPropertyNamesRuleNil = commonerrors.New(commonerrors.ErrInvalid, "propertyNames rule must not be nil")
 	errPatternRegexpNil     = commonerrors.New(commonerrors.ErrInvalid, "pattern regexp must not be nil")
 	errNullableRuleNil      = commonerrors.New(commonerrors.ErrInvalid, "nullable rule must not be nil")
-	errNotEmpty             = commonerrors.New(commonerrors.ErrInvalid, "cannot be empty")
 	errLengthBelowMinimum   = commonerrors.New(commonerrors.ErrInvalid, "the length must be no less than the minimum")
 )
 

--- a/utils/validation/json-schema-rules_test.go
+++ b/utils/validation/json-schema-rules_test.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-faker/faker/v4"
 	validation "github.com/go-ozzo/ozzo-validation/v4"
@@ -696,6 +697,26 @@ func TestJSONSchemaInspiredRulesFieldReferences(t *testing.T) {
 		other := &stringFields{}
 		err = validation.Validate(value, RequiredFieldsBy(&other.Name))
 		errortest.AssertError(t, err, commonerrors.ErrInvalid)
+	})
+
+	t.Run("required fields allow valid zero values", func(t *testing.T) {
+		type zeroValueFields struct {
+			Enabled bool
+			Count   int
+			When    time.Time
+			Name    string
+		}
+
+		value := &zeroValueFields{Enabled: false, Count: 0}
+		assert.NoError(t, validation.Validate(value, RequiredFieldsBy(&value.Enabled, &value.Count)))
+
+		err := validation.Validate(value, RequiredFieldsBy(&value.Name))
+		require.Error(t, err)
+		errortest.AssertErrorDescription(t, err, "Name")
+
+		err = validation.Validate(value, RequiredFieldsBy(&value.When))
+		require.Error(t, err)
+		errortest.AssertErrorDescription(t, err, "When")
 	})
 
 	t.Run("field dependency, exclusivity, and forbidden fields", func(t *testing.T) {

--- a/utils/validation/json-schema-rules_test.go
+++ b/utils/validation/json-schema-rules_test.go
@@ -20,6 +20,22 @@ import (
 	"github.com/ARM-software/golang-utils/utils/field"
 )
 
+type validatableRequiredPropertiesFields struct {
+	Name string
+}
+
+func (v *validatableRequiredPropertiesFields) Validate() error { return nil }
+
+type validatablePropertyOrientedFields struct {
+	Summary     string
+	SummaryFile string
+	Token       string
+	APIKey      string
+	Debug       string
+}
+
+func (v *validatablePropertyOrientedFields) Validate() error { return nil }
+
 func TestJSONSchemaInspiredRules(t *testing.T) {
 	invalidCollectionInputs := []struct {
 		name  string
@@ -602,6 +618,164 @@ func TestJSONSchemaInspiredRulesFieldReferences(t *testing.T) {
 		assert.NoError(t, validation.Validate(value, AdditionalPropertiesBy(&value.A, "B", &value.C)))
 		assert.NoError(t, validation.Validate(value, AdditionalPropertiesBy([]string{"A", "B", "C"})))
 		assert.Error(t, validation.Validate(value, AdditionalPropertiesBy(&value.A)))
+	})
+
+	t.Run("required properties rejects field references on validatable struct", func(t *testing.T) {
+		value := &validatableRequiredPropertiesFields{Name: "alice"}
+		err := validation.Validate(value, RequiredPropertiesBy(&value.Name))
+		errortest.AssertError(t, err, commonerrors.ErrInvalid)
+		errortest.AssertErrorDescription(t, err, "use RequiredFieldsBy instead")
+	})
+
+	t.Run("other property-oriented helpers reject field references on validatable struct", func(t *testing.T) {
+		t.Run("dependent required", func(t *testing.T) {
+			value := &validatablePropertyOrientedFields{}
+			err := validation.Validate(value, DependentRequiredBy(map[any]any{&value.SummaryFile: []any{&value.Summary}}))
+			errortest.AssertError(t, err, commonerrors.ErrInvalid)
+			errortest.AssertErrorDescription(t, err, "use FieldDependencyBy instead")
+		})
+
+		t.Run("mutually exclusive", func(t *testing.T) {
+			value := &validatablePropertyOrientedFields{}
+			err := validation.Validate(value, MutuallyExclusiveWithBy(&value.Token, &value.APIKey))
+			errortest.AssertError(t, err, commonerrors.ErrInvalid)
+			errortest.AssertErrorDescription(t, err, "use MutuallyExclusiveFieldsBy instead")
+		})
+
+		t.Run("at most one", func(t *testing.T) {
+			value := &validatablePropertyOrientedFields{}
+			err := validation.Validate(value, AtMostOnePropertyBy(&value.Token, &value.APIKey))
+			errortest.AssertError(t, err, commonerrors.ErrInvalid)
+			errortest.AssertErrorDescription(t, err, "use MutuallyExclusiveFieldsBy instead")
+		})
+
+		t.Run("one of", func(t *testing.T) {
+			value := &validatablePropertyOrientedFields{}
+			err := validation.Validate(value, OneOfPropertiesBy(&value.Token, &value.APIKey))
+			errortest.AssertError(t, err, commonerrors.ErrInvalid)
+			errortest.AssertErrorDescription(t, err, "use OneOfFieldsBy instead")
+		})
+
+		t.Run("at least one", func(t *testing.T) {
+			value := &validatablePropertyOrientedFields{}
+			err := validation.Validate(value, AtLeastOnePropertyBy(&value.Token, &value.APIKey))
+			errortest.AssertError(t, err, commonerrors.ErrInvalid)
+			errortest.AssertErrorDescription(t, err, "use AtLeastOneFieldBy instead")
+		})
+
+		t.Run("forbidden", func(t *testing.T) {
+			value := &validatablePropertyOrientedFields{}
+			err := validation.Validate(value, ForbiddenPropertiesBy(&value.Debug))
+			errortest.AssertError(t, err, commonerrors.ErrInvalid)
+			errortest.AssertErrorDescription(t, err, "use ForbiddenFieldsBy instead")
+		})
+	})
+
+	t.Run("required properties still supports property-oriented maps", func(t *testing.T) {
+		payload := map[string]any{"name": "alice"}
+		err := validation.Validate(payload, RequiredPropertiesBy("name"))
+		require.NoError(t, err)
+	})
+
+	t.Run("required fields", func(t *testing.T) {
+		type stringFields struct {
+			Name string
+			Mode string
+			Note string
+		}
+
+		value := &stringFields{Name: "alice", Mode: "strict"}
+		assert.NoError(t, validation.Validate(value, RequiredFieldsBy(&value.Name, &value.Mode)))
+		assert.NoError(t, validation.Validate(value, RequiredFieldsBy([]string{"Name", "Mode"})))
+
+		value.Mode = ""
+		err := validation.Validate(value, RequiredFieldsBy(&value.Name, &value.Mode))
+		require.Error(t, err)
+		errortest.AssertErrorDescription(t, err, "Mode")
+
+		other := &stringFields{}
+		err = validation.Validate(value, RequiredFieldsBy(&other.Name))
+		errortest.AssertError(t, err, commonerrors.ErrInvalid)
+	})
+
+	t.Run("field dependency, exclusivity, and forbidden fields", func(t *testing.T) {
+		type stringFields struct {
+			Summary     string
+			SummaryFile string
+			Token       string
+			APIKey      string
+			Debug       string
+		}
+
+		value := &stringFields{Summary: "file", SummaryFile: "summary.md"}
+		assert.NoError(t, validation.Validate(value, FieldDependencyBy(map[any][]any{&value.SummaryFile: []any{&value.Summary}})))
+
+		value = &stringFields{SummaryFile: "summary.md"}
+		err := validation.Validate(value, FieldDependencyBy(map[any][]any{&value.SummaryFile: []any{&value.Summary}}))
+		require.Error(t, err)
+		errortest.AssertErrorDescription(t, err, "Summary")
+
+		value = &stringFields{Token: "token"}
+		assert.NoError(t, validation.Validate(value, MutuallyExclusiveFieldsBy(&value.Token, &value.APIKey)))
+		value.APIKey = "key"
+		assert.Error(t, validation.Validate(value, MutuallyExclusiveFieldsBy(&value.Token, &value.APIKey)))
+
+		value = &stringFields{}
+		assert.NoError(t, validation.Validate(value, ForbiddenFieldsBy(&value.Debug)))
+		value.Debug = "enabled"
+		assert.Error(t, validation.Validate(value, ForbiddenFieldsBy(&value.Debug)))
+
+		value = &stringFields{Token: "token"}
+		assert.NoError(t, validation.Validate(value, OneOfFieldsBy(&value.Token, &value.APIKey)))
+		value.APIKey = "key"
+		assert.Error(t, validation.Validate(value, OneOfFieldsBy(&value.Token, &value.APIKey)))
+
+		value = &stringFields{}
+		assert.Error(t, validation.Validate(value, AtLeastOneFieldBy(&value.Token, &value.APIKey)))
+		value.Token = "token"
+		assert.NoError(t, validation.Validate(value, AtLeastOneFieldBy(&value.Token, &value.APIKey)))
+	})
+
+	t.Run("value-oriented field rules do not recurse inside Validate", func(t *testing.T) {
+		recursionErr := commonerrors.New(commonerrors.ErrUnexpected, "recursive validate call")
+		type config struct {
+			Summary     string
+			SummaryFile string
+			Token       string
+			APIKey      string
+			Debug       string
+			validating  bool
+		}
+		validateConfig := func(cfg *config) error {
+			if cfg.validating {
+				return recursionErr
+			}
+			cfg.validating = true
+			defer func() {
+				cfg.validating = false
+			}()
+			return NewAllRule(
+				FieldDependencyBy(map[any][]any{&cfg.SummaryFile: []any{&cfg.Summary}}),
+				MutuallyExclusiveFieldsBy(&cfg.Token, &cfg.APIKey),
+				ForbiddenFieldsBy(&cfg.Debug),
+			).Validate(cfg)
+		}
+
+		cfg := &config{SummaryFile: "summary.md"}
+		err := validateConfig(cfg)
+		require.Error(t, err)
+		errortest.AssertErrorDescription(t, err, "Summary")
+		assert.False(t, commonerrors.Any(err, commonerrors.ErrUnexpected))
+
+		cfg = &config{Token: "token", APIKey: "key"}
+		err = validateConfig(cfg)
+		require.Error(t, err)
+		assert.False(t, commonerrors.Any(err, commonerrors.ErrUnexpected))
+
+		cfg = &config{Debug: "enabled"}
+		err = validateConfig(cfg)
+		require.Error(t, err)
+		assert.False(t, commonerrors.Any(err, commonerrors.ErrUnexpected))
 	})
 
 	t.Run("dependent properties and schemas", func(t *testing.T) {

--- a/utils/validation/state_rules.go
+++ b/utils/validation/state_rules.go
@@ -1,0 +1,183 @@
+package validation
+
+import (
+	"reflect"
+	"time"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+
+	valueutils "github.com/ARM-software/golang-utils/utils/value"
+)
+
+var (
+	// ErrZeroRequired reports that the value must be the zero value for its type.
+	ErrZeroRequired = validation.NewError("validation_zero_required", "must be zero")
+	// ErrNotZeroRequired reports that the value must not be the zero value for its type.
+	ErrNotZeroRequired = validation.NewError("validation_not_zero_required", "must not be zero")
+	// ErrTrueRequired reports that the value must be true.
+	ErrTrueRequired = validation.NewError("validation_true_required", "must be true")
+	// ErrFalseRequired reports that the value must be false.
+	ErrFalseRequired = validation.NewError("validation_false_required", "must be false")
+	// ErrEmptyRequired reports that the value must be empty.
+	ErrEmptyRequired = validation.NewError("validation_empty_required", "must be empty")
+	// ErrNotEmptyRequired reports that the value must not be empty.
+	ErrNotEmptyRequired = validation.NewError("validation_not_empty_required", "must not be empty")
+	// ErrNilRequired reports that the value must be nil.
+	ErrNilRequired = validation.NewError("validation_nil_required", "must be nil")
+	// ErrNotNilRequired reports that the value must not be nil.
+	ErrNotNilRequired = validation.NewError("validation_not_nil_required", "must not be nil")
+)
+
+// IsZero validates that a value is the zero value for its type.
+var IsZero = validation.By(func(value any) error {
+	if !isZeroValue(value) {
+		return ErrZeroRequired
+	}
+	return nil
+})
+
+// IsNotZero validates that a value is not the zero value for its type.
+var IsNotZero = validation.By(func(value any) error {
+	if isZeroValue(value) {
+		return ErrNotZeroRequired
+	}
+	return nil
+})
+
+// IsTrue validates that a value is true.
+var IsTrue = validation.By(func(value any) error {
+	if valueBool, ok := value.(bool); ok && valueBool {
+		return nil
+	}
+	return ErrTrueRequired
+})
+
+// IsFalse validates that a value is false.
+var IsFalse = validation.By(func(value any) error {
+	if valueBool, ok := value.(bool); ok && !valueBool {
+		return nil
+	}
+	return ErrFalseRequired
+})
+
+// IsEmpty validates that a value is empty according to golang-utils empty semantics.
+var IsEmpty = validation.By(func(value any) error {
+	if !isEmptyValue(value) {
+		return ErrEmptyRequired
+	}
+	return nil
+})
+
+// IsNotEmpty validates that a value is not empty according to golang-utils empty semantics.
+var IsNotEmpty = validation.By(func(value any) error {
+	if isEmptyValue(value) {
+		return ErrNotEmptyRequired
+	}
+	return nil
+})
+
+// NotEmpty validates that a value is not empty according to the repository's
+// reflection-based emptiness semantics.
+//
+// Example: `NotEmpty()` rejects `"   "`.
+func NotEmpty() validation.Rule {
+	return IsNotEmpty
+}
+
+// IsNil validates that a value is nil.
+var IsNil = validation.Nil.ErrorObject(ErrNilRequired)
+
+// IsNotNil validates that a value is not nil.
+var IsNotNil = validation.NotNil.ErrorObject(ErrNotNilRequired)
+
+// IsNotNilAndNotEmpty validates that a value is both non-nil and non-empty.
+var IsNotNilAndNotEmpty = validation.By(func(value any) error {
+	if err := IsNotNil.Validate(value); err != nil {
+		return err
+	}
+	v, isNil := validation.Indirect(value)
+	if isNil || isEmptyValue(v) {
+		return ErrNotEmptyRequired
+	}
+	return nil
+})
+
+// IsNilOrNotEmpty validates that a value is either nil or not empty.
+var IsNilOrNotEmpty = validation.By(func(value any) error {
+	if isNilValue(value) {
+		return nil
+	}
+	if isEmptyValue(value) {
+		return validation.ErrNilOrNotEmpty
+	}
+	return nil
+})
+
+func isNilValue(value any) bool {
+	_, isNil := validation.Indirect(value)
+	return isNil
+}
+
+func isEmptyValue(value any) bool {
+	return valueutils.IsEmpty(value)
+}
+
+func isNotEmptyValue(value any) bool {
+	return !isEmptyValue(value)
+}
+
+// IsRequiredLegacy preserves the pre-v4.4 ozzo Required semantics where zero-valued
+// structs other than time.Time{} are still considered present.
+var IsRequiredLegacy = validation.By(func(value any) error {
+	value, isNil := validation.Indirect(value)
+	if isNil || isEmptyLegacy(value) {
+		return validation.ErrRequired
+	}
+	return nil
+})
+
+// IsRequired preserves the legacy struct-friendly required semantics for callers
+// that still expect the pre-v4.4 ozzo behaviour.
+var IsRequired = IsRequiredLegacy
+
+func isZeroValue(value any) bool {
+	rv := reflect.ValueOf(value)
+	if !rv.IsValid() {
+		return true
+	}
+	if rv.Kind() == reflect.Pointer || rv.Kind() == reflect.Interface {
+		if rv.IsNil() {
+			return true
+		}
+		return isZeroValue(rv.Elem().Interface())
+	}
+	return rv.IsZero()
+}
+
+func isEmptyLegacy(value any) bool {
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.String, reflect.Array, reflect.Map, reflect.Slice:
+		return rv.Len() == 0
+	case reflect.Bool:
+		return !rv.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return rv.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return rv.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return rv.Float() == 0
+	case reflect.Invalid:
+		return true
+	case reflect.Interface, reflect.Pointer:
+		if rv.IsNil() {
+			return true
+		}
+		return isEmptyLegacy(rv.Elem().Interface())
+	case reflect.Struct:
+		if t, ok := value.(time.Time); ok && t.IsZero() {
+			return true
+		}
+	}
+	return false
+}

--- a/utils/validation/state_rules.go
+++ b/utils/validation/state_rules.go
@@ -90,6 +90,53 @@ var IsNil = validation.Nil.ErrorObject(ErrNilRequired)
 // IsNotNil validates that a value is not nil.
 var IsNotNil = validation.NotNil.ErrorObject(ErrNotNilRequired)
 
+// Required validates that a value is present for state-style configuration use.
+//
+// Unlike ozzo's `validation.Required`, this rule treats zero-valued structs,
+// `false`, and numeric zero values as present. It rejects nil values, empty
+// strings, and zero `time.Time{}` values.
+//
+// This better aligns runtime value validation with the intent behind JSON Schema
+// and OpenAPI `required`, where a field may be required even though its valid
+// value can legitimately be `false`, `0`, or another zero value. In Go, once a
+// property has been decoded into a struct field, this rule can be used to
+// enforce that required-ness without incorrectly rejecting those valid zero
+// values.
+//
+// It should be noted that JSON Schema and OpenAPI `required` remain
+// property-level concepts describing
+// whether an object must define a named property, rather than whether an
+// already-selected Go value should count as present.
+//
+// References:
+//   - JSON Schema object required properties:
+//     https://json-schema.org/understanding-json-schema/reference/object#required-properties
+//   - OpenAPI Schema Object required:
+//     https://spec.openapis.org/oas/latest.html#schema-object
+var Required = validation.By(validateRequiredValue)
+
+func validateRequiredValue(value any) error {
+	// Nil pointers, nil maps, and nil slices are all considered missing here.
+	if isNilValue(value) {
+		return validation.ErrRequired
+	}
+	v, isNil := validation.Indirect(value)
+	if isNil {
+		return validation.ErrRequired
+	}
+	// Zero time values are treated as missing even though other zero-valued structs
+	// are accepted as present.
+	if t, ok := v.(time.Time); ok && t.IsZero() {
+		return validation.ErrRequired
+	}
+	// Empty strings remain missing, but other zero values such as false, 0, and
+	// empty non-nil maps/slices are accepted as present.
+	if str, ok := v.(string); ok && isEmptyValue(str) {
+		return validation.ErrRequired
+	}
+	return nil
+}
+
 // IsNotNilAndNotEmpty validates that a value is both non-nil and non-empty.
 var IsNotNilAndNotEmpty = validation.By(func(value any) error {
 	if err := IsNotNil.Validate(value); err != nil {

--- a/utils/validation/state_rules_test.go
+++ b/utils/validation/state_rules_test.go
@@ -1,0 +1,134 @@
+package validation
+
+import (
+	"testing"
+	"time"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
+)
+
+func TestStateRules(t *testing.T) {
+	type zeroStruct struct {
+		Enabled bool
+	}
+
+	nonZeroStruct := zeroStruct{Enabled: true}
+	zeroTime := time.Time{}
+	nonZeroTime := time.Now().UTC()
+
+	t.Run("IsZero", func(t *testing.T) {
+		require.NoError(t, validation.Validate(0, IsZero))
+		require.NoError(t, validation.Validate(false, IsZero))
+		require.NoError(t, validation.Validate(zeroStruct{}, IsZero))
+		require.NoError(t, validation.Validate(zeroTime, IsZero))
+		errortest.AssertErrorDescription(t, validation.Validate(1, IsZero), ErrZeroRequired.Error())
+		errortest.AssertErrorDescription(t, validation.Validate(nonZeroStruct, IsZero), ErrZeroRequired.Error())
+	})
+
+	t.Run("IsNotZero", func(t *testing.T) {
+		require.NoError(t, validation.Validate(1, IsNotZero))
+		require.NoError(t, validation.Validate(nonZeroStruct, IsNotZero))
+		errortest.AssertErrorDescription(t, validation.Validate(0, IsNotZero), ErrNotZeroRequired.Error())
+		errortest.AssertErrorDescription(t, validation.Validate(zeroStruct{}, IsNotZero), ErrNotZeroRequired.Error())
+	})
+
+	t.Run("IsTrue and IsFalse", func(t *testing.T) {
+		require.NoError(t, validation.Validate(true, IsTrue))
+		require.NoError(t, validation.Validate(false, IsFalse))
+		errortest.AssertErrorDescription(t, validation.Validate(false, IsTrue), ErrTrueRequired.Error())
+		errortest.AssertErrorDescription(t, validation.Validate(true, IsFalse), ErrFalseRequired.Error())
+		errortest.AssertErrorDescription(t, validation.Validate("true", IsTrue), ErrTrueRequired.Error())
+	})
+
+	t.Run("IsEmpty and IsNotEmpty", func(t *testing.T) {
+		require.NoError(t, validation.Validate("   ", IsEmpty))
+		require.NoError(t, validation.Validate(false, IsEmpty))
+		require.NoError(t, validation.Validate(zeroStruct{}, IsEmpty))
+		errortest.AssertErrorDescription(t, validation.Validate("value", IsEmpty), ErrEmptyRequired.Error())
+
+		require.NoError(t, validation.Validate("value", IsNotEmpty))
+		require.NoError(t, validation.Validate(nonZeroStruct, IsNotEmpty))
+		errortest.AssertErrorDescription(t, validation.Validate("", IsNotEmpty), ErrNotEmptyRequired.Error())
+		errortest.AssertErrorDescription(t, validation.Validate(zeroStruct{}, IsNotEmpty), ErrNotEmptyRequired.Error())
+	})
+
+	t.Run("IsNil and IsNotNil", func(t *testing.T) {
+		var nilString *string
+		nonNilString := "value"
+		require.NoError(t, validation.Validate(nil, IsNil))
+		require.NoError(t, validation.Validate(nilString, IsNil))
+		errortest.AssertErrorDescription(t, validation.Validate(nonNilString, IsNil), ErrNilRequired.Error())
+
+		require.NoError(t, validation.Validate(nonNilString, IsNotNil))
+		require.NoError(t, validation.Validate(&nonNilString, IsNotNil))
+		errortest.AssertErrorDescription(t, validation.Validate(nil, IsNotNil), ErrNotNilRequired.Error())
+		errortest.AssertErrorDescription(t, validation.Validate(nilString, IsNotNil), ErrNotNilRequired.Error())
+	})
+
+	t.Run("IsNotNilAndNotEmpty", func(t *testing.T) {
+		var nilString *string
+		emptyString := ""
+		nonNilString := "value"
+		require.NoError(t, validation.Validate(nonNilString, IsNotNilAndNotEmpty))
+		require.NoError(t, validation.Validate(&nonNilString, IsNotNilAndNotEmpty))
+		errortest.AssertErrorDescription(t, validation.Validate(nil, IsNotNilAndNotEmpty), ErrNotNilRequired.Error())
+		errortest.AssertErrorDescription(t, validation.Validate(nilString, IsNotNilAndNotEmpty), ErrNotNilRequired.Error())
+		errortest.AssertErrorDescription(t, validation.Validate(emptyString, IsNotNilAndNotEmpty), ErrNotEmptyRequired.Error())
+		errortest.AssertErrorDescription(t, validation.Validate(zeroStruct{}, IsNotNilAndNotEmpty), ErrNotEmptyRequired.Error())
+	})
+
+	t.Run("IsNilOrNotEmpty", func(t *testing.T) {
+		var nilString *string
+		nonNilString := "value"
+		require.NoError(t, validation.Validate(nil, IsNilOrNotEmpty))
+		require.NoError(t, validation.Validate(nilString, IsNilOrNotEmpty))
+		require.NoError(t, validation.Validate(nonNilString, IsNilOrNotEmpty))
+		errortest.AssertErrorDescription(t, validation.Validate("", IsNilOrNotEmpty), validation.ErrNilOrNotEmpty.Error())
+		errortest.AssertErrorDescription(t, validation.Validate("   ", IsNilOrNotEmpty), validation.ErrNilOrNotEmpty.Error())
+	})
+
+	t.Run("IsRequiredLegacy preserves legacy ozzo struct semantics", func(t *testing.T) {
+		errortest.AssertErrorDescription(t, validation.Validate(false, IsRequiredLegacy), validation.ErrRequired.Error())
+		errortest.AssertErrorDescription(t, validation.Validate("", IsRequiredLegacy), validation.ErrRequired.Error())
+		errortest.AssertErrorDescription(t, validation.Validate(zeroTime, IsRequiredLegacy), validation.ErrRequired.Error())
+
+		require.NoError(t, validation.Validate(zeroStruct{}, IsRequiredLegacy))
+		require.NoError(t, validation.Validate(nonZeroStruct, IsRequiredLegacy))
+		require.NoError(t, validation.Validate(nonZeroTime, IsRequiredLegacy))
+	})
+
+	t.Run("IsRequired aliases IsRequiredLegacy", func(t *testing.T) {
+		require.NoError(t, validation.Validate(zeroStruct{}, IsRequired))
+		errortest.AssertErrorDescription(t, validation.Validate(false, IsRequired), validation.ErrRequired.Error())
+	})
+
+	t.Run("ozzo required semantics on zero-valued structs stay pinned", func(t *testing.T) {
+		type boolStruct struct {
+			Enabled bool
+			Ready   bool
+		}
+		type nestedStruct struct {
+			Flags boolStruct
+		}
+
+		zeroBools := boolStruct{}
+		zeroNested := nestedStruct{}
+
+		// Pin ozzo's current behaviour so future upgrades make any semantic drift
+		// explicit in tests before it changes repository validation expectations.
+		require.NoError(t, validation.Validate(zeroBools, validation.Required))
+		require.NoError(t, validation.Validate(zeroNested, validation.Required))
+		errortest.AssertErrorDescription(t, validation.Validate(time.Time{}, validation.Required), validation.ErrRequired.Error())
+
+		// Our legacy-compatible helper keeps zero-valued structs present even when
+		// all their fields are zero values, such as booleans set to false.
+		require.NoError(t, validation.Validate(zeroBools, IsRequiredLegacy))
+		require.NoError(t, validation.Validate(zeroNested, IsRequiredLegacy))
+		require.NoError(t, validation.Validate(zeroBools, IsRequired))
+		require.NoError(t, validation.Validate(zeroNested, IsRequired))
+	})
+
+}

--- a/utils/validation/state_rules_test.go
+++ b/utils/validation/state_rules_test.go
@@ -68,6 +68,37 @@ func TestStateRules(t *testing.T) {
 		errortest.AssertErrorDescription(t, validation.Validate(nilString, IsNotNil), ErrNotNilRequired.Error())
 	})
 
+	t.Run("Required", func(t *testing.T) {
+		var nilString *string
+		var nilSlice []string
+		var nilMap map[string]string
+		emptyString := ""
+		spaceString := "   "
+		spaceStringPtr := &spaceString
+		zeroTime := time.Time{}
+		zeroTimePtr := &zeroTime
+		zeroInt := 0
+		falseBool := false
+		emptySlice := []string{}
+		emptyMap := map[string]string{}
+
+		errortest.AssertErrorDescription(t, validation.Validate(nil, Required), validation.ErrRequired.Error())
+		errortest.AssertErrorDescription(t, validation.Validate(nilString, Required), validation.ErrRequired.Error())
+		errortest.AssertErrorDescription(t, validation.Validate(nilSlice, Required), validation.ErrRequired.Error())
+		errortest.AssertErrorDescription(t, validation.Validate(nilMap, Required), validation.ErrRequired.Error())
+		errortest.AssertErrorDescription(t, validation.Validate(emptyString, Required), validation.ErrRequired.Error())
+		errortest.AssertErrorDescription(t, validation.Validate(spaceString, Required), validation.ErrRequired.Error())
+		errortest.AssertErrorDescription(t, validation.Validate(spaceStringPtr, Required), validation.ErrRequired.Error())
+		errortest.AssertErrorDescription(t, validation.Validate(zeroTime, Required), validation.ErrRequired.Error())
+		errortest.AssertErrorDescription(t, validation.Validate(zeroTimePtr, Required), validation.ErrRequired.Error())
+
+		require.NoError(t, validation.Validate(zeroInt, Required))
+		require.NoError(t, validation.Validate(falseBool, Required))
+		require.NoError(t, validation.Validate(zeroStruct{}, Required))
+		require.NoError(t, validation.Validate(emptySlice, Required))
+		require.NoError(t, validation.Validate(emptyMap, Required))
+	})
+
 	t.Run("IsNotNilAndNotEmpty", func(t *testing.T) {
 		var nilString *string
 		emptyString := ""

--- a/utils/validation/time_rules.go
+++ b/utils/validation/time_rules.go
@@ -198,8 +198,7 @@ var IsDuration = validation.By(func(value any) error {
 // NilTimestampOrNotEmpty validates that a timestamp value is either nil or a
 // non-zero valid timestamp.
 var NilTimestampOrNotEmpty = validation.By(func(value any) error {
-	_, isNil := validation.Indirect(value)
-	if isNil {
+	if isNilValue(value) {
 		return nil
 	}
 	return timestampNotEmptyRule.Validate(value)

--- a/utils/validation/utils.go
+++ b/utils/validation/utils.go
@@ -502,7 +502,7 @@ func objectSequence2ToAccessor(value any) (*objectAccessor, bool, bool, error) {
 		},
 		presentNonEmpty: func(key string) bool {
 			value, found := items[key]
-			return found && !utilreflection.IsEmpty(value)
+			return found && isNotEmptyValue(value)
 		},
 	}, true, false, nil
 }
@@ -528,7 +528,7 @@ func objectProperties(value any) (props *objectAccessor, isNil bool, err error) 
 		},
 		presentNonEmpty: func(key string) bool {
 			value, found := objectPropertyValue(rv, key)
-			return found && !utilreflection.IsEmpty(value)
+			return found && isNotEmptyValue(value)
 		},
 	}, false, nil
 }
@@ -757,8 +757,7 @@ func countPresentResolvedFields(props *objectAccessor, names []string) int {
 		return 0
 	}
 	return collection.CountBy(names, func(name string) bool {
-		actual, found := props.value(name)
-		return found && utilreflection.IsNotEmpty(actual)
+		return props.presentNonEmpty(name)
 	})
 }
 

--- a/utils/validation/utils.go
+++ b/utils/validation/utils.go
@@ -677,6 +677,136 @@ func propertyNamesForValue(value any, keys ...any) (result []string, err error) 
 	return collection.UniqueEntries(result), nil
 }
 
+func hasFieldReferenceSpecifier(keys ...any) bool {
+	return collection.AnyFunc(keys, func(key any) bool {
+		switch typed := key.(type) {
+		case string, []string:
+			return false
+		case []any:
+			return hasFieldReferenceSpecifier(typed...)
+		default:
+			return true
+		}
+	})
+}
+
+func valueImplementsValidate(value any) bool {
+	type validatable interface{ Validate() error }
+	if value == nil {
+		return false
+	}
+	_, ok := value.(validatable)
+	return ok
+}
+
+func rejectPropertyStyleFieldReferencesOnValidatable(value any, helperName string, replacement string, specifiers ...any) error {
+	if !hasFieldReferenceSpecifier(specifiers...) || !valueImplementsValidate(value) {
+		return nil
+	}
+	return commonerrors.Newf(commonerrors.ErrInvalid, "%s is property-oriented and should not be used with field references on a struct that implements Validate(); use %s instead", helperName, replacement)
+}
+
+func dependencySpecifiers(dependencies map[any]any) []any {
+	result := make([]any, 0, len(dependencies)*2)
+	for key, values := range dependencies {
+		result = append(result, key)
+		result = append(result, values)
+	}
+	return result
+}
+
+type propertyRuleEvaluator func(replayableValue any, names []string) error
+
+func propertyRuleBy(value any, helperName string, replacement string, specifiers []any, evaluator propertyRuleEvaluator) error {
+	replayableValue, err := replayableValidationValue(value)
+	if err != nil {
+		return err
+	}
+	if replacement != "" {
+		if err := rejectPropertyStyleFieldReferencesOnValidatable(replayableValue, helperName, replacement, specifiers...); err != nil {
+			return err
+		}
+	}
+	normalisedKeys, err := propertyNamesForValue(replayableValue, specifiers...)
+	if err != nil {
+		return err
+	}
+	return evaluator(replayableValue, normalisedKeys)
+}
+
+type fieldValueRuleEvaluator func(props *objectAccessor, names []string) error
+
+func fieldValueRuleBy(value any, fields []any, evaluator fieldValueRuleEvaluator) error {
+	replayableValue, err := replayableValidationValue(value)
+	if err != nil {
+		return err
+	}
+	props, isNil, err := objectProperties(replayableValue)
+	if err != nil || isNil {
+		return err
+	}
+	normalisedFields, err := propertyNamesForValue(replayableValue, fields...)
+	if err != nil {
+		return err
+	}
+	return evaluator(props, normalisedFields)
+}
+
+func countPresentResolvedFields(props *objectAccessor, names []string) int {
+	if props == nil {
+		return 0
+	}
+	return collection.CountBy(names, func(name string) bool {
+		actual, found := props.value(name)
+		return found && utilreflection.IsNotEmpty(actual)
+	})
+}
+
+func requireResolvedFields(props *objectAccessor, names []string) error {
+	if props == nil {
+		return nil
+	}
+	validationErrors := collection.Reduce(names, validation.Errors{}, func(acc validation.Errors, name string) validation.Errors {
+		actual, found := props.value(name)
+		if !found {
+			acc[name] = validation.ErrRequired
+			return acc
+		}
+		if err := validation.Required.Validate(actual); err != nil {
+			acc[name] = err
+		}
+		return acc
+	})
+	if len(validationErrors) > 0 {
+		return validationErrors
+	}
+	return nil
+}
+
+func forbidResolvedFields(props *objectAccessor, names []string) error {
+	if countPresentResolvedFields(props, names) > 0 {
+		return errAdditionalProperties
+	}
+	return nil
+}
+
+func checkResolvedFieldCardinality(props *objectAccessor, names []string, minCount int, maxCount int) error {
+	count := countPresentResolvedFields(props, names)
+	if minCount >= 0 && count < minCount {
+		if minCount == 1 {
+			return errRequiredProperties
+		}
+		return errMutuallyExclusive
+	}
+	if maxCount >= 0 && count > maxCount {
+		return errMutuallyExclusive
+	}
+	if minCount == 1 && maxCount == 1 && count != 1 {
+		return errMutuallyExclusive
+	}
+	return nil
+}
+
 func propertyNamesForSpecifier(value any, key any) ([]string, error) {
 	if name, ok := key.(string); ok {
 		return []string{name}, nil

--- a/utils/validation/utils.go
+++ b/utils/validation/utils.go
@@ -771,7 +771,7 @@ func requireResolvedFields(props *objectAccessor, names []string) error {
 			acc[name] = validation.ErrRequired
 			return acc
 		}
-		if err := validation.Required.Validate(actual); err != nil {
+		if err := validateRequiredValue(actual); err != nil {
 			acc[name] = err
 		}
 		return acc

--- a/utils/validation/when_rules.go
+++ b/utils/validation/when_rules.go
@@ -232,8 +232,8 @@ func WhenFieldEqualsValue(field any, expected any, rules ...validation.Rule) val
 //
 // Example:
 //
-// 	cfg := &Config{}
-// 	err := validation.Validate(cfg, WhenFieldNotEqualsValue(&cfg.Mode, "strict", RequiredFieldsBy(&cfg.Profile)))
+//	cfg := &Config{}
+//	err := validation.Validate(cfg, WhenFieldNotEqualsValue(&cfg.Mode, "strict", RequiredFieldsBy(&cfg.Profile)))
 //
 // This requires `cfg.Profile` whenever `cfg.Mode != "strict"`.
 func WhenFieldNotEqualsValue(field any, expected any, rules ...validation.Rule) validation.Rule {
@@ -252,8 +252,8 @@ func WhenFieldNotEquals(field any, expected any, rules ...validation.Rule) valid
 //
 // Example:
 //
-// 	cfg := &Config{}
-// 	err := validation.Validate(cfg, WhenFieldInValues(&cfg.Mode, []any{"strict", "relaxed"}, RequiredFieldsBy(&cfg.Profile)))
+//	cfg := &Config{}
+//	err := validation.Validate(cfg, WhenFieldInValues(&cfg.Mode, []any{"strict", "relaxed"}, RequiredFieldsBy(&cfg.Profile)))
 //
 // This requires `cfg.Profile` whenever `cfg.Mode` is either `strict` or
 // `relaxed`.
@@ -275,8 +275,8 @@ func WhenFieldInValues(field any, expected []any, rules ...validation.Rule) vali
 //
 // Example:
 //
-// 	cfg := &Config{}
-// 	err := validation.Validate(cfg, WhenFieldNotInValues(&cfg.Mode, []any{"strict", "relaxed"}, RequiredFieldsBy(&cfg.FallbackProfile)))
+//	cfg := &Config{}
+//	err := validation.Validate(cfg, WhenFieldNotInValues(&cfg.Mode, []any{"strict", "relaxed"}, RequiredFieldsBy(&cfg.FallbackProfile)))
 //
 // This requires `cfg.FallbackProfile` whenever `cfg.Mode` is neither `strict`
 // nor `relaxed`.

--- a/utils/validation/when_rules.go
+++ b/utils/validation/when_rules.go
@@ -301,8 +301,8 @@ func WhenFieldNotInValues(field any, expected []any, rules ...validation.Rule) v
 //
 // Example:
 //
-// 	cfg := &Config{}
-// 	err := validation.Validate(cfg, WhenFieldAbsent(&cfg.Token, RequiredFieldsBy(&cfg.Username)))
+//	cfg := &Config{}
+//	err := validation.Validate(cfg, WhenFieldAbsent(&cfg.Token, RequiredFieldsBy(&cfg.Username)))
 //
 // This requires `cfg.Username` whenever `cfg.Token` is empty.
 func WhenFieldAbsent(field any, rules ...validation.Rule) validation.Rule {
@@ -318,8 +318,8 @@ func WhenFieldAbsent(field any, rules ...validation.Rule) validation.Rule {
 //
 // Example:
 //
-// 	cfg := &Config{}
-// 	err := validation.Validate(cfg, WhenFieldPresent(&cfg.Token, ForbiddenFieldsBy(&cfg.Username)))
+//	cfg := &Config{}
+//	err := validation.Validate(cfg, WhenFieldPresent(&cfg.Token, ForbiddenFieldsBy(&cfg.Username)))
 //
 // This rejects `cfg.Username` whenever `cfg.Token` is non-empty.
 func WhenFieldPresent(field any, rules ...validation.Rule) validation.Rule {

--- a/utils/validation/when_rules.go
+++ b/utils/validation/when_rules.go
@@ -10,28 +10,26 @@ import (
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 
 	"github.com/ARM-software/golang-utils/utils/collection"
+	utilreflection "github.com/ARM-software/golang-utils/utils/reflection"
 )
 
-// WhenPropertyEquals applies rules when the value stored under key equals expected.
-//
-// Equality is evaluated with `reflect.DeepEqual`.
-//
-// Example: `WhenPropertyEquals("mode", "strict", RequiredProperties("name"))`
-// validates `RequiredProperties("name")` only when `mode == "strict"`.
-func WhenPropertyEquals(key string, expected any, rules ...validation.Rule) validation.Rule {
-	return WhenPropertyMatches(key, expected, func(left, right any) (bool, error) {
-		return reflect.DeepEqual(left, right), nil
-	}, rules...)
-}
+type propertyConditionFunc func(actual any, found bool) (bool, error)
 
-// WhenPropertyMatches applies rules when the value stored under key matches expected.
-//
-// The comparison is delegated to match so callers can define case-insensitive or
-// other domain-specific matching behaviour.
-func WhenPropertyMatches[T any](key string, expected T, match collection.MatchFunc[T], rules ...validation.Rule) validation.Rule {
-	filteredRules := collection.Filter(rules, func(rule validation.Rule) bool {
+func filteredWhenRules(rules []validation.Rule) []validation.Rule {
+	return collection.Filter(rules, func(rule validation.Rule) bool {
 		return rule != nil
 	})
+}
+
+func evaluateConditionalRules(value any, matched bool, rules []validation.Rule) error {
+	if !matched || len(rules) == 0 {
+		return nil
+	}
+	return NewAllRule(rules...).Validate(value)
+}
+
+func whenProperty(key string, condition propertyConditionFunc, rules ...validation.Rule) validation.Rule {
+	filteredRules := filteredWhenRules(rules)
 	return validation.By(func(value any) error {
 		replayableValue, err := replayableValidationValue(value)
 		if err != nil {
@@ -42,19 +40,153 @@ func WhenPropertyMatches[T any](key string, expected T, match collection.MatchFu
 			return err
 		}
 		actual, found := props.value(key)
-		if !found {
-			return nil
-		}
-		cast, ok := actual.(T)
-		if !ok {
-			return nil
-		}
-		condition, err := match(cast, expected)
+		matched, err := condition(actual, found)
 		if err != nil {
 			return err
 		}
-		return validation.When(condition, filteredRules...).Validate(replayableValue)
+		return evaluateConditionalRules(replayableValue, matched, filteredRules)
 	})
+}
+
+func whenField(field any, propertyRule func(fieldName string) validation.Rule) validation.Rule {
+	return validation.By(func(value any) error {
+		replayableValue, err := replayableValidationValue(value)
+		if err != nil {
+			return err
+		}
+		fieldName, err := propertyNameForValue(replayableValue, field)
+		if err != nil {
+			return err
+		}
+		return propertyRule(fieldName).Validate(replayableValue)
+	})
+}
+
+// WhenPropertyEquals applies rules when the value stored under key equals expected.
+//
+// Equality is evaluated with `reflect.DeepEqual`.
+//
+// This helper is primarily intended for property-oriented validation of maps or
+// decoded object content where conditions are expressed in terms of named
+// properties. For struct-oriented cross-field validation, prefer
+// [WhenFieldEqualsValue].
+//
+// If the structure in question has its own `Validate()` method, prefer the
+// field-oriented helpers for nested composition. They are designed to avoid the
+// recursive re-entry pitfalls that older conditional-validation patterns can
+// trigger.
+//
+// Example: `WhenPropertyEquals("mode", "strict", RequiredProperties("name"))`
+// validates `RequiredProperties("name")` only when `mode == "strict"`.
+func WhenPropertyEquals(key string, expected any, rules ...validation.Rule) validation.Rule {
+	return WhenPropertyMatches(key, expected, func(left, right any) (bool, error) {
+		return reflect.DeepEqual(left, right), nil
+	}, rules...)
+}
+
+// WhenPropertyNotEquals applies rules when the value stored under key does not equal expected.
+//
+// Equality is evaluated with `reflect.DeepEqual`.
+//
+// This helper is primarily intended for property-oriented validation of maps or
+// decoded object content. For struct-oriented cross-field validation, prefer
+// [WhenFieldNotEqualsValue].
+//
+// If the structure in question has its own `Validate()` method, prefer the
+// field-oriented helpers for nested composition. They are designed to avoid the
+// recursive re-entry pitfalls that older conditional-validation patterns can
+// trigger.
+//
+// Example: `WhenPropertyNotEquals("mode", "strict", ForbiddenProperties("name"))`
+// rejects a payload that defines `name` unless `mode == "strict"`.
+func WhenPropertyNotEquals(key string, expected any, rules ...validation.Rule) validation.Rule {
+	return WhenPropertyMatches(key, expected, func(left, right any) (bool, error) {
+		return !reflect.DeepEqual(left, right), nil
+	}, rules...)
+}
+
+// WhenPropertyAbsent applies rules when the value stored under key is absent.
+//
+// A property is considered absent when it is missing or when its value is empty
+// according to `reflection.IsEmpty`.
+//
+// This helper is primarily intended for property-oriented validation of maps or
+// decoded object content. For struct-oriented cross-field validation, prefer
+// [WhenFieldAbsent].
+//
+// If the structure in question has its own `Validate()` method, prefer the
+// field-oriented helpers for nested composition. They are designed to avoid the
+// recursive re-entry pitfalls that older conditional-validation patterns can
+// trigger.
+//
+// Example: `WhenPropertyAbsent("token", RequiredProperties("username"))`
+// requires `username` whenever `token` is missing or empty.
+func WhenPropertyAbsent(key string, rules ...validation.Rule) validation.Rule {
+	return whenProperty(key, func(actual any, found bool) (bool, error) {
+		return !found || utilreflection.IsEmpty(actual), nil
+	}, rules...)
+}
+
+// WhenPropertyPresent applies rules when the value stored under key is present.
+//
+// A property is considered present when it exists and its value is not empty
+// according to `reflection.IsNotEmpty`.
+//
+// This helper is primarily intended for property-oriented validation of maps or
+// decoded object content. For struct-oriented cross-field validation, prefer
+// [WhenFieldPresent].
+//
+// If the structure in question has its own `Validate()` method, prefer the
+// field-oriented helpers for nested composition. They are designed to avoid the
+// recursive re-entry pitfalls that older conditional-validation patterns can
+// trigger.
+//
+// Example: `WhenPropertyPresent("token", ForbiddenProperties("username"))`
+// rejects a payload that defines `username` whenever `token` is already set.
+func WhenPropertyPresent(key string, rules ...validation.Rule) validation.Rule {
+	return whenProperty(key, func(actual any, found bool) (bool, error) {
+		return found && utilreflection.IsNotEmpty(actual), nil
+	}, rules...)
+}
+
+// WhenPropertyEmpty applies rules when the value stored under key is empty.
+//
+// Deprecated: prefer [WhenPropertyAbsent] for schema-style presence checks.
+func WhenPropertyEmpty(key string, rules ...validation.Rule) validation.Rule {
+	return WhenPropertyAbsent(key, rules...)
+}
+
+// WhenPropertyNotEmpty applies rules when the value stored under key is not empty.
+//
+// Deprecated: prefer [WhenPropertyPresent] for schema-style presence checks.
+func WhenPropertyNotEmpty(key string, rules ...validation.Rule) validation.Rule {
+	return WhenPropertyPresent(key, rules...)
+}
+
+// WhenPropertyMatches applies rules when the value stored under key matches expected.
+//
+// The comparison is delegated to match so callers can define case-insensitive or
+// other domain-specific matching behaviour.
+//
+// This helper is primarily intended for property-oriented validation of maps or
+// decoded object content. For struct-oriented cross-field validation, prefer the
+// corresponding `WhenField...` helpers.
+//
+// If the structure in question has its own `Validate()` method, prefer the
+// field-oriented helpers for nested composition. They are designed to avoid the
+// recursive re-entry pitfalls that older conditional-validation patterns can
+// trigger.
+func WhenPropertyMatches[T any](key string, expected T, match collection.MatchFunc[T], rules ...validation.Rule) validation.Rule {
+	return whenProperty(key, func(actual any, found bool) (bool, error) {
+		if !found {
+			return false, nil
+		}
+		cast, ok := actual.(T)
+		if !ok {
+			return false, nil
+		}
+		return match(cast, expected)
+	}, rules...)
 }
 
 // WhenFieldEquals applies rules when the resolved field value equals expected.
@@ -69,20 +201,150 @@ func WhenFieldEquals(field any, expected any, rules ...validation.Rule) validati
 	}, rules...)
 }
 
+// WhenFieldEqualsValue applies rules when the resolved field value equals expected.
+//
+// It is the preferred value-oriented entrypoint for composing cross-field rules
+// such as `RequiredFieldsBy(...)` against a containing struct.
+//
+// The current implementation is equivalent to [WhenFieldEquals], but this name
+// makes the intended usage clearer when the nested rules validate field values
+// rather than mere property presence.
+//
+// Unlike older patterns that rely on `validation.When(...).Validate(value)`, the
+// `WhenField...` helper family now executes nested rules directly against the
+// containing object so it can be used safely from a struct's own `Validate()`
+// implementation without recursive re-entry into that method.
+//
+// Example:
+//
+//	cfg := &Config{}
+//	err := validation.Validate(cfg, NewAllRule(
+//		WhenFieldEqualsValue(&cfg.Mode, "strict", RequiredFieldsBy(&cfg.Name)),
+//		WhenFieldPresent(&cfg.Name, RequiredFieldsBy(&cfg.Mode)),
+//	))
+func WhenFieldEqualsValue(field any, expected any, rules ...validation.Rule) validation.Rule {
+	return WhenFieldEquals(field, expected, rules...)
+}
+
+// WhenFieldNotEqualsValue applies rules when the resolved field value does not equal expected.
+//
+// It is the value-oriented counterpart to [WhenFieldNotEquals].
+//
+// Example:
+//
+// 	cfg := &Config{}
+// 	err := validation.Validate(cfg, WhenFieldNotEqualsValue(&cfg.Mode, "strict", RequiredFieldsBy(&cfg.Profile)))
+//
+// This requires `cfg.Profile` whenever `cfg.Mode != "strict"`.
+func WhenFieldNotEqualsValue(field any, expected any, rules ...validation.Rule) validation.Rule {
+	return WhenFieldNotEquals(field, expected, rules...)
+}
+
+// WhenFieldNotEquals applies rules when the resolved field value does not equal expected.
+func WhenFieldNotEquals(field any, expected any, rules ...validation.Rule) validation.Rule {
+	return WhenFieldMatches(field, expected, func(left, right any) (bool, error) {
+		return !reflect.DeepEqual(left, right), nil
+	}, rules...)
+}
+
+// WhenFieldInValues applies rules when the resolved field value equals any of
+// the supplied expected values.
+//
+// Example:
+//
+// 	cfg := &Config{}
+// 	err := validation.Validate(cfg, WhenFieldInValues(&cfg.Mode, []any{"strict", "relaxed"}, RequiredFieldsBy(&cfg.Profile)))
+//
+// This requires `cfg.Profile` whenever `cfg.Mode` is either `strict` or
+// `relaxed`.
+func WhenFieldInValues(field any, expected []any, rules ...validation.Rule) validation.Rule {
+	return whenField(field, func(fieldName string) validation.Rule {
+		return whenProperty(fieldName, func(actual any, found bool) (bool, error) {
+			if !found {
+				return false, nil
+			}
+			return collection.In(expected, actual, func(left any, right any) (bool, error) {
+				return reflect.DeepEqual(left, right), nil
+			}), nil
+		}, rules...)
+	})
+}
+
+// WhenFieldNotInValues applies rules when the resolved field value equals none
+// of the supplied expected values.
+//
+// Example:
+//
+// 	cfg := &Config{}
+// 	err := validation.Validate(cfg, WhenFieldNotInValues(&cfg.Mode, []any{"strict", "relaxed"}, RequiredFieldsBy(&cfg.FallbackProfile)))
+//
+// This requires `cfg.FallbackProfile` whenever `cfg.Mode` is neither `strict`
+// nor `relaxed`.
+func WhenFieldNotInValues(field any, expected []any, rules ...validation.Rule) validation.Rule {
+	return whenField(field, func(fieldName string) validation.Rule {
+		return whenProperty(fieldName, func(actual any, found bool) (bool, error) {
+			if !found {
+				return false, nil
+			}
+			inValues := collection.In(expected, actual, func(left any, right any) (bool, error) {
+				return reflect.DeepEqual(left, right), nil
+			})
+			return !inValues, nil
+		}, rules...)
+	})
+}
+
+// WhenFieldAbsent applies rules when the resolved field value is absent.
+//
+// A field is considered absent when its value is empty according to
+// `reflection.IsEmpty`.
+//
+// Example:
+//
+// 	cfg := &Config{}
+// 	err := validation.Validate(cfg, WhenFieldAbsent(&cfg.Token, RequiredFieldsBy(&cfg.Username)))
+//
+// This requires `cfg.Username` whenever `cfg.Token` is empty.
+func WhenFieldAbsent(field any, rules ...validation.Rule) validation.Rule {
+	return whenField(field, func(fieldName string) validation.Rule {
+		return WhenPropertyAbsent(fieldName, rules...)
+	})
+}
+
+// WhenFieldPresent applies rules when the resolved field value is present.
+//
+// A field is considered present when its value is not empty according to
+// `reflection.IsNotEmpty`.
+//
+// Example:
+//
+// 	cfg := &Config{}
+// 	err := validation.Validate(cfg, WhenFieldPresent(&cfg.Token, ForbiddenFieldsBy(&cfg.Username)))
+//
+// This rejects `cfg.Username` whenever `cfg.Token` is non-empty.
+func WhenFieldPresent(field any, rules ...validation.Rule) validation.Rule {
+	return whenField(field, func(fieldName string) validation.Rule {
+		return WhenPropertyPresent(fieldName, rules...)
+	})
+}
+
+// WhenFieldEmpty applies rules when the resolved field value is empty.
+//
+// Deprecated: prefer [WhenFieldAbsent] for schema-style presence checks.
+func WhenFieldEmpty(field any, rules ...validation.Rule) validation.Rule {
+	return WhenFieldAbsent(field, rules...)
+}
+
+// WhenFieldNotEmpty applies rules when the resolved field value is not empty.
+//
+// Deprecated: prefer [WhenFieldPresent] for schema-style presence checks.
+func WhenFieldNotEmpty(field any, rules ...validation.Rule) validation.Rule {
+	return WhenFieldPresent(field, rules...)
+}
+
 // WhenFieldMatches applies rules when the resolved field value matches expected.
 func WhenFieldMatches[T any](field any, expected T, match collection.MatchFunc[T], rules ...validation.Rule) validation.Rule {
-	filteredRules := collection.Filter(rules, func(rule validation.Rule) bool {
-		return rule != nil
-	})
-	return validation.By(func(value any) error {
-		replayableValue, err := replayableValidationValue(value)
-		if err != nil {
-			return err
-		}
-		fieldName, err := propertyNameForValue(replayableValue, field)
-		if err != nil {
-			return err
-		}
-		return WhenPropertyMatches(fieldName, expected, match, filteredRules...).Validate(replayableValue)
+	return whenField(field, func(fieldName string) validation.Rule {
+		return WhenPropertyMatches(fieldName, expected, match, rules...)
 	})
 }

--- a/utils/validation/when_rules_test.go
+++ b/utils/validation/when_rules_test.go
@@ -178,8 +178,7 @@ func TestWhenRules(t *testing.T) {
 			SummaryFile string
 			validating  bool
 		}
-		var validateConfig func(*config) error
-		validateConfig = func(cfg *config) error {
+		validateConfig := func(cfg *config) error {
 			if cfg.validating {
 				return recursionErr
 			}

--- a/utils/validation/when_rules_test.go
+++ b/utils/validation/when_rules_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ARM-software/golang-utils/utils/collection"
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
 )
 
 func TestWhenRules(t *testing.T) {
@@ -39,6 +41,48 @@ func TestWhenRules(t *testing.T) {
 		assert.NoError(t, validation.Validate(cfg, rule))
 	})
 
+	t.Run("property not equals", func(t *testing.T) {
+		rule := WhenPropertyNotEquals("mode", "strict", RequiredProperties("name"))
+		assert.Error(t, validation.Validate(map[string]any{"mode": "relaxed"}, rule))
+		assert.NoError(t, validation.Validate(map[string]any{"mode": "relaxed", "name": "ok"}, rule))
+		assert.NoError(t, validation.Validate(map[string]any{"mode": "strict"}, rule))
+	})
+
+	t.Run("field not equals", func(t *testing.T) {
+		type config struct {
+			Mode string
+			Name string
+		}
+		cfg := &config{Mode: "relaxed"}
+		rule := WhenFieldNotEquals(&cfg.Mode, "strict", PatternProperties(
+			PatternProperty{Pattern: regexp.MustCompile(`^Name$`), Rule: MinLength(1)},
+		))
+		err := validation.Validate(cfg, rule)
+		require.Error(t, err)
+
+		cfg.Name = "ok"
+		assert.NoError(t, validation.Validate(cfg, rule))
+
+		cfg.Mode = "strict"
+		cfg.Name = ""
+		assert.NoError(t, validation.Validate(cfg, rule))
+	})
+
+	t.Run("field not equals value", func(t *testing.T) {
+		type config struct {
+			Mode string
+			Name string
+		}
+		cfg := &config{Mode: "relaxed"}
+		rule := WhenFieldNotEqualsValue(&cfg.Mode, "strict", PatternProperties(
+			PatternProperty{Pattern: regexp.MustCompile(`^Name$`), Rule: MinLength(1)},
+		))
+		err := validation.Validate(cfg, rule)
+		require.Error(t, err)
+		cfg.Name = "ok"
+		assert.NoError(t, validation.Validate(cfg, rule))
+	})
+
 	t.Run("property matches", func(t *testing.T) {
 		rule := WhenPropertyMatches("mode", "strict", collection.StringCaseInsensitiveMatch, RequiredProperties("name"))
 		assert.Error(t, validation.Validate(map[string]any{"mode": "STRICT"}, rule))
@@ -59,5 +103,109 @@ func TestWhenRules(t *testing.T) {
 
 		cfg.Name = "ok"
 		assert.NoError(t, validation.Validate(cfg, rule))
+	})
+
+	t.Run("property absent and present", func(t *testing.T) {
+		absentRule := WhenPropertyAbsent("name", RequiredProperties("mode"))
+		presentRule := WhenPropertyPresent("name", RequiredProperties("mode"))
+
+		assert.Error(t, validation.Validate(map[string]any{"name": ""}, absentRule))
+		assert.Error(t, validation.Validate(map[string]any{}, absentRule))
+		assert.NoError(t, validation.Validate(map[string]any{"name": "", "mode": "strict"}, absentRule))
+
+		assert.Error(t, validation.Validate(map[string]any{"name": "ok"}, presentRule))
+		assert.NoError(t, validation.Validate(map[string]any{"name": "ok", "mode": "strict"}, presentRule))
+		assert.NoError(t, validation.Validate(map[string]any{}, presentRule))
+	})
+
+	t.Run("field absent and present", func(t *testing.T) {
+		type config struct {
+			Mode string
+			Name string
+		}
+
+		absentCfg := &config{}
+		absentRule := WhenFieldAbsent(&absentCfg.Name, PatternProperties(
+			PatternProperty{Pattern: regexp.MustCompile(`^Mode$`), Rule: MinLength(1)},
+		))
+		err := validation.Validate(absentCfg, absentRule)
+		require.Error(t, err)
+		absentCfg.Mode = "strict"
+		assert.NoError(t, validation.Validate(absentCfg, absentRule))
+
+		presentCfg := &config{Name: "ok"}
+		presentRule := WhenFieldPresent(&presentCfg.Name, PatternProperties(
+			PatternProperty{Pattern: regexp.MustCompile(`^Mode$`), Rule: MinLength(1)},
+		))
+		err = validation.Validate(presentCfg, presentRule)
+		require.Error(t, err)
+		presentCfg.Mode = "strict"
+		assert.NoError(t, validation.Validate(presentCfg, presentRule))
+
+		presentCfg.Name = ""
+		presentCfg.Mode = ""
+		assert.NoError(t, validation.Validate(presentCfg, presentRule))
+	})
+
+	t.Run("field in and not in values", func(t *testing.T) {
+		type config struct {
+			Mode string
+			Name string
+		}
+		cfg := &config{Mode: "strict"}
+		inRule := WhenFieldInValues(&cfg.Mode, []any{"strict", "relaxed"}, PatternProperties(
+			PatternProperty{Pattern: regexp.MustCompile(`^Name$`), Rule: MinLength(1)},
+		))
+		err := validation.Validate(cfg, inRule)
+		require.Error(t, err)
+		cfg.Name = "ok"
+		assert.NoError(t, validation.Validate(cfg, inRule))
+
+		notInCfg := &config{Mode: "archive"}
+		notInRule := WhenFieldNotInValues(&notInCfg.Mode, []any{"strict", "relaxed"}, PatternProperties(
+			PatternProperty{Pattern: regexp.MustCompile(`^Name$`), Rule: MinLength(1)},
+		))
+		err = validation.Validate(notInCfg, notInRule)
+		require.Error(t, err)
+		notInCfg.Name = "ok"
+		assert.NoError(t, validation.Validate(notInCfg, notInRule))
+	})
+
+	t.Run("field equals value and not empty do not recurse inside Validate", func(t *testing.T) {
+		recursionErr := commonerrors.New(commonerrors.ErrUnexpected, "recursive validate call")
+		type config struct {
+			Summary     string
+			SummaryFile string
+			validating  bool
+		}
+		var validateConfig func(*config) error
+		validateConfig = func(cfg *config) error {
+			if cfg.validating {
+				return recursionErr
+			}
+			cfg.validating = true
+			defer func() {
+				cfg.validating = false
+			}()
+			return NewAllRule(
+				WhenFieldEqualsValue(&cfg.Summary, "file", RequiredFieldsBy(&cfg.SummaryFile)),
+				WhenFieldPresent(&cfg.SummaryFile, RequiredFieldsBy(&cfg.Summary)),
+			).Validate(cfg)
+		}
+
+		cfg := &config{Summary: "file"}
+		err := validateConfig(cfg)
+		require.Error(t, err)
+		errortest.AssertErrorDescription(t, err, "SummaryFile")
+		assert.False(t, commonerrors.Any(err, commonerrors.ErrUnexpected))
+
+		cfg.SummaryFile = "summary.md"
+		require.NoError(t, validateConfig(cfg))
+
+		cfg = &config{SummaryFile: "summary.md"}
+		err = validateConfig(cfg)
+		require.Error(t, err)
+		errortest.AssertErrorDescription(t, err, "Summary")
+		assert.False(t, commonerrors.Any(err, commonerrors.ErrUnexpected))
 	})
 }


### PR DESCRIPTION
Add validation helpers to avoid recursive trap when validating a structure (https://github.com/go-ozzo/ozzo-validation/blob/0fb4d5abfbe7c5c5b672bf2780aa225653675157/validation.go#L140)
Add ways to catch the changing behaviour in latest ozzo validation version which can lead to strange behaviours